### PR TITLE
Add device marketing name

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source 'https://rubygems.org'
 
 gem 'codeclimate-test-reporter', group: :test, require: nil
+gem 'rake'
 
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,6 +15,7 @@ GEM
     diff-lcs (1.3)
     docile (1.1.5)
     json (2.1.0)
+    rake (12.3.0)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
       rspec-expectations (~> 3.5.0)
@@ -40,8 +41,9 @@ PLATFORMS
 DEPENDENCIES
   codeclimate-test-reporter
   device_api-android!
+  rake
   rspec (~> 3)
   simplecov (~> 0.12)
 
 BUNDLED WITH
-   1.14.6
+   1.16.1

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,14 @@
+require 'csv'
+require 'open-uri'
+
+task :update do
+  puts 'Fetching Data'
+  csv_url = 'http://storage.googleapis.com/play_public/supported_devices.csv'
+  devices = CSV.parse(open(csv_url).read)
+
+  File.open('lib/device_api/android/device/devices.csv', 'w') do |file|
+    puts 'Writing to File'
+    file.write(devices.inject([]) { |csv, row| csv << CSV.generate_line(row) }
+    .join('').encode('UTF-8'))
+  end
+end

--- a/lib/device_api/android/device.rb
+++ b/lib/device_api/android/device.rb
@@ -3,7 +3,7 @@
 require 'device_api/device'
 require 'device_api/android/adb'
 require 'device_api/android/aapt'
-require 'android/devices'
+require 'device_api/android/device_model'
 
 # DeviceAPI - an interface to allow for automation of devices
 module DeviceAPI
@@ -79,8 +79,7 @@ module DeviceAPI
       end
 
       def display_name
-        device = Android::Devices.search_by_model(model)
-        device.model unless device.nil?
+        Android::DeviceModel.marketing_name(manufacturer, model)
       end
 
       # Return the device range
@@ -97,6 +96,12 @@ module DeviceAPI
       # @return (String) serial number
       def serial_no
         get_prop('ro.serialno')
+      end
+
+      # Return the device class - i.e. tablet, phone, etc
+      # @return (String) Android device class
+      def device_class
+        get_prop('ro.build.characteristics')
       end
 
       # Return the device type
@@ -263,7 +268,7 @@ module DeviceAPI
       # Return the device type based on the DPI
       # @return [Symbol] :tablet or :mobile based upon the devices DPI
       def type
-        get_dpi.to_i > 533 ? :tablet : :mobile
+        device_class.casecmp('tablet').zero ? :tablet : :mobile
       end
 
       # Returns wifi status and access point name

--- a/lib/device_api/android/device/devices.csv
+++ b/lib/device_api/android/device/devices.csv
@@ -1,0 +1,17814 @@
+﻿Retail Branding,Marketing Name,Device,Model
+,,AD681H,Smartfren Andromax AD681H
+,,FJL21,FJL21
+,,hws7721g,MediaPad 7 Youth 2
+10.or,D,10or_D,D
+10.or,E,E,E
+10.or,G,G,G
+3Q,OC1020A,OC1020A,OC1020A
+4good,4GOOD Light B100,4GOOD_Light_B100,Light B100
+4good,A103,4GOOD_Light_A103,Light A103
+7Eleven,IN265,IN265,IN265
+7mobile,KAMBA,KAMBA,KAMBA
+A.O.I. ELECTRONICS FACTORY,A.O.I.,TR10CS1_11,TR10CS1
+AG Mobile,AG BOOST 2,BOOST2,E4010
+AG Mobile,AG Flair,AG_Flair,Flair
+AG Mobile,AG Go Tab Access 2,AG_Go_Tab_Access_2,AG_Go_Tab_Access_2
+AG Mobile,AG Ultra2,AG_Ultra2,Ultra 2
+AG Mobile,AG_Go-Tab_Access,md789hwag,AG Go-Tab Access
+AG Mobile,AG_Tab_7_0,AG_Tab_7_0,AG_Tab_7_0
+AG Mobile,Boost,Boost,Boost
+AG Mobile,Chacer,Chacer,Chacer
+AG Mobile,Freedom Access,Freedom_Access,Freedom Access
+AG Mobile,Freedom E,Freedom_E,Freedom E
+AG Mobile,Freedom Plus LTE,Freedom_Plus_LTE,Freedom Plus LTE
+AG Mobile,Ghost,Ghost,Ghost
+AG Mobile,Glow,Glow,Glow
+AG Mobile,HASHTAG,Hashtag,Hashtag
+AG Mobile,Hype,Hype,Hype
+AG Mobile,Neon,Neon,Neon
+AG Mobile,Quest,Quest,Quest
+AG Mobile,Rage,Rage,Rage
+AG Mobile,STYLE PLUS,STYLE_PLUS,STYLE_PLUS
+AG Mobile,Shine,Shine,Shine
+AG Mobile,Status,Status,Status
+AG Mobile,Style,Style,Style
+AG Mobile,Style_2,Style_2,Style 2
+AG Mobile,Swift,Swift,Swift
+AG Mobile,Swift_Plus,Swift_Plus,Swift_Plus
+AG Mobile,ULTRA,Ultra,Ultra
+AG Mobile,Zenith,Zenith,Zenith
+AG Mobile,Zone,Zone,Zone
+AG Mobile,Zoom,Zoom,Zoom
+AMTC,MD1001 Tablet,MD1001,MD1001
+AMTC,MD7008,MD7008A,MD7008
+AMTC,MD7081,MD7081A,MD7081
+ANS,Trailblazer,rugged-smartphone,H450R
+ANS,UL40,UL40,UL40
+AOC,A110_E,A110_E,A110_E
+AOC,A731,A731-N1,A731-N1
+AOC,A731-N2,A731-N2,A731-N2
+AOC,AOC,A731,A731
+AOC,AOC,A731-H1,A731-H1
+AOC,AOC,A732G,A732G
+AOpen,"RK3288 10"" Chromebase",tiger_cheets,AOpen Chromebase Mini
+AOpen,RK3288 Mini Chromebox,fievel_cheets,AOpen Chromebox Mini
+AT&T,9020A,tint8_att,9020A
+AV,AV10,RCT6203W46,AV10
+AV,AV7,RCT6773W22,AV7
+AZBox,AZDroid,AZDroid,AZDroid
+AZPEN,A720,wing-inet,A720
+AZPEN,A920,wing-ibt,A920
+Aamra WE,E2,E2,WE E2
+Abocom,A08SM,A08,A08S
+Accent,FAST7 3G,FAST7_3G,FAST7 3G
+Accent,Pearl_A4,Pearl_A4,Pearl A4
+Accent,SPEED S8,SPEED_S8,SPEED_S8
+Acer,,C6,Acer E320
+Acer,,C6,Acer E320-orange
+Acer,,C7,E330
+Acer,,C8n,E350
+Acer,,K3,E130
+Acer,,T2,AT390
+Acer,,T603T,TD600
+Acer,,a3,Stream
+Acer,,a5,S300
+Acer,,c4,E310
+Acer,,k4,E140
+Acer,,k5,E210
+Acer,A1-713,acer_aprilia,A1-713
+Acer,A1-734,acer_barricade,A1-734
+Acer,A1-810,mango,A1-810
+Acer,A1-811,mango,A1-811
+Acer,A1-830,ducati,A1-830
+Acer,A100,vangogh,A100
+Acer,A101,vangogh,A101
+Acer,A110,a110,A110
+Acer,A3-A10,zara,A3-A10
+Acer,A3-A11,zara,A3-A11
+Acer,A3-A20,acer_harley,A3-A20
+Acer,A3-A20FHD,acer_harleyfhd,A3-A20FHD
+Acer,A3-A30,omega,A3-A30
+Acer,A3-A40,acer_jetfirefhd,A3-A40
+Acer,AK330s,C8n,AK330S
+Acer,Acer Chromebook 11 (C740),paine_cheets,Acer Chromebook 11 (C740)
+Acer,Acer Chromebook R13,elm_cheets,Acer Chromebook R13 (CB5-312T)
+Acer,Acer Holo360,acer_c01,C01
+Acer,Aspire A3,aa3-600,AA3-600
+Acer,B1-710,B1-710,B1-710
+Acer,B1-711,B1-711,B1-711
+Acer,B1-720,b1-720,b1-720
+Acer,B1-721,b1-721,b1-721
+Acer,B1-723,oban,B1-723
+Acer,B1-730,vespatn,B1-730
+Acer,B1-730HD,vespa,B1-730HD
+Acer,B1-733,acer_barricade_3G,B1-733
+Acer,B1-780,acer_barricadewifi,B1-780
+Acer,B1-790,acer_barricadewifi,B1-790
+Acer,B1-820,citizen,B1-820
+Acer,B1-850,Frenzy,B1-850
+Acer,B1-A71,B1-A71,B1-A71
+Acer,B3-A30,acer_jetfirehd,B3-A30
+Acer,B3-A32,acer_jetfirelte,B3-A32
+Acer,B3-A40,acer_asgard,B3-A40
+Acer,B3-A40FHD,acer_asgardfhd,B3-A40FHD
+Acer,C01,acer_c01,C01
+Acer,C01 (PA),acer_c01,C01
+Acer,CW01,acer_cw01,CW01
+Acer,Chromebook 14 for work,lars_cheets,Chromebook 14 for work (CP5-471)
+Acer,Chromebook 15 (CB3-532),banon_cheets,Acer Chromebook 15 (CB3-532)
+Acer,Chromebook 15 CB515-1HT/1H,sand_cheets,Chromebook 15 CB515-1HT/1H
+Acer,Chromebook 15 CB515-1HT/1H,sand_cheets,sand
+Acer,Chromebook R11 (C738T),cyan_cheets,Acer Chromebook R11
+Acer,Chromebook R11 (C738T),cyan_cheets,Acer Chromebook R11 (CB5-132T / C738T)
+Acer,CloudMobile S500,a9,S500
+Acer,DA220HQL,DA220HQL,DA220HQL
+Acer,DA221HQL,da1,DA221HQL
+Acer,DA222HQL,da2,DA222HQL
+Acer,DA222HQLA,da2,DA222HQLA
+Acer,DA222HQLA,da222hqla,DA222HQLA
+Acer,DA223HQL,da3,DA223HQL
+Acer,DA226HQ,da6,DA226HQ
+Acer,DA241HL,DA241HL,DA241HL
+Acer,DA245HQL,da245hql,DA245HQL
+Acer,E380,acer_e3n,E380
+Acer,G1-715,G1-715,G1-715
+Acer,G100W,maya,G100W
+Acer,GT-810,rolex,GT-810
+Acer,I110,I1,I110
+Acer,Icona One 7,vespa,B1-730HD
+Acer,Iconia One 10,acer_jetfirelte,B3-A32
+Acer,Iconia One 10,corona,B3-A20
+Acer,Iconia One 10,corona,B3-A20B
+Acer,Iconia One 7,G1-725,G1-725
+Acer,Iconia One 7,acer_Vulcan,B1-7A0
+Acer,Iconia One 7,vespa,B1-730HD
+Acer,Iconia One 7,vespa2,B1-750
+Acer,Iconia One 7,vespatn,B1-730
+Acer,Iconia One 8,acer_FrenzyRefresh,B1-860A
+Acer,Iconia One 8,acer_Zipp,B1-870
+Acer,Iconia One 8,vespa8,A1-850
+Acer,Iconia One 8,vespa8,B1-810
+Acer,Iconia Tab 10,acer_Titan,A3-A50
+Acer,Iconia Tab 10,acer_harley,A3-A20
+Acer,Iconia Tab 10,acer_harleyfhd,A3-A20FHD
+Acer,Iconia Tab 7,acer_aprilia,A1-713
+Acer,Iconia Tab 7,acer_apriliahd,A1-713HD
+Acer,Iconia Tab 8,ducati2fhd,A1-840FHD
+Acer,Iconia Tab 8,ducati2hd,A1-840
+Acer,Iconia Tab 8,ducati2hd3g,A1-841
+Acer,Iconia Tab A100 (VanGogh),vangogh,A100
+Acer,Iconia Tab A100 (VanGogh),vangogh,A101
+Acer,Iconia Tab A200,picasso_e,A200
+Acer,Iconia Tab A210,picasso_e2,A210
+Acer,Iconia Tab A211,picasso_e2,A211
+Acer,Iconia Tab A500,picasso,A500
+Acer,Iconia Tab A501,picasso,A501
+Acer,Iconia Tab A510,picasso_m,A510
+Acer,Iconia Tab A511,picasso_m,A511
+Acer,Iconia Tab A700,picasso_mf,A700
+Acer,Iconia Tab A701,picasso_mf,A701
+Acer,Iconia TalkTab 7,acer_a1_724,A1-724
+Acer,Liquid,a1,Acer Liquid
+Acer,Liquid,a1,Acer S100
+Acer,Liquid,a1,Liquid
+Acer,Liquid 200,acer_z200,Z200
+Acer,Liquid C1,I1,I110
+Acer,Liquid E1,C10,V360
+Acer,Liquid E2,C11,V370
+Acer,Liquid E3,acer_e3,E380
+Acer,Liquid E3,acer_e3n,E380
+Acer,Liquid E3S,acer_ZXR,Z130
+Acer,Liquid E600,e600,E600
+Acer,Liquid E700,acer_e39,E39
+Acer,Liquid Gallant E350,C8,AK330
+Acer,Liquid Gallant E350,C8,E350
+Acer,Liquid Jade,acer_S55,S55
+Acer,Liquid Jade 2,acer_s58a,S58A
+Acer,Liquid Jade S,acer_S56,S56
+Acer,Liquid Jade Z,acer_S57,S57
+Acer,Liquid Mini,C4R,E310
+Acer,Liquid S1,a10,S510
+Acer,Liquid S2,a12,S520
+Acer,Liquid S3,s3,S53
+Acer,Liquid X1,s3,S53
+Acer,Liquid X2,acer_S59,S59
+Acer,Liquid Z200,acer_z200,Z200
+Acer,Liquid Z205,acer_z205,Z205
+Acer,Liquid Z205,acer_z205p,Z205
+Acer,Liquid Z205,acer_z205p,Z205P
+Acer,Liquid Z220,z220,Z220
+Acer,Liquid Z3,ZX,Z130
+Acer,Liquid Z3,acer_ZXR,Z130
+Acer,Liquid Z320,T012,T012
+Acer,Liquid Z330,T01,T01
+Acer,Liquid Z4,acer_Z6,Z160
+Acer,Liquid Z410,acer_z410,Z410
+Acer,Liquid Z5,acer_ZXL,Z150
+Acer,Liquid Z500,acer_Z500,Z500
+Acer,Liquid Z520,acer_z520,Z520
+Acer,Liquid Z530,acer_T02,T02
+Acer,Liquid Z530S,acer_t05,T05
+Acer,Liquid Z6,acer_t09,T09
+Acer,Liquid Z6 Plus,acer_t11,T11
+Acer,Liquid Z630,acer_t03,T03
+Acer,Liquid Z630S,acer_t04,T04
+Acer,Liquid Z6E,acer_t10,T10
+Acer,Liquid Zest,acer_t06,T06
+Acer,Liquid Zest 4G,acer_t07,T07
+Acer,Liquid Zest Plus,acer_t08,T08
+Acer,LiquidMT,a4,Acer Liquid Metal
+Acer,LiquidMT,a4,Liquid MT
+Acer,LiquidMT,a4,Liquid Metal
+Acer,M3-2200,da2,M3-2200
+Acer,MWND1,MW1,MWND1
+Acer,N3-2200,da2,N3-2200
+Acer,Picasso,picasso,A501
+Acer,Picasso,ventana,A500
+Acer,Picasso,ventana,G100W
+Acer,Picasso,ventana,TPA60W
+Acer,TA2,ta2,TA272HUL
+Acer,TA272HUL,ta2,TA272HUL
+Acer,TPA60W,maya,TPA60W
+Acer,Tab 7,td070va1,TD070VA1
+Acer,Z110,Z1,Z110
+Acer,Z120,Z2,Z120
+Adart,ALIGATOR RX510,RX510,ALIGATOR RX510
+Adart,ALIGATOR S4080 Duo,ALIGATOR_S4080,ALIGATOR S4080
+Adart,ALIGATOR S4082 Duo,S4082Duo,S4082 Duo
+Adart,ALIGATOR S5062 Duo,S5062Duo,S5062 Duo
+Adart,ALIGATOR S5510 Duo,Aligator_S5510,Aligator S5510
+Adart,RX550,ALIGATOR_RX550,RX550
+Adart,S5060 Duo,ALIGATOR_S5060,ALIGATOR S5060
+Admiral Overseas Corporation,A2272PW4T,AOC_WW,G3SMNTA22
+Admiral Overseas Corporation,A2272PW4T,AOC_WW,G3SMNTA24
+Admiral Overseas Corporation,A2272PWHT,AOC_WW,G2SMNT
+Admiral Overseas Corporation,A2472PW4T,G3SMNTA24,G3SMNTA24
+Admiral Overseas Corporation,A7,A7,A7
+Admiral Overseas Corporation,C7,C7,C7
+Admiral Overseas Corporation,O7,O7,O7
+Advan digital,5041,ADVAN_5041,5041
+Advan digital,5059,ADVAN_5059,5059
+Advan digital,5060,ADVAN_5060,5060
+Advan digital,5061,ADVAN_5061,5061
+Advan digital,A8,ADVAN_A8,A8
+Advan digital,E1C,ADVAN_E1C_3G,E1C_3G
+Advan digital,E1C NXT,ADVAN_E1C_NXT,S7D
+Advan digital,G1,G1,G1
+Advan digital,G1 PRO,ADVAN_G1_Pro,i5K
+Advan digital,G2,ADVAN_G2,i55C
+Advan digital,I Tab,ADVAN_i_Tab,i7_Plus
+Advan digital,I55A,I55A,I55A
+Advan digital,I5E,ADVAN_I5E,I5E
+Advan digital,I5E,ADVAN_I5Es,i5E
+Advan digital,I7D,ADVAN_I7D,I7D
+Advan digital,M4,ADVAN_M4,ADVAN M4
+Advan digital,S40,ADVAN_S40,ADVAN S40
+Advan digital,S45E,ADVAN_S45E,S45E
+Advan digital,S4T,S4T,S4T
+Advan digital,S4Z,ADVAN_S4Z,S4Z
+Advan digital,S5E_NXT,ADVAN_S5E_NXT,S5E_NXT
+Advan digital,S7A,S7A,S7A
+Advan digital,S7C,ADVAN_S7C,S7C
+Advan digital,T2J,T2J,T2J
+Advan digital,T2K,T2K,T2K
+Advan digital,X7 Pro,ADVAN_7008,7008
+Advan digital,i10,i10,i10
+Advan digital,i5C,i5C,i5C
+Advan digital,i5C plus,ADVAN_i5C_Plus,5058
+Advan digital,i7,ADVAN_i7,i7
+Advan digital,i7A,ADVAN_i7A,i7A
+Affix,T737,AFFIX_T737,AFFIX T737
+Aikun,EDSTAR LC-TS08A,LC-TS08A,LC-TS08A
+Aikun,EDSTAR LC-TS08S,LC-TS08S,LC-TS08S
+Aikun,RX300,X300,X300
+Aikun,Solely Tab S7,HV1A,S7
+Aikun,Solely Tab S8,HV1A,S8
+Airtel,SH960S-AT,ganesa,SH960S-AT
+Aiuto,AT1001,AT1001,AT1001
+Aiuto,AT701,AT701,AT701
+Aiwa,AW790,AW790,AW790
+Aiwa,Z9,AIWA_Z9,Z9
+Aiwa,Z9 PLUS,AIWA_Z9_PLUS,Z9 PLUS
+Alba,ALBA 7 TABLET,ac70plv6,ALBA 7 TABLET
+Alba,Alba_8in,Alba_8in,Alba_8in
+Aligator,S5065,ALIGATORS5065,ALIGATOR S5065
+AllView,A5 Easy,A5_Easy,A5_Easy
+AllView,A5 Easy,A5_Easy,A5_Easy_TM
+AllView,A5 Lite,A5_Lite,A5_Lite
+AllView,A5 Quad Plus,A5_Quad_Plus,A5_Quad_Plus
+AllView,A5 Quad Plus,A5_Quad_Plus,A5_Quad_Plus_TM
+AllView,A5 Ready,A5_Ready,A5_Ready
+AllView,A5 Ready,A5_Ready,A5_Ready_TM
+AllView,A6 Duo,A6_Duo,A6_Duo
+AllView,A6 Lite,A6_Lite,A6_Lite
+AllView,A7 Lite,A7_Lite,A7_Lite
+AllView,A8 Lite,A8_Lite,A8_Lite
+AllView,A8 Lite TM,A8_Lite,A8_Lite_TM
+AllView,A9 Lite,A9_Lite,A9_Lite
+AllView,AX4 Nano Plus,AX4Nano_plus,AX4Nano_plus
+AllView,AX501Q,AX501Q,AX501Q
+AllView,C6 Duo,C6_Duo,C6_Duo
+AllView,C6 Quad 4G,C6_Quad_4G,C6Quad_4G
+AllView,E2 Jump,ALLVIEW_E2_Jump,E2_Jump
+AllView,E3 Jump,E3_Jump,E3_Jump
+AllView,E3 Living,E3_Living,E3_Living
+AllView,E3 Sign,E3_Sign,E3_Sign
+AllView,E4,E4,E4
+AllView,E4 Lite,E4_Lite,E4_Lite
+AllView,P4 Pro,P4_Pro,P4_Pro
+AllView,P4 Quad,P4_Quad,P4_Quad
+AllView,P4 eMagic,P4_eMagic,P4_eMagic
+AllView,P4 eMagic,P4_eMagic,P4_eMagic_TM
+AllView,P41 eMagic,P41_eMagic,P41_eMagic
+AllView,P41 eMagic,P41_eMagic,P41_eMagic_TM
+AllView,P42,P42,P42
+AllView,P43 Easy,P43_Easy,P43_Easy
+AllView,P5 Energy,P5_Energy,P5_Energy
+AllView,P5 Life,P5Life,P5Life_TM
+AllView,P5 Lite,P5_Lite,P5_Lite
+AllView,P5 Pro,P5_Pro,P5_Pro
+AllView,P5 eMagic,P5_eMagic,P5_eMagic
+AllView,P5 eMagic,P5_eMagic,P5_eMagic_TM
+AllView,P5Life,P5Life,P5Life
+AllView,P5_Pro,P5_Pro,P5_Pro_TM
+AllView,P6  Plus,P6_plus,P6_plus
+AllView,P6 Energy,P6_Energy,P6_Energy_TM
+AllView,P6 Energy Lite,P6_Energy_Lite,P6_Energy_Lite
+AllView,P6 Energy Lite,P6_Energy_Lite,P6_Energy_Lite_TM
+AllView,P6 Energy mini,P6_Energy_mini,P6_Energy_mini
+AllView,P6 Life,P6_Life,P6_Life
+AllView,P6 Lite,P6_lite,P6_lite
+AllView,P6 Lite,P6_lite,P6_lite_TM
+AllView,P6 Lite,P6_lite,P6_lite_mTEL
+AllView,P6 Pro,P6_Pro,P6_Pro
+AllView,P6 Qmax,P6_Qmax,P6_Qmax
+AllView,P6 eMagic,P6_eMagic,P6_eMagic
+AllView,P6_Energy,P6_Energy,P6_Energy
+AllView,P7 Lite,P7_Lite,P7_Lite
+AllView,P7 Lite,P7_Lite,P7_Lite_TM
+AllView,P7 PRO,P7_PRO,P7_PRO
+AllView,P7 PRO_TM,P7_PRO,P7_PRO_TM
+AllView,P8 Energy,P8_Energy,P8_Energy
+AllView,P8 Energy Pro,P8_Energy_PRO,P8_Energy_PRO
+AllView,P8 Energy mini,P8_Energy_mini,P8_Energy_mini
+AllView,P8 Energy mini,P8_Energy_mini,P8_Energy_mini_TM
+AllView,P8 Life,P8_Life,P8_Life
+AllView,P8 eMagic,P8_eMagic,P8_eMagic
+AllView,P8 eMagic,P8_eMagic,P8_eMagic_TM
+AllView,P9 Energy,P9_Energy,P9_Energy
+AllView,P9 Energy Lite,P9_Energy_Lite,P9_Energy_Lite
+AllView,P9 Energy Lite 2017,P9_Energy_Lite_2017,P9_Energy_Lite_2017
+AllView,P9 Energy Mini,P9_Energy_mini,P9_Energy_mini_TM
+AllView,P9 Energy S,P9_Energy_S,P9_Energy_S
+AllView,P9 Energy mini,P9_Energy_mini,P9_Energy_mini
+AllView,P9 Life,P9_Life,P9_Life
+AllView,P9_Life_TM,P9_Life,P9_Life_TM
+AllView,V1 Viper E,V1_Viper_E,V1_Viper_E
+AllView,V1 Viper I4G,V1_Viper_I4G,V1_Viper_I4G
+AllView,V1 Viper I4G,V1_Viper_I4G,V1_Viper_I4G_PL
+AllView,V1 Viper I4G,V1_Viper_I4G,V1_Viper_I4G_TM
+AllView,V1 Viper I4G,V1_Viper_I4G_PL,V1_Viper_I4G_PL
+AllView,V1 Viper L,V1_Viper_L,V1_Viper_L
+AllView,V1 Viper S4G,V1_Viper_S4G,V1_Viper_S4G
+AllView,V2 Viper,V2_Viper,V2_Viper
+AllView,V2 Viper E,V2_Viper_E,V2_Viper_E
+AllView,V2 Viper I,V2_Viper_I,V2_Viper_I
+AllView,V2 Viper I,V2_Viper_I,V2_Viper_I_TM
+AllView,V2 Viper I4G,V2_Viper_I4G,V2_Viper_I4G
+AllView,V2 Viper S,V2_Viper_S,V2_Viper_S
+AllView,V2 Viper X,V2_Viper_X,V2_Viper_X
+AllView,V2 Viper X plus,V2_Viper_X_plus,V2_Viper_X_plus
+AllView,V2 Viper Xe,V2_Viper_Xe,V2_Viper_Xe
+AllView,Viva 1001G,Viva_1001G,Viva_1001G
+AllView,Viva C701,Viva_C701,Viva_C701
+AllView,Viva C702,Viva_C702,Viva_C702
+AllView,Viva H10 LTE,Allview_VivaH10LTE_KK,VivaH10LTE
+AllView,Viva H1001 LTE,Viva_H1001_LTE,Viva_H1001_LTE
+AllView,Viva H1002 LTE,Viva_H1002_LTE,Viva_H1002_LTE
+AllView,Viva H7 LTE,Allview_VivaH7LTE_KK,VivaH7LTE
+AllView,Viva H8 LTE,Allview_VivaH8LTE_KK,VivaH8LTE
+AllView,Viva H8 Life,H8_Life,H8_Life
+AllView,Viva H801,Viva_H801,Viva_H801
+AllView,Viva H801 LTE,Viva_H801_LTE,Viva_H801_LTE
+AllView,Viva H802 LTE,Viva_H802_LTE,Viva_H802_LTE
+AllView,Viva H802 LTE,Viva_H802_LTE,Viva_H802_LTE_TM
+AllView,Viva i10HD,Viva_i10HD,Viva_i10HD
+AllView,Viva i701G,Viva_H701_LTE,Viva_H701_LTE_CZ
+AllView,Viva i701G,Viva_i701G,Viva_i701G
+AllView,Viva i701G,Viva_i701G,Viva_i701G_TM
+AllView,Viva i7G,Viva_i7G,Viva_i7G
+AllView,Viva_H701_LTE,Viva_H701_LTE,Viva_H701_LTE
+AllView,X2 Soul Lite,X2_Soul_Lite,X2_Soul_Lite
+AllView,X2 Soul Lite,X2_Soul_Lite,X2_Soul_Lite_TM
+AllView,X2 Soul Mini,X2_Soul_Mini,X2_Soul_Mini
+AllView,X2 Soul PRO,X2_Soul_PRO,X2_Soul_PRO
+AllView,X2 Soul Style,X2_Soul_Style,X2_Soul_Style
+AllView,X2 Soul Style,X2_Soul_Style,X2_Soul_Style_TM
+AllView,X2 Soul Style+,X2_Soul_Style_Plus,X2_Soul_Style_Plus
+AllView,X2 Soul Xtreme,X2_Soul_Xtreme,X2_Soul_Xtreme
+AllView,X3 Soul Lite,X3_Soul_Lite,X3_Soul_Lite
+AllView,X3 Soul Lite,X3_Soul_Lite,X3_Soul_Lite_TM
+AllView,X3 Soul Plus,X3_Soul_PLUS,X3_Soul_PLUS
+AllView,X3 Soul Pro,X3_Soul_PRO,X3_Soul_PRO
+AllView,X3 Soul Style,X3_Soul_Style,X3_Soul_Style
+AllView,X3 Soul mini,X3_Soul_mini,X3_Soul_mini
+AllView,X3Soul,X3_Soul,X3_Soul
+AllView,X4 Soul,X4_Soul,X4_Soul
+AllView,X4 Soul Infinity L,X4_Soul_Infinity_L,X4_Soul_Infinity_L
+AllView,X4 Soul Infinity L,X4_Soul_Infinity_LV,X4_Soul_Infinity_L
+AllView,X4 Soul Infinity N,X4_Soul_Infinity_N,X4_Soul_Infinity_N
+AllView,X4 Soul Infinity S,X4_Soul_Infinity_S,X4_Soul_Infinity_S
+AllView,X4 Soul Infinity Z,X4_Soul_Infinity_Z,X4_Soul_Infinity_Z
+AllView,X4 Soul Lite,X4_Soul_Lite,X4_Soul_Lite
+AllView,X4 Soul Mini,X4_Soul_Mini,X4_Soul_Mini
+AllView,X4 Soul Mini S,X4_Soul_Mini_S,X4_Soul_Mini_S
+AllView,X4 Soul Mini S,X4_Soul_Mini_S,X4_Soul_Mini_S_TM
+AllView,X4 Soul Style,X4_Soul_Style,X4_Soul_Style
+AllView,X4 Soul Vision,X4_Soul_Vision,X4_Soul_Vision
+AllView,X4 Soul Xtreme,X4_Soul_Xtreme,X4_Soul_Xtreme
+Allfine,M721,86S,M721
+Allfine,PC1038Q,fine10_Joy,PC1038Q
+Alphascan,SAT2242 WorkTab,ADP_WW,G2SMNT
+Altice,ALTICE S70,S70,S70
+Altice,S60,S60,S60
+Altice,STARACTIVE,STARACTIVE,STARACTIVE
+Altice,STARNAUTE 4,STARNAUTE4,STARNAUTE4
+Altice,STARNAUTE3,STARNAUTE3,STARNAUTE 3
+Altice,STARTRAIL 7,STARTRAIL7,STARTRAIL7
+Altice,STARXTREM5,STARXTREM5,STARXTREM5
+Altice,Staractive,STARACTIVE,STARACTIVE
+Altice,T10,T10,T10
+Amgoo,AM350,AM350,AM350
+Amgoo,AM402,AM402,AM402
+Amgoo,AM410,AM410,AM410
+Amgoo,AM415,AM415,AM415
+Amgoo,AM506,AM506,AM506
+Amgoo,AM508,AM508,AM508
+Amgoo,AM509,AM509,AM509
+Amgoo,AM509,AM509-A,AM509
+Amgoo,AM515,AM515,AM515
+Amgoo,AM518,AM518,AM518
+Amgoo,AM520,AM520,AM520
+Amgoo,AM530,AM530,AM530
+Amgoo,AM535,AM535,AM535
+Amplify,TL10RA3,TL10RA3_1,TL10RA3
+Amplify,TR10CD3,TR10CD3_1,TR10CD3
+Amplify,TR10CD3,TR10CD3_2,TR10CD3
+Anydata,,ASP320Q_GSM,ASP320Q_ANDi
+Anydata,Aquaris I8,bq_Aquaris,bq Aquaris
+Anydata,Auchan MID7317CP Tablet,MID7317CP,MID7317CP
+Anydata,COBY MID7055,MID7055,MID7055
+Anydata,Carrefour CT710,M755ND,CT710
+Anydata,Carrefour CT720 / Emdoor EM63 Tablet,EM63,EM63
+Anydata,Coby MID1065,MID1065,MID1065
+Anydata,Coby MID7065,MID7065,MID7065
+Anydata,Coby MID8065,MID8065,MID8065
+Anydata,D2-721G,D2-721G,D2-721G
+Anydata,D2-727G,D2-727,D2-727
+Anydata,DOPO GMS-718 Tablet / Discovery,DT088,GS-718
+Anydata,DOTPAD DP3D8 / Gadmei,E8-3D,DP3D8
+Anydata,Digix TAB-840_G,TAB-840_G,TAB-840_G
+Anydata,Eviant MT8000,PDM829MD,MT8000
+Anydata,Garmin nuvi3590,scorpio,nuvi 3590
+Anydata,Garmin nuvi3595,scorpio,nuvi 3595
+Anydata,Grundig GR-TB10S Tablet,GR-TB10S,GR-TB10S
+Anydata,HCL ME TABLET PC U2,M712MC,U2
+Anydata,HKC P771A,P771A_WIFI,P771A
+Anydata,HKC P774A,P774A,P774A
+Anydata,HKC P776A,P776A,P776A
+Anydata,HKC P778A,HKCP778A,P778A
+Anydata,HKC P886A,P886A,P886A
+Anydata,HS_7DTB14,HS_7DTB14,HS_7DTB14
+Anydata,Insignia NS-13T001 Tablet,oracle,NS-13T001
+Anydata,Jiateng JT1241,JT1241,JT1241
+Anydata,Lazer MD7305 Tablet / AMTC,MD7305,MD7305
+Anydata,Le Pan S,oracle,Le Pan S
+Anydata,LePanII,LePanII_wifi,LePanII
+Anydata,Leader I10A-LE,I10A-LE,I10A-LE
+Anydata,Mach_Speed Trio G2 Tablet,Trio_Stealth_G2,G2
+Anydata,Marquis Tablet,marquis_tablet,Marquis_MP977
+Anydata,Matsunichi M97,oracle,M97
+Anydata,Monster M7 Tablet,MONSTERM7,M7
+Anydata,Nextbook NX007HD Tablet,M7000ND,NX007HD
+Anydata,Nextbook NX008HD8G Tablet,M8000ND,NX008HD8G
+Anydata,Nextbook NX008HI Tablet / Carrefour CT810,M909NP,NX008HI
+Anydata,Nextbook Next7D12 Tablet,M757ND,Next7D12
+Anydata,Nextbook Next7P12,M727MC,Next7P12
+Anydata,Pendo PNDPP48GP,PNDPP48GP,PNDPP48GP
+Anydata,Philips W336,Crane,Philips W336
+Anydata,Philips W536,Philips_WG-MANTO-RU_B,Philips W536
+Anydata,Philips W626,sangfei73_gb,W626
+Anydata,Philips W632,robot,Philips W632
+Anydata,Philips W832,Philips_WG-ROVER-RU_A,Philips W832
+Anydata,Proscan PLT7223G,PLT7223G,PLT7223G
+Anydata,Proscan PLT7777,AMLMID710K,PLT7777
+Anydata,Proscan PLT8223G,PLT8223G,PLT8223G
+Anydata,RCA RCT6078W2,AMLEM62,RCT6078W2
+Anydata,RCA RCT6078W2,EM62,RCT6078W2
+Anydata,TecToy TT-2500,AML757ND,TECTOYTT2500
+Anydata,Visual Land Prestige 7D,PRO7D,PRO7D
+Anydata,Vivitar Camelio Tablet,PI070H04CA,Camelio Family tablet
+Anydata,Vivitar XO Tablet,PI070H08XO,XO Learning tablet
+Anydata,Zeki TBDG773,TBDG773,TBDG773
+Anydata,ematic EGP008,EGP008,EGP008
+Anydata,ematic EGP010,EGP010,EGP010
+Anydata,ematic EGS004,EGS004,EGS004
+Anydata,ematic EGS102,EGS102,EGS102
+Anydata,essentielb ST8003/FT8001 Tablet,M805ND,Smart\'TAB 8003
+Anydata,iCraig CMP748,CMP748,CMP748
+Anydata,iCraig CMP749,CMP749,CMP749
+Apex,MT-734G,MT-734G,MT-734G
+Apex,TM772,TM772,TM772
+Apex,TM785CH,tm785ch,TM785CH
+Aprix,Phat6,Aprix_Phat6,Aprix_Phat6
+Aprix,Tab64,AprixTab64,Aprix Tab64
+Aprix,X4,Aprix_X4,Aprix_X4
+Aqua,S1 Jazz,S1_Jazz,S1 Jazz
+Arcelik,B55L 9682 5AS,arcelik_eu,arcelik_uhd_powermax_at
+Archos,,A101S,ARCHOS 101G9
+Archos,,A101S,Archos 101 Internet Tablet
+Archos,,A80S,ARCHOS 80G9
+Archos,,A80S,Archos 80 Internet Tablet
+Archos,101 Childpad,A101CHP,ARCHOS 101 CHILDPAD
+Archos,101 Cobalt,AC101CO,Archos 101 Cobalt
+Archos,101 Copper,ac101cv,Archos 101 Copper
+Archos,101 G9,A101,ARCHOS 101G9
+Archos,101 Helium,ac101he,Archos 101 Helium
+Archos,101 Helium Lite,ac101hel,Archos 101 Helium Lite
+Archos,101 Magnus,ac101ma,ARCHOS 101 Magnus
+Archos,101 Neon,A101NE,Archos 101 Neon
+Archos,101 Oxygen,ac101ox,Archos 101 Oxygen
+Archos,101 Platinum,A101PL,ARCHOS 101 PLATINUM
+Archos,101 Titanium,A101TI,ARCHOS 101 Titanium
+Archos,101 XS,A101XS,ARCHOS 101G10
+Archos,101 Xenon,a101xe,Archos 101 Xenon
+Archos,101 Xenon,ac101cxe,Archos 101c Xenon
+Archos,101 Xenon,ac101xev2,Archos 101 Xenon v2
+Archos,101 Xenon Lite,ac101xel,Archos 101 Xenon Lite
+Archos,101D Neon,ac101dne,Archos 101d Neon
+Archos,101XS2,AC101XS2,ARCHOS 101 XS 2
+Archos,101XS3,ac101xs3,Archos 101XS3
+Archos,101b Copper,ac101bcv,Archos 101b Copper
+Archos,101b Helium,ac101bhe,Archos 101b Helium
+Archos,101b Neon,ac101bne,Archos 101b Neon
+Archos,101b Oxygen,ac101box,Archos 101b Oxygen
+Archos,101b Platinum,ac101bpl,Archos 101b Platinium
+Archos,101b XS2,ac101bxs2,ARCHOS 101b XS2
+Archos,101b Xenon,ac101bxev2,Archos 101b Xenon v2
+Archos,101c Copper,ac101ccv,Archos 101c Copper
+Archos,101c Neon,ac101cne,Archos 101c Neon
+Archos,101c Platinum,ac101cpl,Archos 101c Platinum
+Archos,101d Platinum v2,ac101cplv2,Archos 101d Platinum v2
+Archos,101d Platinum v3,ac101dplv3,Archos 101d Platinum v3
+Archos,101e Neon,ac101enev2,Archos 101e Neon
+Archos,101e neon,ac101ene,Archos 101e Neon
+Archos,121 Neon,ac121ne,Archos 121 Neon
+Archos,133 Oxygen,ac133ox,Archos 133 Oxygen
+Archos,35b Titanium,ac35bti,Archos 35b Titanium
+Archos,40 Helium,ac40he,Archos 40 Helium
+Archos,40 Neon,ac40ne,Archos 40 Neon
+Archos,40 Power,ac40po,Archos 40 Power
+Archos,40 Power,ac40pov2,Archos 40 Power
+Archos,40 Titanium,a40ti,Archos 40 Titanium
+Archos,40b Titanium,a40btisr,Archos 40b Titanium Surround
+Archos,40c Titanium,ac40cti,Archos 40c Titanium
+Archos,40c Titanium,ac40ctiv2,ARCHOS 40C TIv2
+Archos,40d Titanium,ac40dti,ARCHOS 40d Titanium
+Archos,45 Helium 4G,a45he,Archos 45 Helium 4G
+Archos,45 Neon,ac45ne,Archos 45 Neon
+Archos,45 Platinum,msm8625,Archos 45 Platinum
+Archos,45 Titanium,a45ti,Archos 45 Titanium
+Archos,45b Helium,ac45bhe,AC45BHE
+Archos,45b Helium,ac45bhe,ARCHOS 45b Helium
+Archos,45b Neon,ac45dpl,Archos 45b Neon
+Archos,45b Platinum,ac45bpl,Archos 45b Platinum
+Archos,45c Helium,ac45che,Archos 45c Helium
+Archos,45c Platinum,ac45cpl,Archos 45c Platinum
+Archos,45c Titanium,ac45cti,Archos 45c Titanium
+Archos,45d Platinum,ac45dpl,Archos 45d Platinum
+Archos,50 Cobalt,ac50co,Archos 50 Cobalt
+Archos,50 Diamond,ac50da,Archos 50 Diamond
+Archos,50 Helium 4G,a50he,Archos 50 Helium 4G
+Archos,50 Helium Plus,ac50heplus,Archos 50 Helium Plus
+Archos,50 Neon,a50ne,Archos 50 Neon
+Archos,50 Oxygen,a50ox,Archos 50 Oxygen
+Archos,50 Oxygen plus,ac50oxplus,Archos 50 Oxygen Plus
+Archos,50 Platinum,msm8625,Archos 50 Platinum
+Archos,50 Platinum 4G,AC50PL4G,Archos 50 Platinum 4G
+Archos,50 Power,ac50po,Archos 50 Power
+Archos,50 Saphir,ac50sa,Archos 50 Saphir
+Archos,50 Titanium,a50ti,Archos 50 Titanium
+Archos,50 Titanium 4G,ac50ti,A50TI
+Archos,50 d Helium,ac50dhe,AC50DHE
+Archos,50B Cobalt,ac50bco,Archos 50B Cobalt
+Archos,50F Neon,ac50fnev2,Archos 50f Neon
+Archos,50b Helium,ac50bhe,AC50BHE
+Archos,50b Helium,ac50bhe,Archos 50b Helium 4G
+Archos,50b Neon,ac50bne,Archos 50b Neon
+Archos,50b Oxygen,a50box,Archos 50b Oxygen
+Archos,50b Platinum,ac50bpl,Archos 50b Platinum
+Archos,50c Helium,ac50che,Archos 50c Helium
+Archos,50c Neon,ac50cne,ARCHOS 50c Neon
+Archos,50c Neon,ac50cne,Archos 50c Neon
+Archos,50c Oxygen,a50cox,Archos 50c Oxygen
+Archos,50c Platinum,ac50cpl,Archos 50c Platinum
+Archos,50d Neon,ac50dne,Archos 50d Neon
+Archos,50d Oxygen,ac50dox,Archos 50d Oxygen
+Archos,50e Helium,ac50ehe,Archos 50e Helium
+Archos,50e Neon,ac50ene,Archos 50e Neon
+Archos,50f Helium,ac50fhe,Archos 50f Helium
+Archos,50f Neon,ac50fne,Archos 50F Neon
+Archos,52 Platinum,ac52pl,Archos 52 Platinum
+Archos,53 Platinum,msm8625,Archos 53 Platinum
+Archos,53 Titanium,a53ti,Archos 53 Titanium
+Archos,55 Cobalt Plus,ac55cop,Archos 55 Cobalt Plus
+Archos,55 Cobalt Plus,ac55cop,Archos 55 Cobalt plus
+Archos,55 Diamond Selfie,ac55diselfie,Archos 55 diamond Selfie
+Archos,55 Helium,ac55he,Archos 55 Helium
+Archos,55 Helium Plus,ac55heplus,Archos 55 Helium Plus
+Archos,55 platinum,ac55pl,Archos 55 Platinum
+Archos,55B Cobalt,ac55bco,Archos 55B Cobalt
+Archos,55b Platinum,ac55bpl,Archos 55B Platinum
+Archos,59 Titanium,ac59ti,Archos 59 Titanium
+Archos,59 Xenon,ac59xe,Archos 59 Xenon
+Archos,60 Platinum,ac60pl,Archos 60 Platinum
+Archos,62 Xenon,ac62xe,Archos 62 Xenon
+Archos,64 Xenon,ac64xe,Archos 64 Xenon
+Archos,70 Cobalt,AC70CO,ARCHOS 70 Cobalt
+Archos,70 Copper,ac70cv,Archos 70 Copper
+Archos,70 Helium,ac70he,Archos 70 Helium
+Archos,70 Neon,ac70ne,Archos 70 Neon
+Archos,70 Neon Plus,ac70nep,Archos 70 Neon Plus
+Archos,70 Oxygen,ac70ox,Archos 70 Oxygen
+Archos,70 Platinum,ac70pl,Archos 70 Platinum
+Archos,70 Platinum 3G,ac70pl3g,Archos 70 Platinum 3G
+Archos,70 Platinum v2,ac70plv4,Archos 70 Platinum v2
+Archos,70 Titanium,A70TI,ARCHOS 70 Titanium
+Archos,70 Xenon,a70xe,Archos 70 Xenon
+Archos,70 Xenon Color,ac70xec,Archos 70 Xenon Color
+Archos,70 platinum,ac70plv3,Archos 70 Platinum v3
+Archos,70b Cobalt,a70bco,Archos 70b Cobalt
+Archos,70b Copper,ac70bcv,Archos 70b Copper
+Archos,70b Helium,ac70bhe,Archos 70b Helium
+Archos,70b Neon,ac70bne,Archos 70b Neon
+Archos,70b Titanium,A70BTI,ARCHOS 70b TITANIUM
+Archos,70b Xenon,ac70bxe,Archos 70b Xenon
+Archos,70c Cobalt,ac70cco,Archos 70c Cobalt
+Archos,70c Neon,ac70cne,Archos 70c Neon
+Archos,70c Titanium,ac70cti,Archos 70c Titanium
+Archos,70c Xenon,ac70cxe,Archos 70c Xenon
+Archos,70it 2,A70it2,ARCHOS 70it2
+Archos,70it 2,A70it2,ARCHOS 70it2G8
+Archos,79 Cobalt,ac79co,Archos 79 Cobalt
+Archos,79 Neon,a79ne,Archos 79 Neon
+Archos,79 Platinium,AC79PL,ARCHOS 79 Platinum
+Archos,79 Xenon,a79xe,Archos 79 Xenon
+Archos,80 Carbon,AC80CA,ARCHOS 80 Carbon
+Archos,80 Childpad,A80CHP,ARCHOS 80 CHILDPAD
+Archos,80 Cobalt,A80CO,ARCHOS 80 COBALT
+Archos,80 G9,A80,ARCHOS 80G9
+Archos,80 Helium,ac80he,Archos 80 Helium 4G
+Archos,80 Oxygen,ac80ox,Archos 80 Oxygen
+Archos,80 Platinum,A80PL,ARCHOS 80 Platinum
+Archos,80 Platinum,ac80cplv2_16G,Archos 80 Platinum
+Archos,80 Platinum v2,ac80dplv2,Archos 80 Platinum v2
+Archos,80 Titanium,A80TI,ARCHOS 80 TITANIUM
+Archos,80 XS,A80XSK,ARCHOS 80XSK
+Archos,80 Xenon,A80XE,Archos 80 Xenon
+Archos,80b Helium,ac80bhe,Archos 80b Helium
+Archos,80b Helium,ac80bhev2,Archos 80b Helium v2
+Archos,80b Platinum,A80BPL,ARCHOS 80b PLATINUM
+Archos,80b xenon,ac80bxe,Archos 80b Xenon
+Archos,80c Xenon,ac80cxe,Archos 80c Xenon
+Archos,80d Xenon,ac80dxe,Archos 80d Xenon
+Archos,9.4\'\' FFF,ac94fff,9.4\'\' FFF
+Archos,90 Copper,ac90cv,Archos 90 Copper
+Archos,90 Neon,a90ne,Archos 90 Neon
+Archos,90b Copper,ac90bcv,Archos 90b Copper
+Archos,90b Neon,ac90bne,Archos 90b Neon
+Archos,96 Xenon,ac96xe,Archos 96 Xenon
+Archos,97 Carbon,A97C,ARCHOS 97 CARBON
+Archos,97 Cobalt,AC97CO,Archos 97 Cobalt
+Archos,97 Platinum,A97PL,ARCHOS 97 Platinum
+Archos,97 Titanium HD,A97TIHD,ARCHOS 97 TITANIUMHD
+Archos,97 Xenon,A97XE,ARCHOS 97 XENON
+Archos,97b Platinum,AC97BPL,ARCHOS 97b PLATINUM
+Archos,97b Titanium,A97BTI,ARCHOS 97B TITANIUM
+Archos,97c Platinum,ac97cpl,Archos 97c Platinum
+Archos,ALBA 5,ac50cr4gv2,ALBA 5
+Archos,ALBA4,ac40as3g,ALBA 4
+Archos,Alba 10,ac101cplv3,ALBA 10 TABLET
+Archos,"Alba 10""",ac101cpl,"Alba 10"""
+Archos,Alba 4,ac40he,"Alba 4.0"" Smartphone"
+Archos,Alba 4,ac40ne,ALBA 4
+Archos,"Alba 4"" Android",ac40dti,"Alba 4"" Android"
+Archos,Alba 5,ac50dne,ALBA 5
+Archos,Alba 5,ac50fne,ALBA 5
+Archos,Alba 7,ac70plv5,ALBA 7 TABLET
+Archos,Alba 7\'\',ac70plv4,Alba 7
+Archos,Alba 7\'\',ac70plv4,"Alba 7"""
+Archos,Alba 8,ac80cplv2,"Alba 8"""
+Archos,Alba 8\'\',ac80cplv2_16G,"Alba 8"""
+Archos,ArcBook,a101db,Archos 101 DB
+Archos,Archos 101 Platinum 3G,ac101pl3g,Archos 101 Platinium 3G
+Archos,Archos 101 Platinum 3G,ac101pl3gv2,Archos 101 Platinum 3G
+Archos,Archos 101b Oxygen,ac101boxv2,Archos 101b Oxygen
+Archos,Archos 101b Xenon,ac101bxev3,Archos 101b Xenon v3
+Archos,Archos 101c Helium,ac101che,Archos 101c Helium
+Archos,Archos 101c Platinum,ac101cplv3,Archos 101c Platinum
+Archos,Archos 101c Xenon,ac101cxev2,Archos 101c Xenon
+Archos,Archos 116 Neon,ac116ne,Archos 116 Neon
+Archos,Archos 156 Oxygen,ac156ox,Archos 156 Oxygen
+Archos,Archos 50c Platinum,ac80cplv3,ALBA 8 TABLET
+Archos,Archos 70 platinum,ac70plv5,Archos 70 Platinum
+Archos,Archos 70d Titanium,ac70dti,Archos 70d Titanium
+Archos,Archos 79b Neon,ac79bnev2,Archos 79b Neon
+Archos,Archos 80 Oxygen,ac80oxv2,Archos 80 Oxygen
+Archos,Archos 80c Platinum,ac80cplv3,Archos 80c Platinum
+Archos,Archos 97c Platinum,ac97cplv2,Archos 97c Platinum
+Archos,Archos Acces 101 3G,ac101as3gv2,Archos Access 101 3G V2
+Archos,Archos Access 101 3G,ac101as3g,Archos Access 101 3G
+Archos,Archos Access 40 3G,ac40as3g,Archos Access 40 3G
+Archos,Archos Access 40 4G,ac40as4g,Archos Access 40 4G
+Archos,Archos Access 45 4G,ac45as4g,Archos Access 45 4G
+Archos,Archos Access 50 3G,ac50as3g,Archos Access 50 3G
+Archos,Archos Access 50 4G,ac50as4g,Archos Access 50 4G
+Archos,Archos Access 50 Color 3G,ac50asclr3g,Archos Access 50 Color 3G
+Archos,Archos Access 50 Color 4G,ac50asclr4g,Archos Access 50 Color 4G
+Archos,Archos Access 55 3G,ac55as3g,Archos Access 55 3G
+Archos,Archos Access 70 3G,ac70as3g,Archos Access 70 3G
+Archos,Archos Core 101 3G,ac101cr3g,Archos Core 101 3G
+Archos,Archos Core 101 4G,ac101cr4g,Archos Core 101 4G
+Archos,Archos Core 50 4G,ac50cr4g,Archos Core 50 4G
+Archos,Archos Core 50 4G,ac50cr4gv2,Archos Phone
+Archos,Archos Core 50P,ac50crp,Archos Core 50P
+Archos,Archos Core 55 4G,ac55cr4g,Archos Core 55 4G
+Archos,Archos Core 55P,ac55crp,Archos Core 55P
+Archos,Archos Core 70 3G,ac70cr3g,Archos Core 70 3G
+Archos,Archos Sense 101X,ac101xse,Archos Sense 101 X
+Archos,Archos Sense 47 X,ac47xse,Archos Sense 47 X
+Archos,Archos Sense 50 DC,ac50sedc,Archos Sense 50 DC
+Archos,Archos Sense 50X,ac50xse,Archos Sense 50X
+Archos,Archos Sense 55 DC,ac55sedc,Archos Sense 55 DC
+Archos,Archos Sense 55 DC,ac55sedcv2,Archos Phone
+Archos,Archos Sense 55 S,ac55ses,Archos Sense 55 S
+Archos,Archos80cpl_loreal,ac80cpl,Archos 80c Platinum
+Archos,Auchan QiLive 45,ql45,Qilive 45
+Archos,Auchan QiLive 50,ql50,Qilive 50
+Archos,Auchan Qilive 40,ql40,Qilive 40
+Archos,Auchan Qilive8,QiLive8,QiLive 8
+Archos,Auchan Qilive8QC,QiLive8QC,QiLive 8QC
+Archos,Auchan Qilive97,QiLive97,QiLive 97
+Archos,Auchan Qilive97R,QiLive97R,QiLive 97R
+Archos,Auchan Selecline 10,SELECLINE10,Selecline 10
+Archos,BUSH SPIRA B3 5.5,ac55cop,BUSH SPIRA B3 5.5
+Archos,BUSH SPIRA B5 POWER,ac50crp,BUSH SPIRA B5 POWER
+Archos,BUSH SPIRA D3 5,ac50dox,BUSH SPIRA D3 5
+Archos,BUSH SPIRA D5 Dual Camera,ac50sedc,BUSH SPIRA D5 Dual Camera
+Archos,BUSH SPIRA D5.5 Dual Camera,ac55sedcv2,BUSH SPIRA D5.5 Dual Camera
+Archos,Bush 10\'\',ac101dplv2,"Bush 10"" Android"
+Archos,Bush 10.0 MyTablet,ac101dpl,Bush 10.0 MyTablet
+Archos,"Bush 4"" Android Phone",ac40cti,Bush 4 Android
+Archos,Bush 5 4G,ac50heplus,"Bush 5"" 4G"
+Archos,Bush 5 4G,ac50heplus,"Bush Spira C2 5"" Smartphone"
+Archos,Bush 5 4G,ac55heplus,"Bush 5.5"" 4G"
+Archos,Bush 5 4G,ac55heplus,"Bush Spira D2 5.5"" Smartphone"
+Archos,"Bush 5"" Android",ac50cne,"Bush 5"" Android"
+Archos,"Bush 5"" Android Phone",ac50bne,BUSH 5 Android
+Archos,Bush 7.0 MyTablet,ac70pl,Bush 7.0 MyTablet
+Archos,Bush 7.85 My Tablet,ac79bu,Archos 79c Neon
+Archos,"Bush 8""",ac80bhe,"Bush 8"" LTE Android"
+Archos,Bush 8\'\',ac80dpl,Bush 8 Android
+Archos,Bush 8.0 MyTablet,ac80cpl,Bush 8.0 MyTablet
+Archos,Bush MyTablet 7,ac70bu,Archos 70 Carbon
+Archos,Bush MyTablet 7,ac70bu,BUSH 7.0 TABLET
+Archos,Bush Mytablet 2,a80bu,Bush Mytablet 2
+Archos,Bush Spira B1 10.1,ac101dplv3a6,"Bush Spira B1 10.1"""
+Archos,Bush Spira B1 10.1\'\',ac101dplv3,"Bush Spira B1 10.1"""
+Archos,Bush Spira B1 8\'\',ac80dplv2,"Bush Spira B1 8"""
+Archos,Bush Spira B2 8 tablet,ac80ox,Bush Spira B2 8 tablet
+Archos,ChefPad,A97CFP,Archos Chefpad
+Archos,Diamond 2 plus,ac55di2plus,Archos 55 Diamond 2 Plus
+Archos,Diamond Plus,ac55diplus,Archos 55 Diamond Plus
+Archos,Diamond Plus,ac55diplus,Archos Diamond Plus
+Archos,Diamond S,ac50dis,Archos Diamond S
+Archos,FamilyPad 2,A133FP2,ARCHOS FAMILYPAD 2
+Archos,Fieldbook G1,LIFBG1,Logic Fieldbook G1
+Archos,GamePad,A70GP,ARCHOS GAMEPAD
+Archos,GamePad 2,A70GP2,ARCHOS GAMEPAD2
+Archos,KUNO 4+,kuno4p,KUNO 4+
+Archos,Kodak Tab 10,ac101tr,KODAK Tablet 10
+Archos,Kodak Tab 7,ac70tr,KODAK Tablet 7
+Archos,Kuno,KUNO4,KUNO4
+Archos,Logic Instrument Fieldbook F1B,lifbf1b,Logic Instrument Fieldbook F1B
+Archos,My Tablet 101,ac101bu,BUSH 10.1 TABLET
+Archos,QiLive 101,aqilive101,QILIVE 101
+Archos,Qilive 45 - 4G,ql45lte,Qilive 45 - 4G
+Archos,Qilive 50 QC,ql50qc,Qilive 50 QC
+Archos,Qilive 53,msm8625,Qilive 53
+Archos,Qilive 7,qilive7,Qilive 7
+Archos,Qilive 97R2,qilive97r2,Qilive 97R-2
+Archos,Qilive79,Qilive79,Qilive 79
+Archos,Qilive7V2,ql70v2,Qilive 70v2
+Archos,Quechua Phone 5,A50RG11,Quechua Phone 5
+Archos,Quechua Tablet 8,A80RG11,A80RG11
+Archos,Smart Home Tablet,hometablet,Archos Smart Home Tablet
+Archos,Smarthome La Poste,hometablet,Archos Smart Home Tablet
+Archos,TV Connect,LUDO,ARCHOS LUDOG10
+Archos,alba 10,ac101cplv2,ALBA 10 TABLET
+Archos,alba 10,ac101cplv2,"Alba 10"""
+Ark,Bebefit M551,Benefit_M551,Benefit_M551
+Ark,Benefit M503,Benefit_M503,Benefit_M503
+Ark,Benefit M505,Benefit_M505,Benefit_M505
+Ark,Benefit M8,Benefit_M8,Benefit_M8
+Ark,Impulse P2,Impulse_P2,Impulse_P2
+Ascom Wireless Solutions,Ascom Myco 2 Cellular,ACBB,SH1
+Ascom Wireless Solutions,Ascom Myco 2 WiFi,ABBB,SH1
+Ascom Wireless Solutions,Ascom Myco 2 WiFi,ACBA,SH1
+Ascom Wireless Solutions,Ascom Myco Cellular,ACBA,SH1
+Ascom Wireless Solutions,Ascom Myco Cellular,myco_gms,SH1
+Ascom Wireless Solutions,Ascom Myco Wi-Fi,ABBA,SH1
+Ashna,X55,X55,X55
+Ashna,X66,X66,X66
+Ashna,Z600,Z600,Z600
+Astak,NEOS,Wenu,NEOS
+Astro Queo,A712,A712,A712
+AstroQueo,polaris_wifionly,polaris-wifionly,A912
+Asus,,EP71,ME171
+Asus,,TF300T,ASUS Transformer Pad TF300T
+Asus,,a10,Asus A10
+Asus,,a10,Garmin-Asus A10
+Asus,,ventana,Transformer TF101
+Asus,ASUS Chromebook Flip C302,cave_cheets,ASUS Chromebook Flip C302
+Asus,ASUS Live (G500TG),ASUS_Z00YD,ASUS_Z00YD
+Asus,ASUSPRO Tablet (M1000C),P023_M,P023
+Asus,ASUSPRO Tablet (M1000CL),P01T_M,P01T
+Asus,ASUSPRO Tablet (M700C),P01W_M,P01W
+Asus,ASUSPRO Tablet (M700KL),P002_M,P002
+Asus,Chromebook C202SA/C300SA/C301SA,terra_cheets,ASUS Chromebook C202SA
+Asus,Chromebook Flip C100PA,minnie_cheets,ASUS Chromebook Flip C100PA
+Asus,Chromebook Flip C101PA,bob_cheets,ASUS Chromebook Flip C101PA
+Asus,Chromebook Flip C101PA,bob_cheets,bob
+Asus,"Commercial tablet 10"" (M1000M)",P00C_M,P00C
+Asus,"Commercial tablet 10"" (R1000M)",P00C_M,P00C
+Asus,"Commercial tablet 8"" (M800M)",P00A_M,P00A
+Asus,"Commercial tablet 8"" (R800M)",P00A_M,P00A
+Asus,Cube,asus_google_cube,asus_google_cube
+Asus,ETBW11AA,ETBW11AA,ETBW11AA
+Asus,ETBW11AA,TF101G,ETBW11AA
+Asus,Eee Pad,EeePad,Transformer TF101
+Asus,Eee Pad,EeePad,Transformer TF101G
+Asus,Eee Pad Slider,SL101,Slider SL101
+Asus,Eee Pad TF101,TF101,TF101
+Asus,Eee Pad TF101,TF101,Transformer TF101
+Asus,Eee Pad TF101-WiMAX,TF101-WiMAX,TF101-WiMAX
+Asus,Eee Pad Transformer,TF101,Transformer TF101
+Asus,Eee Pad Transformer Prime,TF201,TF201
+Asus,Eee Pad Transformer Prime,TF201,Transformer Prime TF201
+Asus,Eee Pad Transformer Prime,TF201,Transformer TF201
+Asus,EeePad Slider SL101,SL101,Slider SL101
+Asus,Fonepad 7 (FE170CG),K012,K012
+Asus,Fonepad 7 (FE171CG),K01N_1,K01N
+Asus,Fonepad 7 (FE171CG),K01N_2,K01N
+Asus,Fonepad 7 (FE171MG),K01F,K01F
+Asus,Fonepad 7 (FE375CG),K019_1,K019
+Asus,Fonepad 7 (FE375CXG),K019_2,K019
+Asus,Fonepad 7 (FE375CXG),K019_3,K019
+Asus,Fonepad 7 (FE375CXG),K019_4,K019
+Asus,Fonepad 7 (ME175CG),K00Z,K00Z
+Asus,Fonepad 7 (ME372CG),K00E,K00E
+Asus,Fonepad 7 LTE (FE375CL),K01Q,K01Q
+Asus,Fonepad 7 LTE (ME372CL),K00Y,K00Y
+Asus,Fonepad 8 (FE380CG),K016_1,K016
+Asus,Fonepad 8 (FE380CG),K016_4,K016
+Asus,Fonepad 8 (FE380CXG),K016_2,K016
+Asus,Fonepad 8 (FE380CXG),K016_3,K016
+Asus,Fonepad ME371MG,ME371MG,ME371MG
+Asus,Fonepad Note 6 (ME560CG),K00G,K00G
+Asus,MeMO PAD,me172v,ME172V
+Asus,MeMO Pad (ME103K),K01E_1,K01E
+Asus,MeMO Pad (ME103K),K01E_2,K01E
+Asus,MeMO Pad 10 (ME102A),K00F,K00F
+Asus,MeMO Pad 7 (FE7010CG),K012_2,K012_2
+Asus,MeMO Pad 7 (ME170C),K017,K017
+Asus,MeMO Pad 7 (ME171C),K01U_1,K01U
+Asus,MeMO Pad 7 (ME171C),K01U_2,K01U
+Asus,MeMO Pad 7 (ME176C),K013,K013
+Asus,MeMO Pad 7 (ME176CE),K013C,K013C
+Asus,MeMO Pad 7 (ME176CX),K013_1,K013
+Asus,MeMO Pad 7 (ME572C),K007,K007
+Asus,MeMO Pad 7 (ME70C),K01A,K01A
+Asus,MeMO Pad 7 LTE (ME375CL),K00X,ASUS MeMO Pad 7
+Asus,MeMO Pad 7 LTE (ME572CL),K00R,K00R
+Asus,MeMO Pad 7 LTE (ME7530CL),K00X_1,K00X
+Asus,MeMO Pad 8 (AST21),K015,AST21
+Asus,MeMO Pad 8 (ME181C),K011,K011
+Asus,MeMO Pad 8 (ME181CX),K011_1,K011
+Asus,MeMO Pad 8 (ME581C),K01H,K01H
+Asus,MeMO Pad 8 (ME581CL),K015,K015
+Asus,MeMO Pad FHD 10 (ME302KL),ME302KL,ME302KL
+Asus,MeMO Pad HD 7 (ME173X),ME173X,ME173X
+Asus,MeMO Pad HD 7 (ME173XX),K00U,K00U
+Asus,MeMO Pad HD 8 (ME180A),K00L,K00L
+Asus,MeMO Pad HD7 Dual SIM (ME175KG),ASUS-K00S,ASUS K00S
+Asus,MeMO Pad Smart 10,ME301T,ME301T
+Asus,MeMo Pad 10 (ME302C),ME302C,ME302C
+Asus,MeMo Pad HD 7 (ME173XX),K00U,K00U
+Asus,Nexus 7 (2012),grouper,Nexus 7
+Asus,Nexus 7 (2012),tilapia,Nexus 7
+Asus,Nexus 7 (2013),deb,Nexus 7
+Asus,Nexus 7 (2013),flo,Nexus 7
+Asus,Nexus Player,fugu,Nexus Player
+Asus,Nuvifone,a50,Garmin-Asus A50
+Asus,PadFone,PadFone,PadFone
+Asus,PadFone 2,A68,PadFone 2
+Asus,PadFone E (A68M),ASUS-T008,PadFone T008
+Asus,PadFone Infinity,A80,PadFone Infinity
+Asus,PadFone Infinity,ASUS-A80,PadFone Infinity
+Asus,PadFone Mini,ASUS-T00C,PadFone T00C
+Asus,PadFone S (PF500KL),ASUS_T00N,ASUS_T00N
+Asus,PadFone X (A91),ASUS-T00D,ASUS PadFone X
+Asus,PadFone X mini (PF450CL),ASUS-T00S,ASUS PadFone X mini
+Asus,PadFone X mini (PF450CL),ASUS-T00S,ASUS_T00T
+Asus,PadFone mini,ASUS-T00C,PadFone T00C
+Asus,PadFone mini,ASUS_T00E,ASUS_T00E
+Asus,R Series Tablet (R1001MFL),ASUS_P00L_M2,P00L
+Asus,R Series Tablet (R1001ML),ASUS_P00L_M1,P00L
+Asus,RTC-700A,RTC-tablet,RTC-tablet
+Asus,T101TA,T10xTA,T10xTA
+Asus,TF700T,TF700T,ASUS Pad TF700T
+Asus,TF700T,TF700T,ASUS Transformer Pad TF700T
+Asus,TX201LAF,TX201LAF,TX201LAF
+Asus,The new PadFone Infinity (A86),ASUS-A86,PadFone T004
+Asus,Trans AiO P1801,P1801-T,ASUS Tablet P1801-T
+Asus,TransBook Trio,TX201LA,TX201LA
+Asus,Transformer AiO P1801,P1801-T,ASUS Tablet P1801-T
+Asus,Transformer AiO P1802,P1802-T,ASUS Tablet P1802-T
+Asus,Transformer Book Trio,TX201LA,TX201LA
+Asus,Transformer Pad,K010_1,K010
+Asus,Transformer Pad,TF300T,ASUS Pad TF300T
+Asus,Transformer Pad,TF300T,ASUS Transformer 300
+Asus,Transformer Pad,TF300T,ASUS Transformer Pad TF300T
+Asus,Transformer Pad (TF103C),K010,K010
+Asus,Transformer Pad (TF103C),K010_3,K010
+Asus,Transformer Pad (TF103CE),K010E,K010E
+Asus,Transformer Pad (TF103CE),K010E_1,K010E
+Asus,Transformer Pad (TF103CG),K018,K018
+Asus,Transformer Pad (TF303CL),K014,K014
+Asus,Transformer Pad (TF303K),K01B,K01B
+Asus,Transformer Pad Infinity,TF700KL,ASUS Transformer Pad TF700KL
+Asus,Transformer Pad Infinity (TF701T),K00C,K00C
+Asus,Transformer Pad TF300TG,TF300TG,ASUS Transformer Pad TF300TG
+Asus,Transformer Pad TF300TL,TF300TL,ASUS Transformer Pad TF300TL
+Asus,Transformer Pad TF502T,TF502T,ASUS Transformer Pad TF502T
+Asus,Transformer Pad TF600T,TF600T,ASUS Transformer Pad TF600T
+Asus,Transformer TF101G,TF101G,Transformer TF101G
+Asus,ZenFone 2 (ZE500CL),ASUS_Z00D,ASUS ZenFone 2
+Asus,ZenFone 2 (ZE500CL),ASUS_Z00D,ASUS ZenFone 2E
+Asus,ZenFone 2 (ZE500CL),ASUS_Z00D,Z00D
+Asus,ZenFone 2 (ZE550ML),Z008_1,ASUS_Z008D
+Asus,ZenFone 2 (ZE551ML),Z00A,ASUS_Z00AD
+Asus,ZenFone 2 (ZE551ML),Z00A,ASUS_Z00ADA
+Asus,ZenFone 2 (ZE551ML),Z00A_1,ASUS_Z00AD
+Asus,ZenFone 2 (ZE551ML),Z00A_1,ASUS_Z00ADB
+Asus,ZenFone 2 (ZE551ML),Z00A_3,ASUS_Z00AD
+Asus,ZenFone 2 Laser (ZE500KG),ASUS_Z00RD_5,ASUS_Z00RD
+Asus,ZenFone 2 Laser (ZE500KG),ASUS_Z00RD_7,ASUS_Z00RD
+Asus,ZenFone 2 Laser (ZE500KL),ASUS_Z00E_1,ASUS_Z00ED
+Asus,ZenFone 2 Laser (ZE500KL),ASUS_Z00E_2,ASUS_Z00ED
+Asus,ZenFone 2 Laser (ZE500KL),ASUS_Z00E_2,ASUS_Z00EDB
+Asus,ZenFone 2 Laser (ZE500KL),ASUS_Z00E_3,ASUS_Z00ED
+Asus,ZenFone 2 Laser (ZE500KL),ASUS_Z00E_4,ASUS_Z00ED
+Asus,ZenFone 2 Laser (ZE550KG),ASUS_Z00W_63,ASUS_Z00WD
+Asus,ZenFone 2 Laser (ZE550KL),ASUS_Z00L_63,ASUS_Z00LD
+Asus,ZenFone 2 Laser (ZE550KL),ASUS_Z00L_63,ASUS_Z00LDC
+Asus,ZenFone 2 Laser (ZE550KL),ASUS_Z00L_63A,ASUS_Z00LD
+Asus,ZenFone 2 Laser (ZE550KL),ASUS_Z00L_63C,ASUS_Z00LD
+Asus,ZenFone 2 Laser (ZE550KL),ASUS_Z00L_93,ASUS_Z00LD
+Asus,ZenFone 2 Laser (ZE551KL),ASUS_Z00T,ASUS_Z00TD
+Asus,ZenFone 2 Laser (ZE600KL),ASUS_Z00M,ASUS_Z00MD
+Asus,ZenFone 2 Laser (ZE601KL),ASUS_Z011,ASUS_Z011D
+Asus,ZenFone 3 (ZE520KL),ASUS_Z017D_1,ASUS_Z017D
+Asus,ZenFone 3 (ZE520KL),ASUS_Z017D_1,ASUS_Z017DA
+Asus,ZenFone 3 (ZE552KL),ASUS_Z012D,ASUS_Z012D
+Asus,ZenFone 3 (ZE552KL),ASUS_Z012D,ASUS_Z012DA
+Asus,ZenFone 3 (ZE552KL),ASUS_Z012D,ASUS_Z012DE
+Asus,ZenFone 3 Deluxe (ZS550KL),ASUS_Z01F_1,ASUS_Z01FD
+Asus,ZenFone 3 Deluxe (ZS570KL),Z016,ASUS_Z016D
+Asus,ZenFone 3 Deluxe (ZS570KL),Z016,ASUS_Z016DA
+Asus,ZenFone 3 Deluxe (ZS570KL),Z016,ASUS_Z016S
+Asus,ZenFone 3 Deluxe (ZS570KL),Z016_1,ASUS_Z016D
+Asus,ZenFone 3 Laser (ZC551KL),Z01B_1,ASUS_Z01BD
+Asus,ZenFone 3 Laser (ZC551KL),Z01B_1,ASUS_Z01BDA
+Asus,ZenFone 3 Laser (ZC551KL),Z01B_1,ASUS_Z01BDC
+Asus,ZenFone 3 Laser (ZC551KL),Z01B_1,ASUS_Z01BS
+Asus,ZenFone 3 Max (ZC520TL),ASUS_X008,ASUS_X008D
+Asus,ZenFone 3 Max (ZC520TL),ASUS_X008,ASUS_X008DA
+Asus,ZenFone 3 Max (ZC520TL),ASUS_X008,ASUS_X008DB
+Asus,ZenFone 3 Max (ZC520TL),ASUS_X008_1,ASUS_X008D
+Asus,ZenFone 3 Max (ZC520TL),ASUS_X008_1,ASUS_X008DA
+Asus,ZenFone 3 Max (ZC520TL),ASUS_X008_1,ASUS_X008DB
+Asus,ZenFone 3 Max (ZC520TL),ASUS_X008_1,ASUS_X008DC
+Asus,ZenFone 3 Max (ZC553KL),ASUS_X00DD,ASUS_X00DD
+Asus,ZenFone 3 Max (ZC553KL),ASUS_X00DD,ASUS_X00DDA
+Asus,ZenFone 3 Ultra (ZU680KL),ASUS_A001,ASUS_A001
+Asus,ZenFone 3 Zoom (ZE553KL),ASUS_Z01H_1,ASUS_Z01HD
+Asus,ZenFone 3 Zoom (ZE553KL),ASUS_Z01H_1,ASUS_Z01HDA
+Asus,ZenFone 3s Max (ZC521TL),ASUS_X00G_1,ASUS_X00GD
+Asus,ZenFone 4 (A400CG),ASUS_T00I,ASUS_T00I
+Asus,ZenFone 4 (A400CG),ASUS_T00I,ASUS_T00I-D
+Asus,ZenFone 4 (A450CG),ASUS_T00Q,ASUS_T00Q
+Asus,ZenFone 4 (ZE554KL),ASUS_Z01KDA,ASUS_Z01KD
+Asus,ZenFone 4 (ZE554KL),ASUS_Z01KDA,ASUS_Z01KS
+Asus,ZenFone 4 (ZE554KL),ASUS_Z01KD_1,ASUS_Z01KDA
+Asus,ZenFone 4 (ZE554KL),ASUS_Z01KD_2,ASUS_Z01KD
+Asus,ZenFone 4 Max (ZC520KL),ASUS_X00HD_1,ASUS_X00HD
+Asus,ZenFone 4 Max (ZC520KL),ASUS_X00HD_2,ASUS_X00HD
+Asus,ZenFone 4 Max (ZC520KL),ASUS_X00HD_4,ASUS_X00HD
+Asus,ZenFone 4 Max (ZC554KL),ASUS_X00ID,ASUS_X00ID
+Asus,ZenFone 4 Max (ZC554KL),ASUS_X00IDB,ASUS_X00ID
+Asus,ZenFone 4 Max (ZC554KL),ASUS_X00IDC,ASUS_X00ID
+Asus,ZenFone 4 Pro (ZS551KL),ASUS_Z01GD_1,ASUS_Z01GD
+Asus,ZenFone 4 Selfie (ZD553KL),ASUS_X00LD_1,ASUS_X00LD
+Asus,ZenFone 4 Selfie Lite (ZB520KL),ASUS_X00HD_3,ASUS_X00HD
+Asus,ZenFone 4 Selfie Lite (ZB520KL),ASUS_X00HD_3,ASUS_X00HDA
+Asus,ZenFone 4 Selfie Pro (ZD552KL),ASUS_Z01M_1,ASUS_Z01MD
+Asus,ZenFone 4 Selfie Pro (ZD552KL),ASUS_Z01M_1,ASUS_Z01MDA
+Asus,ZenFone 5,ASUS_T00F,ASUS_T00F
+Asus,ZenFone 5,ASUS_T00J,ASUS_T00J
+Asus,ZenFone 5 (A500CG),ASUS_T00F,ASUS_T00F
+Asus,ZenFone 5 (A500CG),ASUS_T00F1,ASUS_T00F
+Asus,ZenFone 5 (A501CG),ASUS_T00J1,ASUS_T00J
+Asus,ZenFone 5 (A502CG),ASUS_T00K,ASUS_T00K
+Asus,ZenFone 5 LTE (A500KL),ASUS_T00P,ASUS_T00P
+Asus,ZenFone 6,ASUS_T00G,ASUS_T00G
+Asus,ZenFone 6 (A600CG),ASUS_T00G,ASUS_T00G
+Asus,ZenFone 6 (A601CG),ASUS_Z002,ASUS_Z002
+Asus,ZenFone AR,ASUS_A002_1,ASUS_A002A
+Asus,ZenFone AR (ZS571KL),ASUS_A002,ASUS_A002
+Asus,ZenFone C (ZC451CG),ASUS_Z007,ASUS_Z007
+Asus,ZenFone Go (ZB450KL),ASUS_X009D_2,ASUS_X009DB
+Asus,ZenFone Go (ZB452KG),ASUS_X014D_1,ASUS_X014D
+Asus,ZenFone Go (ZB452KG),ASUS_X014D_2,ASUS_X014D
+Asus,ZenFone Go (ZB500KG),ASUS_X00BD_1,ASUS_X00BD
+Asus,ZenFone Go (ZB500KL),ASUS_X00AD_2,ASUS_X00AD
+Asus,ZenFone Go (ZB551KL),ASUS_X013D_1,ASUS_X013DA
+Asus,ZenFone Go (ZB551KL),ASUS_X013D_1,ASUS_X013DB
+Asus,ZenFone Go (ZB551KL),ASUS_X013D_2,ASUS_X013DA
+Asus,ZenFone Go (ZB551KL),ASUS_X013D_2,ASUS_X013DB
+Asus,ZenFone Go (ZB552KL),ASUS_X007D,ASUS_X007D
+Asus,ZenFone Go (ZB690KG),ASUS_L001_1,ASUS_L001
+Asus,ZenFone Go (ZB690KG),ASUS_L001_2,ASUS_L001
+Asus,ZenFone Go (ZC451TG),ASUS_Z00SD,ASUS_Z00SD
+Asus,ZenFone Go (ZC500TG),ASUS_Z00VD,ASUS_Z00VD
+Asus,ZenFone Live (ZB501KL),ASUS_A007,ASUS_A007
+Asus,ZenFone Live Plus (ZB553KL),ASUS_X00LD_2,ASUS_X00LDB
+Asus,ZenFone Live Plus (ZB553KL),ASUS_X00LD_3,ASUS_X00LDA
+Asus,ZenFone Live Plus (ZB553KL),ASUS_X00LD_3,ZB553KL
+Asus,ZenFone Max Plus M1 (ZB570TL),ASUS_X018_1,ASUS_X018D
+Asus,ZenFone Max Plus M1 (ZB570TL),ASUS_X018_4,ASUS_X018D
+Asus,ZenFone Selfie (ZD551KL),ASUS_Z00U_1,ASUS_Z00UD
+Asus,ZenFone Selfie (ZD551KL),ASUS_Z00U_1,ASUS_Z00UDA
+Asus,ZenFone Selfie (ZD551KL),ASUS_Z00U_2,ASUS_Z00UD
+Asus,ZenFone Zoom (ZX551ML),Z00X,ASUS_Z00XS
+Asus,ZenFone Zoom (ZX551ML),Z00X,ASUS_Z00XSA
+Asus,ZenFone Zoom (ZX551ML),Z00X,ASUS_Z00XSB
+Asus,ZenFone Zoom (ZX551ML),Z00X_1,ASUS_Z00XS
+Asus,ZenFone Zoom (ZX551ML),Z00X_1,ASUS_Z00XSA
+Asus,ZenFone Zoom (ZX551ML),Z00X_2,ASUS_Z00XS
+Asus,ZenFone4 (ZE554KL),ASUS_Z01KD_3,ASUS_Z01KD
+Asus,ZenPad 10 (Z300C),P023_1,P023
+Asus,ZenPad 10 (Z300C),P023_2,P023
+Asus,ZenPad 10 (Z300CG),P021,P021
+Asus,ZenPad 10 (Z300CG),P021_1,P021
+Asus,ZenPad 10 (Z300CL),P01T_1,P01T_1
+Asus,ZenPad 10 (Z300M),P00C_1,P00C
+Asus,ZenPad 10 (Z300M),P00C_2,P00C
+Asus,ZenPad 10 (Z301M),ASUS_P028_1,P028
+Asus,ZenPad 10 (Z301MF),ASUS_P028_2,P028
+Asus,ZenPad 10 (Z301MFL),ASUS_P00L_2,P00L
+Asus,ZenPad 10 (Z301ML),ASUS_P00L_1,P00L
+Asus,ZenPad 3 8.0,P008_1,P008
+Asus,ZenPad 3 8.0,P008_2,P008
+Asus,ZenPad 3S 10 (Z500M),P027,P027
+Asus,ZenPad 3S 10 LTE (Z500KL),ASUS_P00I,ASUS_P00I
+Asus,ZenPad 7.0 (Z370C),P01W,P01W
+Asus,ZenPad 7.0 (Z370CG),P01V_1,P01V
+Asus,ZenPad 7.0 (Z370CG),P01V_2,P01V
+Asus,ZenPad 7.0 (Z370KL),P002_1,P002
+Asus,ZenPad 7.0 (Z370KL),P002_2,P002
+Asus,ZenPad 8.0 (Z380KL),P024_1,P024
+Asus,ZenPad 8.0 (Z380KL),P024_2,P024
+Asus,ZenPad 8.0 (Z380KL),P024_3,P024
+Asus,ZenPad 8.0 (Z380KL),P024_4,P024
+Asus,ZenPad 8.0 (Z380M),P00A_1,P00A
+Asus,ZenPad 8.0 (Z380M),P00A_2,P00A
+Asus,ZenPad C 7.0,P01Y_S,P01Y
+Asus,ZenPad C 7.0,P01Y_S,P01Y_S
+Asus,ZenPad C 7.0 (Z170C),P01Z,P01Z
+Asus,ZenPad C 7.0 (Z170C),P01Z_2,P01Z
+Asus,ZenPad C 7.0 (Z170CG),P01Y,P01Y
+Asus,ZenPad C 7.0 (Z170CG),P01Y_2,P01Y
+Asus,ZenPad C 7.0 (Z170MG),P001,P001
+Asus,ZenPad C 7.0 (Z170MG),P001_2,P001
+Asus,ZenPad S 8.0 (Z580C),P01M_2,P01M
+Asus,ZenPad S 8.0 (Z580C),P01M_4,P01M
+Asus,ZenPad S 8.0 (Z580CA),P01M_1,P01MA
+Asus,ZenPad S 8.0 (Z580CA),P01M_3,P01MA
+Asus,ZenPad S 8.0 (Z580CA),P01M_5,P01MA
+Asus,ZenPad Z10,P00I,P00I
+Asus,ZenPad Z8s,ASUS_P00J,ASUS_P00J
+Asus,ZenPadC 7.0 (Z170MG),P001_2,P001_2
+Asus,ZenWatch,anthias,ASUS ZenWatch
+Asus,ZenWatch 2,sparrow,ASUS ZenWatch 2
+Asus,ZenWatch 2,wren,ASUS ZenWatch 2
+Asus,ZenWatch 3,swift,ASUS ZenWatch 3
+Asus,Zenbo,ASUS_ZENBO,Zenbo
+Asus,Zenbo Qrobot,ASUS_ZENBO,Zenbo
+Asus,Zenfone 4V (V520KL),ASUS_A006,ASUS_A006
+Asus,Zenfone Go (ASUS_X00BD),ASUS_X00BD_1,ASUS_X00BD
+Asus,Zenfone Go (T500),ASUS_X003,ASUS_X003
+Asus,Zenfone MAX,ASUS_Z010,ASUS_Z010DA
+Asus,Zenfone MAX,ASUS_Z010,ASUS_Z010DB
+Asus,Zenfone MAX,ASUS_Z010_CD,ASUS_Z010D
+Asus,Zenfone MAX,ASUS_Z010_CD,ASUS_Z010DA
+Asus,Zenfone MAX (ZC550KL),ASUS_Z010,ASUS_Z010D
+Asus,Zenfone Max,ASUS_Z010_2,ASUS_Z010DD
+Asus,Zenfone V Live (Verizon),ASUS_A009,ASUS_A009
+Asus,Zenpad 8.0 (Z380C),P022_1,P022
+Asus,Zenpad 8.0 (Z380C),P022_2,P022
+Asus,\xe9\xa3\x9b\xe9\xa6\xac (T500KLC),ASUS_X003,ASUS_X003
+Asus,\xe9\xa3\x9b\xe9\xa6\xac (T500TLT),ASUS_X002,ASUS_X002
+Asus,\xe9\xa3\x9b\xe9\xa6\xac 5000 (T551TLC),ASUS_X005,ASUS_X005
+Asus,\xe9\xa3\x9b\xe9\xa6\xac2 Plus (T550KLC),ASUS_X550,ASUS_X550
+AtGames-zooti,ZOOTI PAD ZT-701,ZT-701,ZT-701
+Auchan,AUCHAN,Q7T9INK,Q7T9INK
+Auchan,LI12210IN,LI12210IN,LI12210IN
+Auchan,LI902T9IN,LI902T9IN,LI902T9IN
+Auchan,Q.4514,Q4514,Q4514
+Auchan,Q4S6IN4G,Q4S6IN4G,Q4S6IN4G
+Auchan,Q4T10IN,Q4T10IN,Q4T10IN
+Auchan,Q4T7IN,Q4T7IN,Q4T7IN
+Auchan,Q4T7IN3G,Q4T7IN3G,Q4T7IN3G
+Auchan,Q4T8IN,Q4T8IN,Q4T8IN
+Auchan,Q5S55IN4G,Q5S55IN4G,Q5S55IN4G
+Auchan,Q5S5IN4G,Q5S5IN4G,Q5S5IN4G
+Auchan,Q6T10IN,Q6T10IN,Q6T10IN
+Auchan,Q6T10IN4G,Q6T10IN4G,Q6T10IN4G
+Auchan,Q6T7IN,Q6T7IN,Q6T7IN
+Auchan,Q6T7IN4G,Q6T7IN4G,Q6T7IN4G
+Auchan,Q6T7INK,Q6T7INK,Q6T7INK
+Auchan,Q7S55IN4G,Q7S55IN4G,Q7S55IN4G
+Auchan,Q7S5IN4G,Q7S5IN4G,Q7S5IN4G
+Auchan,Q7S5IN4GP,Q7S5IN4GP,Q7S5IN4GP
+Auchan,Q7T10INP,Q7T10INP,Q7T10INP
+Auchan,Q7T7INK,Q7T7INK,Q7T7INK
+Auchan,Q8S55IN4G,Q8S55IN4G,Q8S55IN4G
+Auchan,Q8S55IN4G2,Q8S55IN4G2,Q8S55IN4G2
+Auchan,Q8S6IN4G,Q8S6IN4G,Q8S6IN4G
+Auchan,Q8T10IN,Q8T10IN,Q8T10IN
+Auchan,Q8T7IN,Q8T7IN,Q8T7IN
+Auchan,Q8T7IN4G,Q8T7IN4G,Q8T7IN4G
+Auchan,QILIVE,Q4T10INK,Q4T10INK
+Auchan,S3T10IN,S3T10IN,S3T10IN
+Auchan,S3T10IN3G,S3T10IN3G,S3T10IN3G
+Auchan,S3T7IN,S3T7IN,S3T7IN
+Auchan,S3T7IN,astar-d86,S3T7IN
+Auchan,S3T7IN3G,S3T7IN3G,S3T7IN3G
+Auchan,S4S5IN3G,S4S5IN3G,S4S5IN3G
+Auchan,S4S5IN4G,S4S5IN4G,S4S5IN4G
+Auchan,S4S6IN3G,S4S6IN3G,S4S6IN3G
+Auchan,S4T10IN3G,S4T10IN3G,S4T10IN3G
+Auchan,S4T7IN,S4T7IN,S4T7IN
+Auchan,S4T7IN3G,S4T7IN3G,S4T7IN3G
+Auchan,S4T9IN,S4T9IN,S4T9IN
+Auchan,S5S4IN3G,S5S4IN3G,S5S4IN3G
+Auchan,S5S5IN4G,S5S5IN4G,S5S5IN4G
+Auchan,S5T10IN3G,S5T10IN3G,S5T10IN3G
+Auchan,S5T7IN3G,S5T7IN3G,S5T7IN3G
+Auchan,S5T9INDVD,S5T9INDVD,S5T9INDVD
+Auchan,S6S4IN3G,S6S4IN3G,S6S4IN3G
+Auchan,S6S55IN3G,S6S55IN3G,S6S55IN3G
+Auchan,S6S5IN3G,S6S5IN3G,S6S5IN3G
+Auchan,Selecline X35T,X35T,X35T
+Auchan,Selecline-854599,854599,Selecline-854599
+Auchan,"Smartphone 5"" Q.4094",ac50bhe,Q.4094
+Audi AG,Audi Tab CN,sdis1,Audi tablet
+Audi AG,Audi tablet,sdis1,Audi tablet
+Audi AG,RSE-III,RSEIII,RSEIII
+Audiovox,T752 Tablet,AD7L,T752
+Audiovox,T852 Tablet,MID30801,T852
+Avaya,Vantage,K175,Avaya Vantage
+Avaya,Vantage,K175,K175
+Avaya,Vantage,Vantage,Avaya Vantage
+Avaya,Vantage,Vantage,K165
+Avoca,STB7012,STB7012,STB7012
+Avoca,STB7013,AVOCA,STB7013
+Avoca,STB8098,STB8098,STB8098
+Avoca,STB9097,STB9097,STB9097
+Avvio,Avvio A400,Avvio_A400,Avvio_A400
+Avvio,Avvio PRO450,Avvio_Pro450,Avvio_Pro450
+Avvio,Avvio PRO550,Avvio_Pro550,Avvio_Pro550
+Avvio,Avvio Platinum A50,Avvio_A50,Avvio_A50
+Axioo,Axioo AX4,Axioo_AX4,Axioo_AX4
+Azumi,A40 Style Plus,A40_Style_Plus,A40_Style_Plus
+Azumi,A40C,A40C,A40C
+Azumi,A50 Style Plus,A50_Style_Plus,A50_Style_Plus
+Azumi,A50LT,A50LT,A50LT
+Azumi,AX5,AX5,Azumi AX5
+Azumi,AZUMI_Daburu_A55O,Daburu_A55O,Azumi_Daburu_A55O
+Azumi,Azumi_Extend_Akaru_55_QL,Extend_Akaru_55_QL,Azumi Extend Akaru 55 QL
+Azumi,Azumi_KIREI_A45_D,KIREI_A45_D,Azumi_KIREI_A45_D
+Azumi,Azumi_KIREI_A4_D,KIREI_A4_D,Azumi_KIREI_A4_D
+Azumi,Azumi_KIREI_A5_D,KIREI_A5_D,Azumi_KIREI_A5_D
+Azumi,Azumi_Speed_Pro_55,Speed_Pro_55,Azumi_Speed_Pro_55
+Azumi,DOSHI A55 QL,Azumi_DOSHI_A55_QL,Azumi_DOSHI_A55_QL
+Azumi,EXTEND 55 QL,EXTEND_55_QL,EXTEND 55 QL
+Azumi,IRO A4Q,IRO_A4_Q,Azumi_IRO_A4_Q
+Azumi,IRO A4Q,IRO_A4_Q_AF,Azumi_IRO_A4_Q
+Azumi,IRO A5 QL,IRO_A5_QL,Azumi_IRO_A5_QL
+Azumi,IRO A5 QL,IRO_A5_QL_OM,Azumi_IRO_A5_QL
+Azumi,IRO A5 QLT,IRO_A5_QLT,Azumi_IRO_A5_QLT
+Azumi,IRO A55 Q,IRO_A55_Q,IRO A55 Q
+Azumi,IRO A55 QL,IRO_A55_QL,Azumi_IRO_A55_QL
+Azumi,IRO A5Q,IRO_A5_Q,Azumi_IRO_A5_Q
+Azumi,IRO A5Q,IRO_A5_Q_AF,Azumi_IRO_A5_Q
+Azumi,IRO A5QL,IRO_A5QL_V2,Azumi IRO A5QL V2
+Azumi,IRO A5QL,IRO_A5_QL_HD,Azumi_IRO_A5_QL
+Azumi,IRO_A4_Q_Pro,IRO_A4_Q_PRO,Azumi_IRO_A4_Q_PRO
+Azumi,IRO_A55_Q_Pro,IRO_A55_Q_Pro,Azumi IRO A55 Q Pro
+Azumi,IRO_A6_Q,IRO_A6_Q,IRO A6 Q
+Azumi,KINZO A55 OLi,KINZO_A55_OLi,Azumi_KINZO_A55_OLi
+Azumi,KINZO A55QL,KINZO_A55_OLi_CL,Azumi_KINZO_A55_OLi
+Azumi,KINZO ICHI A5 QL,KINZO_ichi_A5_QL_NA,KINZO_ichi_A5_QL
+Azumi,Speed 55,Speed_55,Speed_55
+Azumi,T7 3G,T7_3G,Azumi_T7_3G
+BGH S.A.,BGH Joy 303,BGH_Joy_303,BGH Joy 303
+BKAV,B2017,B2017,B2017
+BKAV,Bphone,Bphone,Bphone B1111
+BKAV,Bphone,Bphone,Bphone B1112
+BKAV,Bphone,Bphone,Bphone B1114
+BKAV,Bphone,Bphone,Bphone B1115
+BKAV,Bphone,Bphone,Bphone B1116
+BLECK,ELEMENT,ELEMENT,ELEMENT
+BMobile,AX1010,Bmobile_AX1010,AX1010
+BMobile,AX1010,Bmobile_AX1010,Bmobile AX1010
+BMobile,AX1015,Bmobile_AX1015,AX1015
+BMobile,AX1015,Bmobile_AX1015A,AX1015
+BMobile,AX1020,Bmobile,AX1020
+BMobile,AX1020,Bmobile_AX1020,AX1020
+BMobile,AX1030,Bmobile_AX1030,AX1030
+BMobile,AX1035,Bmobile_AX1035,AX1035
+BMobile,AX1040,Bmobile_AX1040,AX1040
+BMobile,AX1045E,Bmobile_AX1045,AX1045
+BMobile,AX1055,Bmobile,AX1055
+BMobile,AX1055,Bmobile_AX1055,AX1055
+BMobile,AX1060,AX1060,AX1060
+BMobile,AX1065,Bmobile_AX1065,AX1065
+BMobile,AX1065E,Bmobile_AX1065E,AX1065E
+BMobile,AX1070E,BMOBILE_AX1070,AX1070
+BMobile,AX1070E,Bmobile_AX1070,AX1070
+BMobile,AX1071,Bmobile_AX1071,AX1071
+BMobile,AX1072,Bmobile_AX1072,AX1072
+BMobile,AX1075,Bmobile_AX1075,AX1075
+BMobile,AX1085,Bmobile_AX1085,AX1085
+BMobile,AX1091,Bmobile_AX1091,AX1091
+BMobile,AX1091,Bmobile_AX1091,Bmobile_AX1091
+BMobile,AX660,Bmobile,AX660
+BMobile,AX680+,Bmobile_AX680_,AX680+
+BMobile,AX681,Bmobile_AX681,AX681
+BMobile,AX681,Bmobile_AX681A,AX681
+BMobile,AX684,Bmobile_AX684,AX684
+BMobile,AX685,Bmobile_AX685,AX685
+BMobile,AX685,Bmobile_AX685,Bmobile_AX685
+BMobile,AX686,Bmobile_AX686,AX686
+BMobile,AX700,Bmobile,AX7OO
+BMobile,AX810,Bmobile,Bmobile_AX810
+BMobile,AX810,Bmobile_AX810,Bmobile_AX810
+BMobile,AX820,Bmobile_AX820,AX820
+BMobile,AX821,Bmobile_AX821,AX821
+BMobile,AX822,Bmobile_AX822,AX822
+BMobile,AX822,Bmobile_AX822A,AX822
+BMobile,AX920,Bmobile_AX920,AX920
+BMobile,AX921,Bmobile_AX921,AX921
+BMobile,AX921,Bmobile_AX921,Bmobile_AX921
+BMobile,AX922,Bmobile_AX922,AX922
+BQru,5060,BQru-5060,BQru-5060
+BQru,BQ 5503 NICE 2,BQru_5503,BQru-5503
+BQru,BQ-1045G,BQru-1045,BQ-1045
+BQru,BQ-1056L,BQru_1056L,BQru-1056L
+BQru,BQ-1057L,BQru_1057L,BQru-1057L
+BQru,BQ-4028UP!,BQru-4028,BQru-4028
+BQru,BQ-4072 Strike Mini,BQru_4072,BQru-4072
+BQru,BQ-4500L,BQru-4500,BQru-4500
+BQru,BQ-5000L,BQru-5000,BQru-5000
+BQru,BQ-5033 Shark,BQru_5033,BQru-5033
+BQru,BQ-5035 Velvet,BQru-5035,BQru-5035
+BQru,BQ-5044 Strike LTE,BQru-5044,BQru-5044
+BQru,BQ-5057 Strike 2,BQru_5057,BQru-5057
+BQru,BQ-5058 Strike Power Easy,BQru-5058,BQru_BQru-5058
+BQru,BQ-5059 Strike Power,BQru_5059,BQru-5059
+BQru,BQ-5201,BQru-5201,BQ-5201
+BQru,BQ-5201,BQru-5201,BQru-5201
+BQru,BQ-5202,BQru-5202,BQru-5202
+BQru,BQ-5203 Shark,BQru-5203,BQru-5203
+BQru,BQ-5204 Strike Selfie,BQru-5204,BQru-5204
+BQru,BQ-5500L Advance,BQru-5500L,BQ-5500L
+BQru,BQ-5504\xc2\xa0Strike\xc2\xa0Selfie\xc2\xa0Max,BQru_5504,BQru-5504
+BQru,BQ-5510 Strike Power Max 4G,BQru_5510,BQru-5510
+BQru,BQ-5521 STRIKE POWER MAX,BQru-5521,BQru-5521
+BQru,BQ-5522\xc2\xa0Next,BQru-5522,BQ-5522
+BQru,BQ-5590 Spring,BQru_5590,BQru_5590
+BQru,BQ-5591 Jeans,BQru-5591,BQ-5591
+BQru,BQ-5700L Space X,BQru-5700L,BQ-5700L
+BQru,BQ-6000L Aurora,BQru-6000L,BQ-6000L
+BQru,BQ-7022G,BQru-7022,BQ-7022
+BQru,BQ-7081G,BQru-7081,BQru-7081
+BQru,BQru-1081G,BQru-1081G,BQru-1081G
+BQru,BQru-4526,BQru-4526,BQru-4526
+BQru,BQru-5022,BQru,BQru-5022
+BQru,BQru-7082,BQru-7082,BQru-7082
+BQru,BQru-7083,BQru-7083,BQru-7083
+BQru,Bqru-5037,BQru-5037,BQru-5037
+BQru,CRYSTAL,BQru-5054,BQru-5054
+BQru,FOX  POWER,BQru-4583,BQru-4583
+BQru,FOX POWER,BQru-4583,BQru-4583
+BYD,DynaVox T10,T10,T10
+BYD,FarEastone Smart 502,Smart502,Smart 502
+BYD,INHON G3,G3,G3
+BYD,K-Touch E815,E815,E815
+BYD,M601,M601,M601
+BYD,Moii E996+,E996plus,moii E996+
+BYD,PT452E,PT452E,Digma Linx 4.5 PT452E
+BYD,Prestigio PAP5430,PAP5430,PAP5430
+BYD,SI4301,SI4301,SI4301
+BYD,SOLO S450,S450,S450
+BYD,SP355AWG,msm7627a_sku3,SP355AWG
+BYD,Smart 401,tianyu72_wet_jb3,Smart 401
+BYD,Smart 402,hawaii_garnet_c_w68tk,Smart402
+BYD,Solo S350,S350,S350
+BYD,WISKY W032I,W032I,W032I
+BYD,X910,X910,XOLO X910
+BYD,Zippers,Zippers,Vexia Zippers
+Bang & Olufsen,BeoVision,bno_MT5593Uplus_EU,QM153E
+Barel,Cavion Solid 4.5,Cavion_Solid_4_5,Cavion_Solid_4_5
+Barnes and Noble,HD,hummingbird,BNTV400
+Barnes and Noble,HD+,ovation,BNTV600
+Barnes and Noble,NOOK\xc2\xae HD,hummingbird,BNTV400
+Barnes and Noble,NOOK\xc2\xae HD+,ovation,BNTV600
+Becrypt,Convex 430,granite,Becrypt Convex 430
+Becrypt,Convex 430,granite,Becrypt Indigo 430
+Beeline,Beeline\xc2\xa0Pro 4,Beeline_Pro_4,Beeline Pro 4
+Beeline,Beeline\xc2\xa0Tab Fast 2,z701,Beeline Tab Fast 2
+Beeline,Beeline\xc2\xa0Tab\xc2\xa0Pro,BeelineTabPro,Beeline Tab Pro
+Beeline,Fast,Fast,Beeline Fast
+Beeline,Fast HD,Beeline_Fast_HD,Beeline Fast HD
+Beeline,Fast-Plus,Fast_Plus,Beeline Fast +
+Beeline,Pro 2,Beeline_Pro_2,Beeline Pro 2
+Beeline,Pro 3,Pro_3,Beeline_Pro_3
+Beeline,Pro 6,Beeline_Pro_6,Beeline_Pro_6
+Beeline,Pro5,Beeline_Pro_5,A451
+Beeline,Smart 6,Beeline_Smart_6,Beeline Smart 6
+Beeline,Smart Dual,Beeline,Beeline Smart Dual
+Beeline,Smart_8,Beeline_Smart_8,A221
+Beeline,Smart_8,Beeline_Smart_8,A239
+Beeline,Tab,Beeline_Tab,Beeline Tab
+Beeline,Tab 2,Tab_2,Tab_2
+Beeline,Tab IS,Beeline_Tab_IS,Beeline_Tab_IS
+Beeline,Tab_Fast,Beeline_Tab_Fast,Beeline_Tab_Fast
+BenQ,A3,A3,A3
+BenQ,A3c,BenQ_A3c,BenQ A3c
+BenQ,Agora 4G,Agora_4G,Agora 4G
+BenQ,Agora_4G_Pro,Agora_4G_Pro,Agora 4G Pro
+BenQ,Agora_Lite,Agora_Lite,Agora Lite
+BenQ,B50,B50,B50
+BenQ,B502,B502,B502
+BenQ,B502,B502,B502_SA
+BenQ,B505,B505,B505
+BenQ,B506,B506_TW,B506_TW
+BenQ,B50_CHT,B50,B50_CHT
+BenQ,F3,F3,F3
+BenQ,F4,benq_a3s,BenQ A3s
+BenQ,F5,BENQ_F5,BenQ F5
+BenQ,F5,F5,BenQ F5
+BenQ,F52,F52,F52_05
+BenQ,F52_09,F52,F52_09
+BenQ,F55,F55,BenQ F55
+BenQ,F55J,F55J,BenQ F55J
+BenQ,F5_06,F5,F5_06
+BenQ,F5_13,F5,F5_13
+BenQ,F5_15,F5,F5_15
+BenQ,F5_16,F5,F5_16
+BenQ,F5_18,F5,F5_18
+BenQ,F5_19,F5,F5_19
+BenQ,Harrier,Harrier,Harrier from EE
+BenQ,Harrier Mini,harrier_mini,Harrier Mini from EE
+BenQ,Harrier Tab,harrier_tab,Harrier Tab from EE
+BenQ,JD-150,JD-150_P1,JD-150
+BenQ,JM-250,JM-250,JM-250
+BenQ,JM-250,JM-250_P1,JM-250
+BenQ,Kogan 4G+,Agora_4G_PLUS,Agora 4G+
+BenQ,Kogan Agora 4G Lite,B506,Kogan Agora 4G Lite
+BenQ,PT2200,PT2200,PT2200
+BenQ,T3,T3,BenQ T3
+BenQ,T3,T3_17A,BenQ T3
+BenQ,T3_08,T3_17A,BenQ T3
+BenQ,T3_17A,T3_17A,BenQ T3
+BenQ,T47,T47,T47_05
+BenQ,T47_09,T47,T47_09
+BenQ,T55,T55,T55
+Benesse,TAB-A03-BR,TAB-A03-BR,TAB-A03-BR
+Benesse,TAB-A03-BS,TAB-A03-BS,TAB-A03-BS
+Bentley,Tab,sdis1,BENTLEY ENTERTAINMENT TABLET
+Best Buy,Transformer Pad (TF103C),K010,K010
+Bigben,BB8252,Bigben-TAB,BB8252
+Bigben,GAMETAB-ONE,GAMETAB-ONE,GAMETAB-ONE
+Billion,Billion Capture+,rimoB,Capture+
+Binatone,SMART64,SMART64,SMART64
+Binatone,Smart 63,SMART63,SMART63
+Binatone,Smart 66,SMART66,SMART66
+Bitel,B8416,B8416,B8416
+Bitel,B9401,B9401,B9401
+Bitel,B9502,B9502,B9502
+Bitmore,GTAB700,GTAB700,NID_7010
+Bitmore,GTAB900,GTAB900,S952
+Bitmore,LUXYA MID704DC Tablet / Bitmore Tab770,MY7317P,Tab770
+Bitmore,Tab870,Tab870,Tab870
+Bittium,Air-Lynx ALS14000,granite,Bittium Tough Mobile
+Bittium,Mx Smart,adakite_sm,Mx Smart
+Bittium,Tough Mobile,granite,Bittium Tough Mobile
+BlackBerry,Aurora,bbc100,BBC100-1
+BlackBerry,BlackBerry KEYone,bbb100,BBB100-7
+BlackBerry,BlackBerry MOTION,bbd100,BBD100-1
+BlackBerry,BlackBerry MOTION,bbd100,BBD100-2
+BlackBerry,BlackBerry MOTION,bbd100,BBD100-6
+BlackBerry,Blackberry Keyone,bbb100,BBB100-7
+BlackBerry,DTEK50,hamburg,STH100-1
+BlackBerry,DTEK50,hamburg,STH100-2
+BlackBerry,DTEK50 by BlackBerry,hamburg,STH100-1
+BlackBerry,DTEK50 by BlackBerry,hamburg,STH100-2
+BlackBerry,DTEK60,argon,BBA100-1
+BlackBerry,DTEK60,argon,BBA100-2
+BlackBerry,DTEK60 by BlackBerry,argon,BBA100-1
+BlackBerry,DTEK60 by BlackBerry,argon,BBA100-2
+BlackBerry,KEYone,bbb100,BBB100-1
+BlackBerry,KEYone,bbb100,BBB100-2
+BlackBerry,KEYone,bbb100,BBB100-3
+BlackBerry,KEYone,bbb100,BBB100-4
+BlackBerry,KEYone,bbb100,BBB100-6
+BlackBerry,PRIV by BlackBerry,venice,STV100-1
+BlackBerry,PRIV by BlackBerry,venice,STV100-2
+BlackBerry,PRIV by BlackBerry,venice,STV100-3
+BlackBerry,PRIV by BlackBerry,venice,STV100-4
+Blackfox,BMM541D,BMM541D,BMM541D
+Blackfox,BMM542D,BMM542D,BMM542D
+Blackfox,BMM_533D,BMM_533D,BMM_533D
+Blackview,A5,A5,A5
+Blackview,A7,A7,A7
+Blackview,A7PRO,A7Pro,A7Pro
+Blackview,A8 MAX,A8_MAX,A8 MAX
+Blackview,A9 Pro,A9_Pro,A9_Pro
+Blackview,BV4000,BV4000,BV4000
+Blackview,BV6000,Blackview,BV6000
+Blackview,BV6000s,BV6000S,BV6000S
+Blackview,BV7000,BV7000,BV7000
+Blackview,BV7000 Pro,BV7000_Pro,BV7000 Pro
+Blackview,BV8000 Pro,BV8000Pro,BV8000Pro
+Blackview,Blackview A10,A10,A10
+Blackview,Blackview BV4000Pro,BV4000Pro,BV4000Pro
+Blackview,Blackview P2,P2,P2
+Blackview,E7S,E7s,E7s
+Blackview,P2 Lite,P2Lite,P2Lite
+Blackview,S8,S8,S8
+Blaupunkt,Blaupunkt SL 01,Blaupunkt_SL_01,Blaupunkt SL 01
+Blaupunkt,Blaupunkt SL 02,Blaupunkt_SL_02,Blaupunkt SL 02
+Blaupunkt,Blaupunkt SL 04,Blaupunkt_SL_04,Blaupunkt SL 04
+Blaupunkt,Blaupunkt SM 01,Blaupunkt_SM_01,Blaupunkt SM 01
+Blaupunkt,Endeavour101,Blaupunkt,Endeavour101
+Blaupunkt,SLplus02,SLplus02,SLplus02
+Blu,ADVANCE 4.0 L2,BLU_ADVANCE_4_0_L2,BLU ADVANCE 4.0 L2
+Blu,ADVANCE 4.0 L3,Advance_4_0_L3,Advance 4.0 L3
+Blu,ADVANCE 5.0 HD,Advance_5_0_HD,Advance 5.0 HD
+Blu,Advance 4.0M,Advance_4_0M,Advance 4.0M
+Blu,Advance 4.0M,Advance_4_0M,Studio M4
+Blu,Advance 5.2,A230Q,Advance 5.2
+Blu,Advance A5 LTE,A0010WW,Advance A5 LTE
+Blu,Advance A6,A190,Advance A6
+Blu,Advance\xc2\xa0A5\xc2\xa0Plus\xc2\xa0LTE,A0031WW,Advance A5 Plus LTE
+Blu,BLU Studio G3,S770P,Studio G3
+Blu,C5 LTE,C0010UU,C5 LTE
+Blu,DASH L2,BLU_DASH_L2,BLU DASH L2
+Blu,DASH M2,BLU_DASH_M2,BLU DASH M2
+Blu,DASH X LTE,DASH_X_LTE,BLU DASH X LTE
+Blu,DASH X PLUS LTE,BLU_DASH_X_PLUS_LTE,DASH X PLUS LTE
+Blu,DASH X2,BLU_DASH_X2,BLU DASH X2
+Blu,DIAMOND M,BLU_DIAMOND_M,DIAMOND M
+Blu,Dash 4.5,D730,Dash 4.5
+Blu,Dash G,Dash_G,Dash G
+Blu,Dash L3,D931,Dash L3
+Blu,Dash X,BLU_DASH_X,BLU DASH X
+Blu,Dash X2,Dash_X2,Dash X2
+Blu,Dash XL,Dash_XL,Dash XL
+Blu,Dash XL,Dash_XL,Studio M5 Plus
+Blu,Dash_L3,Dash_L3,Dash L3
+Blu,ENERGY  XL,BLU_ENERGY_XL,ENERGY XL
+Blu,ENERGY DIAMOND,BLU_ENERGY_DIAMOND,BLU ENERGY DIAMOND
+Blu,ENERGY DIAMOND MINI,ENERGY_DIAMOND_MINI,ENERGY_DIAMOND_MINI
+Blu,ENERGY M,BLU_ENERGY_M,BLU ENERGY M
+Blu,ENERGY X PLUS 2,BLU_ENERGY_X_PLUS_2,BLU ENERGY X PLUS 2
+Blu,ENERGY_DIAMOND_MINI,ENERGY_DIAMOND_MINI,ENERGY_DIAMOND_MINI
+Blu,Energy X 2,BLU_Energy_X_2,Energy X 2
+Blu,Energy X LTE,BLU_Energy_X_LTE,Energy X LTE
+Blu,GRAND 5.5 HD,BLU_GRAND_5_5_HD,BLU GRAND 5.5 HD
+Blu,Grand Energy,Grand_Energy,Grand Energy
+Blu,Grand M,Grand_M,Grand M
+Blu,Grand MAX,Grand_Max,Grand Max
+Blu,Grand Mini,G170Q,Grand Mini
+Blu,Grand X,Grand_X,Grand X
+Blu,Grand X LTE,BLU_Grand_X_LTE,BLU Grand X LTE
+Blu,Grand X LTE,Grand_X_LTE,Grand X LTE
+Blu,Grand XL,Grand_XL,Grand XL
+Blu,Grand_M2,G190,Grand M2
+Blu,Grand_X,Grand_X,Grand X
+Blu,LIFE ONE X,BLU_LIFE_ONE_X,BLU LIFE ONE X
+Blu,LIFE ONE X,Life_One_X,Life One X
+Blu,LIFE ONE X2,Life_One_X2,Life One X2
+Blu,LIFE ONE X2 MINI,Life_One_X2_Mini,Life One X2 Mini
+Blu,LIFE XL,BLU_LIFE_XL,BLU LIFE XL
+Blu,Life Mark,BLU_LIFE_MARK,BLU LIFE MARK
+Blu,Life Max,Life_Max,Life Max
+Blu,NEO ENERGY MINI,BLU_NEO_ENERGY_MINI,BLU NEO ENERGY MINI
+Blu,NEO X,BLU_NEO_X,BLU NEO X
+Blu,NEO X LTE,BLU_NEO_X_LTE,BLU NEO X LTE
+Blu,NEO X MINI,BLU_NEO_X_MINI,BLU NEO X MINI
+Blu,NEO X PLUS,BLU_NEO_X_PLUS,BLU NEO X PLUS
+Blu,NEO XL,BLU_NEO_XL,BLU NEO XL
+Blu,Neo X2,Neo_X2,Neo X2
+Blu,PURE XL,BLU_PURE_XL,PURE XL
+Blu,PURE XR,BLU_Pure_XR,Pure XR
+Blu,R1 HD,BLU_R1_HD,BLU R1 HD
+Blu,R1 HD,R1_HD,R1 HD
+Blu,R1 PLUS,R1_PLUS,R1 PLUS
+Blu,R1 Plus,R1_PLUS,R1 PLUS
+Blu,R2,R010P,R2 3G
+Blu,R2 LTE,R0150EE,R2 LTE
+Blu,R2 LTE,R0170WW,R2 LTE
+Blu,STUDIO 7.0 LTE,blu_s0010tw,BLU STUDIO 7.0 LTE
+Blu,STUDIO 7.0 LTE,blu_s0010uu,BLU STUDIO 7.0 LTE
+Blu,STUDIO C 8+8 LTE,BLU_STUDIO_C_8_8_LTE,BLU STUDIO C 8+8 LTE
+Blu,STUDIO G,BLU_STUDIO_G,BLU STUDIO G
+Blu,STUDIO G HD,Studio_G_HD,BLU Studio G HD
+Blu,STUDIO G HD LTE,Studio_G_HD_LTE,Studio G HD LTE
+Blu,STUDIO G MAX,Studio_G_Max,Studio G Max
+Blu,STUDIO G PLUS,Studio_G_Plus,BLU STUDIO G PLUS
+Blu,STUDIO G PLUS HD,Studio_G_Plus_HD,Studio G Plus HD
+Blu,STUDIO G2,BLU_STUDIO_G2,BLU STUDIO G2
+Blu,STUDIO M HD,BLU_STUDIO_M_HD,STUDIO M HD
+Blu,STUDIO M LTE,BLU_STUDIO_M_LTE,STUDIO M LTE
+Blu,STUDIO MAX,Studio_Max,Studio Max
+Blu,STUDIO ONE PLUS,BLU_STUDIO_ONE_PLUS,BLU STUDIO ONE PLUS
+Blu,STUDIO SELFIE 2,BLU_STUDIO_SELFIE_2,BLU STUDIO SELFIE 2
+Blu,STUDIO TOUCH,BLU_Studio_Touch,BLU Studio Touch
+Blu,STUDIO XL LTE,BLU_STUDIO_XL_LTE,BLU STUDIO XL LTE
+Blu,STUIDIO C 8+8,BLU_STUDIO_C_8_8,BLU STUDIO C 8+8
+Blu,STUIDIO SELFIE 2,BLU_STUDIO_SELFIE_2,BLU STUDIO SELFIE 2
+Blu,SUTDIO ENERGY 2,BLU_STUDIO_ENERGY_2,STUDIO ENERGY 2
+Blu,Studio 5.5 HD,S150,STUDIO 5.5 HD
+Blu,Studio C HD,BLU_STUDIO_C_HD,BLU STUDIO C HD
+Blu,Studio C HD,Studio_C_HD,Studio C HD
+Blu,Studio G HD,STUDIO_G_HD,STUDIO_G_HD
+Blu,Studio G Mini,S210,Studio G Mini
+Blu,Studio G2 HD,Studio_G2_HD,Studio G2 HD
+Blu,Studio J1,Studio_J1,Advance A4
+Blu,Studio J1,Studio_J1,Studio J1
+Blu,Studio J2,Studio_J2,Advance A5
+Blu,Studio J2,Studio_J2,Studio J2
+Blu,Studio J2,Studio_J2,Studio M5
+Blu,Studio J5,Studio_J5,Studio J5
+Blu,Studio J8,Studio_J8,Studio J8
+Blu,Studio M5 Plus LTE,S0390WW,Studio M5 Plus LTE
+Blu,Studio M6,S730,Studio M6
+Blu,Studio Mega,Studio_Mega,Studio Mega
+Blu,Studio One,BLU_STUDIO_ONE,BLU STUDIO ONE
+Blu,Studio Pro,S750,Studio Pro
+Blu,Studio Selfie LTE,BLU_STUDIO_SELFIE_LTE,BLU STUDIO SELFIE LTE
+Blu,Studio X Mini,BLU_STUDIO_X_MINI,BLU STUDIO X MINI
+Blu,Studio XL 2,Studio_XL_2,Studio M6 LTE
+Blu,Studio XL 2,Studio_XL_2,Studio XL 2
+Blu,TOUCHBOOK M7,BLU_TOUCHBOOK_M7,BLU TOUCHBOOK M7
+Blu,Tank Xtreme 4.0,Tank_Xtreme_4_0,Tank Xtreme 4.0
+Blu,Tank Xtreme 5.0,Tank_Xtreme_5_0,Tank Xtreme 5.0
+Blu,Tank Xtreme Pro,T0010UU,Tank Xtreme Pro
+Blu,VIVO 5,BLU_VIVO_5,VIVO 5
+Blu,VIVO 5R,BLU_Vivo_5R,Vivo 5R
+Blu,VIVO 6,BLU_Vivo_6,Vivo 6
+Blu,VIVO XL,BLU_VIVO_XL,VIVO XL
+Blu,VIVO XL2,BLU_Vivo_XL2,Vivo XL2
+Blu,Vivo 5 Mini,Vivo_5_Mini,Vivo 5 Mini
+Blu,Vivo 8,V0150UU,Vivo 8
+Bluboo,S1a,S1a,S1a
+Bluebird,BM180,BM180,BM180
+Bluebird,EF400,EF400,EF400
+Bluebird,EF500,EF500,EF500
+Bluebird,SF550,SF550,SF550
+Bluedot,BNT-700K,BNT-700K,BNT-700K
+Booken,Cybook Tablet,cybtt10_bk,Cybook-Tablet
+Boost,Cabana,Cabana,Cabana
+Boost,Cabana,Cabana_D001,Cabana
+Boost,Moova Shuffle,MoovaShuffle,MoovaShuffle
+Boost,Moova Soul,Moova-Soul,Moova-Soul
+Boost,Pulse Glide,PulseGlide,Pulse Glide
+Boost,Pulse Jive,Jive,Jive
+Boost,Pulse Power,Power,Power
+Boost,Pulse Retro,M450B,Pulse Retro
+Boost,Pulse Sky,Y551B,Pulse Sky
+Boost,Shaker-Slim,Shaker-Slim,Shaker-Slim
+Boost,ShakerBeat,ShakerBeat,ShakerBeat
+Boost,Smarty II,Smarty_II,Smarty_II
+Boost,StrikaPlay,StrikaPlay,StrikaPlay
+Boost,X4503,X4503,X4503
+Borqs,Falcon,falcon,falcon
+Bouygues Telecom,Bbox Miami,HMB4213H,BouygtelTV
+Bouygues Telecom,Bs 451,Bs_451,Bs 451
+Brightstar,M8046IU,M8047IU,M8047IU
+British Telecom,BT Home SmartPhone III,BT_Home_SmartPhone_III,E81
+British Telecom,HomeSmartphone d800,d800,BT Home SmartPhone S II
+Brown,Brown2,I9080_PH1,brown 2
+Brown,brown tab1,brown_tab1,brown tab1
+Bullitt Group,Cat S60,CatS60,S60
+Bullitt Group,CatS31,CatS31,S31
+Bullitt Group,S30,CatS30,S30
+Bunbungame,KALOS,FG6Q_N,KALOS
+Bunbungame,MiSS,MiSS,MiSS
+Bush,5 android,ac50cpl,Bush 5 Android
+Bush,BUSH SPIRA B3 10 TABLET,ac101boxv2,BUSH SPIRA B3 10 TABLET
+Bush,BUSH SPIRA B3 8 TABLET,ac80oxv2,BUSH SPIRA B3 8 TABLET
+Bush,BUSH SPIRA B5.5 POWER,ac55crp,BUSH SPIRA B5.5 POWER
+Bush,MyTablet 79,ac79bu,BUSH 7.85 TABLET
+Bush,SPIRA B3 5,ac50co,BUSH SPIRA B3 5
+Bush,SPIRA B4 5,ac50fhe,BUSH SPIRA B4 5
+Bush,SPIRA B4 5.5,ac55bhe,BUSH SPIRA B4 5.5
+Bush,SPIRA D3 5.5,ac55diplus,BUSH SPIRA D3 5.5
+Bush,SPIRA D4 5,ac50bco,BUSH SPIRA D4 5
+Bush,SPIRA E3X 5.5,ac55di2plus,BUSH SPIRA E3X 5.5
+Bush,SPIRA E4X,ac55diselfie,BUSH SPIRA E4X
+Bush,Spira B2 10 tablet,ac101box,Bush Spira B2 10 tablet
+Bush,Spira B2 7 tablet,ac70ox,Bush Spira B2 7 tablet
+Bush,Spira D4 5.5,ac55bco,BUSH SPIRA D4 5.5
+Bush,Spira E2X 5\'\',ac50dis,"Bush Spira E2X 5"" Smartphone"
+C&M,SH950C-CM,stb_catv_cnmuhd,SH950C-CM
+C&M,Smart TV II,stb_catv_cnm,SX930C-CC
+C5 Mobile,Noa X Power,noaXPower,noaXPower
+CCC,AirStick,ts201,AirStick
+CCC,AirStick 4K,ts302,AirStick 4K
+CCC,LifeStick,ts201,LifeStick
+CCC,TSUTAYA Stick,ts201,TStick
+CG Mobile,Blaze  G,Blaze_G,Blaze G
+CG Mobile,EON Blaze Pro,CG_EON_Blaze_Pro,CG_EON_Blaze_Pro
+CHN TELECOM,CHN-UCAN MJ,lefhd,CHN-UCAN MJ
+CJHelloVision,CJ680CL,cj680cl,GX-CJ680CL
+CJHelloVision,Hello TV Smart,SX930C_CJ,SX930C_CJ
+CJHelloVision,viewing,kr101,kr101
+CMCC,M811,m811,M811
+CMCC,M811,m811hk,M811
+CX Argentina,CX9011,CX9011,CX9011
+CZ Electronics,M3CR,Mint_Fox,M3CR
+CZ Electronics,M3CRD,Mint_Fox,M3CRD
+CZ Electronics,M3s,M3s,M3s
+CZ Electronics,M5CR,M5CR,M5CR
+CZ Electronics,M5CRD,M5CR,M5CRD
+CZ Electronics,M7 Sapphire,M7,M7
+CZ Electronics,MX16,Mint_Diamond,MX16
+CZ Electronics,Mint_Iris,Mint_Iris,M7L_Sapphire
+CZ Electronics,Mint_Jane,Mint_Jane,M5E01
+Caldero,Skyworth,grape,HPA02
+Camelus,L10,TR-10HBT,L10
+Camelus,L7,TR-7U,L7
+Candor,PHS-601,phs601,PHS-601
+Captiva,CAPTIVA Pad 10 3G Plus,Pad_10_3G_Plus,Captiva Pad 10 3G Plus
+Carrefour,CT1000,Carrefour,CT1000
+Carrefour,CT1020W,M1010FP,CT1020W
+Carrefour,CT1050,TVE9603,TVE9603I
+Carrefour,CT726,CT726,CT726
+Carrefour,CT820,M878LP,CT820
+Carrefour,CT826,CT826,CT826
+Casio,IT-G400,itg400,IT-G400
+Casio,Smart Outdoor Watch WSD-F10,koi,CASIO WSD-F10
+Casio,WSD-F20,ayu,CASIO WSD-F20
+Casio,WSD-F20,ayu,CASIO WSD-F20S
+Casper,TA80CA2,TA80CA2_1,TA80CA2
+Casper,VIA A2,CASPER_VIA_A2,CASPER_VIA_A2
+Casper,VIA G1,CASPER_VIA_G1,CASPER_VIA_G1
+Casper,VIA G1 Plus,CASPER_VIA_G1_Plus,CASPER_VIA_G1_Plus
+Casper,VIA M3,CASPER_VIA_M3,CASPER_VIA_M3
+Casper,VIA T7D,VIA-T7D,VIA-T7D
+Casper,VIA T7D 3G,VIA-T7D-3G,VIA-T7D-3G
+Casper,VIA_A1,VIA_A1,VIA_A1
+Casper,VIA_A1_1,VIA_A1_1,VIA_A1_1
+Casper,VIA_A1_1,VIA_F1,VIA_F1
+Casper,VIA_A1_Plus,BBL7551TC,VIA_A1_Plus
+Casper,VIA_P2,VIA_P2,VIA_P2
+Casper,VIA_S17,VIA_S17,VIA_S17
+Casper,VIA_S18,VIA_S18,VIA_S18
+Casper,VIA_T41,VIA_T41,VIA_T41
+Cat,B15,TOUGH,B15
+Cat,B15Q,B15Q,B15Q
+Cat,B15Q,CatB15Q,B15Q
+Cat,Cat S41,CatS41,S41
+Cat,CatS50c,CatS50c,S50c
+Cat,S30,CatS30,S30
+Cat,S40,CatS40,S40
+Cat,S50,CatS50,S50
+Cathay,AS01M,AS01M,AS01M
+Ceibal,TC80RA1,TC80RA1_3,TC80RA1
+Ceibal,TC80RA6,TC80RA6_1,TC80RA6
+Celkon,CliQ 2,c707_ym_n_37m35,CliQ2
+Celkon,Smart 4G,Smart_4G,Smart 4G
+Celkon,Swift 4G,Swift_4G,Swift 4G
+Cell_C,Cell C Evolve,CELLC_Evolve,CELLC_Evolve
+Cell_C,Cell C Nitro,CELLC_Nitro,CELLC_Nitro
+Cell_C,CellC_Extreme,CELLC_Extreme,CELLC_Extreme
+Cell_C,Eclipse,Eclipse,Eclipse
+Cell_C,FAME,Cell_C_Fame,Cell_C_Fame
+Cell_C,Fantasy,Cell_C,Fantasy
+Cell_C,JAZZ,Jazz,Jazz
+Cell_C,Jewel,Jewel,Jewel
+Cell_C,Luna,Luna,Luna
+Cell_C,Summit,Cell_C,Summit
+Cell_C,Summit Plus,Summit_Plus,Cell_C_Summit_Plus
+Cell_C,Titan,Titan,Titan
+Cell_C,WIZ,Wiz,Wiz
+Cell_C,deluxe,Cell_C,Deluxe
+Cellon,A27,C8680,A27
+Cellon,A5801,C8680,A5801
+Cellon,Alpha Ice,M8047,Alpha Ice
+Cellon,C3668,C3668,C3668
+Cellon,CI,Dream-C1,CI
+Cellon,CJ-1984,C8690,C8690
+Cellon,CJ-1984,C8690,CJ-1984
+Cellon,CJ-1984,C8690,ELITE 4.7 HD
+Cellon,EI,Dream-E1,EI
+Cellon,EIII,Dream-E3,EIII
+Cellon,EK-8680,C8680,EK-8680
+Cellon,Explosion,C8690,Explosion
+Cellon,HW-W900,C8690,HW-W900
+Cellon,HWW820,C8680,HW-W820
+Cellon,Houston,C8680,Houston
+Cellon,ICON,ICON,ICON
+Cellon,IQ 1.1,IQ1-1,i-mobile IQ1-1
+Cellon,Linx PS474S,C8690,Linx PS474S
+Cellon,MTC SMART Run,SMART_Run,MTC SMART Run
+Cellon,Mach,C8680,Mach
+Cellon,Newman N2,C8690,Newman N2
+Cellon,Q,M8047XT,Q
+Cellon,S21,S21,Q-Smart S21
+Cellon,SI,Dream-S1,SI
+Cellon,SM55,C8660,C8660
+Cellon,SM55,C8660,SM55
+Cellon,Starmobile KNIGHT,KNIGHT,Starmobile KNIGHT
+Cellon,VEON_C8680,C8680,VEON_C8680
+Cellon,i-STYLE7,c8669SA,i-mobile i-STYLE 7
+Cellon,i-STYLE7A,c8669SA,i-mobile i-STYLE 7A
+Cellon,i-mobile IQ X,M8047SA,i-mobile IQ X
+Cellon,i-mobile IQ X,M8047SA,i-mobile IQ XA
+Cellon,i-mobile IQ X2A,M8050SA,i-mobile IQ X2
+Cellon,i-mobile IQ X2A,M8050SA,i-mobile IQ X2A
+Cellon,iris pro 30,pro30,iris pro 30
+Cellon,starTIM1,starTIM1,starTIM1
+Centric,Centric L3,L3,Centric CM3331
+Centric,G1,CM4331,CM4331
+Centric,G1,CM4331,G1
+CenturyLink,PureTV,ctl_iptv_mrvl,CTLPlayer
+CenturyLink,PureTV,ctl_iptv_mrvl,S60CLI
+Cherry Mobile,Cherry W900 LTE,al7,W900 LTE
+Cherry Mobile,Desire R7 Lite,Desire_R7_Lite,Desire R7 Lite
+Cherry Mobile,Desire R8 Lite,Desire_R8_Lite,Desire R8 Lite
+Cherry Mobile,FB100,FB100,FB100
+Cherry Mobile,Flare 5,X630,Flare_5
+Cherry Mobile,Flare A1,FlareA1,FlareA1
+Cherry Mobile,Flare A5,Cherry_X740,Cherry_X740
+Cherry Mobile,Flare HD 3,Flare_HD_3,Flare HD 3
+Cherry Mobile,Flare HD Max,Flare_HD_MAX,Flare_HD_MAX
+Cherry Mobile,Flare J2 Mini,Flare_J2_Mini,Flare J2 Mini
+Cherry Mobile,Flare J2S,Flare_J2S,Flare J2S
+Cherry Mobile,Flare J3,FlareJ3,FlareJ3
+Cherry Mobile,Flare J3,H680,Flare_J3
+Cherry Mobile,Flare J3 Plus,FlareJ3Plus,FlareJ3Plus
+Cherry Mobile,Flare J3 Plus,H620,Flare_J3_Plus
+Cherry Mobile,Flare J7,Flare_J7,Flare J7
+Cherry Mobile,Flare Lite 3S,Flare_Lite_3S,Flare_Lite_3S
+Cherry Mobile,Flare P1,Flare_P1,Flare P1
+Cherry Mobile,Flare P1 Lite,Flare_P1_Lite,Flare_P1_Lite
+Cherry Mobile,Flare P1 Mini,Flare_P1_Mini,Flare_P1_Mini
+Cherry Mobile,Flare P1 Plus,Flare_P1_Plus,Flare P1 Plus
+Cherry Mobile,Flare S5,Flare_S5,Flare S5
+Cherry Mobile,Flare S5 Lite DTV,FlareS5LiteDTV,FlareS5LiteDTV
+Cherry Mobile,Flare S5 Max,FLARE_S5_MAX,FLARE S5 MAX
+Cherry Mobile,Flare S5 Plus,Flare_S5_Plus,Flare S5 Plus
+Cherry Mobile,Flare S6,Cherry_Flare_S6,Flare S6
+Cherry Mobile,Flare S6 Max,Flare_S6_Max,Flare_S6_Max
+Cherry Mobile,Flare S6 Plus,Flare_S6_Plus,Flare_S6_Plus
+Cherry Mobile,Flare S6 Power,Cherry_S6_Power,FLARE S6 POWER
+Cherry Mobile,Flare S6 Selfie,Cherry_Selfie,Flare S6 Selfie
+Cherry Mobile,Flare X,Flare_X,Flare_X_V2
+Cherry Mobile,Flare_J3_Lite,Flare_J3_Lite,Flare_J3_Lite
+Cherry Mobile,Flare_S6_Lite,Flare_S6_Lite,Flare_S6_Lite
+Cherry Mobile,H220,ctih220_sprout,H220
+Cherry Mobile,Iris,Iris,iris
+Cherry Mobile,Lenoxx,CX940,CX940
+Cherry Mobile,Omega HD 3S,H115,OMEGA HD 3S
+Cherry Mobile,Omega HD 4,Cherry_Omega_HD_4,Omega_HD_4
+Cherry Mobile,Omega HD3,H110,Omega HD 3
+Cherry Mobile,Omega Icon 2,Omega_Icon_2,Omega Icon 2
+Cherry Mobile,Omega Lite 3C,Omega_Lite_3C,Omega_Lite_3C
+Cherry Mobile,One,H940_sprout,H940
+Cherry Mobile,Selfie Two,Selfie_Two,Selfie_Two
+Cherry Mobile,Spin Max,H650,Spin Max
+Cherry Mobile,Superion Radar Duluxe,Radar_Deluxe,Superion Radar Deluxe
+Cherry Mobile,Touch HD,Touch_HD,Cherry_Mobile_Touch_HD
+Cherry Mobile,ZP785,ZP785,ZP785
+China Mobile,A3,M651G,M651G
+China Mobile,n1 max,m823_cmcc,M823
+Cipherlab,RS30,Mercury,CipherLab RS30
+Cipherlab,RS31,RS31,RS31
+Cipherlab,Saturn,RS50,RS50
+Cisco,CP-DX650,CP-DX650,CP-DX650
+Cisco,DX70,CP-DX70,CP-DX70
+Cisco,Desktop Collaboration Experience DX70,CP-DX70,CP-DX70
+Cisco,Desktop Collaboration Experience DX80,CP-DX80,CP-DX80
+Claresta,F3,F3,F3
+Claresta,G4,G4,G4
+Claresta,G5,G5,G5
+Claresta,G6,G6,G6
+Claresta,S6Plus,S6Plus,S6Plus
+Clarmin,B8,B8,B8
+Clarmin,B8Lite,B8Lite,B8Lite
+Clarmin,B8plus,B8plus,B8plus
+Clementoni,Clempad 4.4 Basic Special,Clempad2_special,Clempad2_special
+Clementoni,Clempad 4.4 Plus,Clempad2_plus,Clempad2_plus
+Clementoni,Clempad 4.4 XL,Clempad2_XL,Clempad2_XL
+Clementoni,Clempad 5.0 XL,Clempad_HR_XL,Clempad_HR_XL
+Clementoni,Clempad 6.0,Clempad_6,Clempad_6
+Clementoni,Clempad 6.0 XL,Clempad_6_XL,Clempad_6_XL
+Clementoni,Clempad 8,Clempad_8,Clempad_8
+Clementoni,Clempad Call,CLEMPADCALL,CLEMPADCALL
+Clementoni,Clempad HR,Clempad_HR,Clempad_HR
+Clementoni,Clempad HR Plus,Clempad_HR_Plus,Clempad_HR_Plus
+Clementoni,Clempad_6_S,Clempad_6_S,Clempad_6_S
+Clementoni,Clempad_7_S,Clempad_7_S,Clempad_7_S
+Clementoni,Clemphone,ClemPhone,ClemPhone
+Clementoni,Clemphone 7.0,ClemPhone_7,ClemPhone_7
+Clementoni,My First Clempad 6.0,MFC_6,MFC_6
+Clementoni,My First Clempad 7,MFC_7,MFC_7
+Clementoni,My First Clempad HR,MFC_HR,MFC_HR
+Clementoni,My First Clempad HR Plus,MFC_HR_Plus,MFC_HR_Plus
+Clementoni,My first Clempad 4.4 Basic Special,MFC2_Special,MFC2_Special
+Clementoni,My first Clempad 4.4 Plus,MFC2_Plus,MFC2_Plus
+Click,M9021G,M9021G,M9021G
+Click,S7043G,S7043G,S7043G
+Click,"Tab 7""",I7043G,I7043G
+ClickN Kids,ClickN Kids,g04e,CK07T
+CloudFone,CloudFone Next Infinity Plus,Next_Infinity_Plus,Next Infinity Plus
+CloudFone,CloudFone Next Infinity Pro,Next_Infinity_Pro,Next Infinity Pro
+CloudFone,CloudFone Thrill Boost 3,Thrill_Boost_3,Thrill Boost 3
+CloudFone,CloudFone Thrill Plus 2,Thrill_Plus_2,Thrill Plus 2
+CloudFone,CloudFone Thrill Snap,Thrill_Snap,Thrill Snap
+CloudFone,Cloudpad One 6.95,one695_1_coho,one695_1
+CloudFone,Cloudpad One 6.95,one695_1_coho,one695_1_coho
+CloudFone,Cloudpad One 7.0,one7_0_4_coho,one7_0_4
+CloudFone,Cloudpad One 7.0,one7_0_4_coho,one7_0_4_coho
+CloudFone,Cloudpad One 8.0,one8_0_1_coho,one8_0_1
+CloudFone,Cloudpad One 8.0,one8_0_1_coho,one8_0_1_coho
+CloudFone,Excite Prime 2,Excite_Prime_2,Excite Prime 2
+CloudFone,Excite Prime 2 Pro,Excite_Prime_2_Pro,Excite Prime 2 Pro
+CloudFone,Next Infinity,Next_Infinity,Next Infinity
+CloudFone,Next Infinity Quattro,Next_Infinity_4,Next Infinity Quattro
+CloudFone,Thrill Boost 2,Thrill_Boost_2,Thrill Boost 2
+CloudFone,Thrill Plus 2,Thrill_Plus_2,Thrill Plus 2
+CloudFone,Thrill Power N,Thrill_Power_N,Thrill Power N
+CloudFone,Thrill Snap,Thrill_Snap,Thrill Snap
+CloudFone,Thrill View,Thrill_View,Thrill View
+Code,CR4900,cr4900,CR4900
+CoinComputers,TF10EA2,TF10EA2_5,TF10EA2
+ColorsMobile,P45,Colors_P45,Colors P45
+ColorsMobile,S1,Colors_S1,Colors S1
+ColorsMobile,S9,Colors_S9,Colors S9
+Comio,AD7003,AD7003,AD7003
+Comio,COMIO C1,ComioC1,COMIO C1
+Comio,COMIO C2,ComioC2,COMIO C2
+Comio,COMIO P1,ComioP1,COMIO P1
+Comio,COMIO S1,ComioS1,COMIO S1
+Compal,,CA22,COSMO DUO
+Compal,,CAP5,A600
+Compal,,CAP6,A600
+Compal,,CAP7,A300
+Compal,,CAP7,A8
+Compal,,CAP7,W12
+Compal,,cap2,Andy
+Compal,,penguin,AX 8.6
+Compal,TANK 4.5,ka09,TANK 4.5
+Condor,A9,PGN_507,PGN-507
+Condor,Allure  M1,Allure_M1,Allure M1
+Condor,Allure A55 Plus,PGN613,PGN613
+Condor,Allure M1 Plus,Allure_M1_Plus,Allure M1 Plus
+Condor,C1+,C1Plus,C1+
+Condor,C6+,PGN_508,PGN-508
+Condor,C7,PGN_506,PGN-506
+Condor,C_5,u970_5,C-6
+Condor,G6 Pro,PHQ526,PHQ526
+Condor,Griffe G5,PHQ520,Griffe G5
+Condor,Griffe G5,PHQ520,PHQ520
+Condor,Griffe G5 Plus,PAM524,PAM524
+Condor,Griffe T1,Griffe_T1,SP413
+Condor,HS-U939,u939e_6,HS-U939
+Condor,PGN404,PGN404,PGN404
+Condor,PGN409,PGN409,PGN409
+Condor,PGN410,PGN410,PGN410
+Condor,PGN507,PGN507,PGN-507
+Condor,PGN509,PGN509,PGN509
+Condor,PGN511,PGN511,PGN511
+Condor,PGN513,PGN513,PGN513
+Condor,PGN514,PGN514,PGN514
+Condor,PGN515,PGN515,PGN515
+Condor,PGN516,PGN516,PGN516
+Condor,PGN517,PGN517,PGN517
+Condor,PGN518,PGN518,PGN518
+Condor,PGN521,PGN521,PGN521
+Condor,PGN522,PGN522,PGN522
+Condor,PGN523,PGN523,PGN523
+Condor,PGN605,PGN605,PGN605
+Condor,PGN606,PGN606,PGN606
+Condor,PGN607,PGN607,PGN607
+Condor,PGN608,PGN608,PGN608
+Condor,PGN609,PGN609,PGN609
+Condor,PGN610,PGN610,PGN610
+Condor,PGN611,PGN611,PGN611
+Condor,PGN612,PGN612,PGN612
+Condor,PHQ525,PHQ525,PHQ525
+Condor,Plume P4 Plus,PGN527,PGN527
+Condor,Plume P6 Pro LTE,PGN528,PGN528
+Condor,Plume P8 Lite,PGN610,PGN610
+Condor,Plume P8 Pro,Plume_P8_Pro,Plume P8 Pro
+Condor,SP530,SP530,Griffe T2
+Condor,T705,TGW710G,TGW710G
+Condor,TFX711G,TFX711G,TFX711G
+Condor,TFX712G,TFX712G,TFX712G
+Condor,TFX713L,TFX713L,TFX713L
+Condor,TFX714L,TFX714L,TFX714L
+Condor,TGW102L,TGW102L,TGW102L
+Condor,TGW706,TGW706,TGW706
+Condor,TGW801G,TGW801G,TGW801G
+Condor,TGW801L,TGW801L,TGW801L
+Condor,TMK715L,TMK715L,TMK715L
+Connectce,Connect Alpha,CNT07002,CNT07002
+Connectce,Connect Core 6,Connect_Core_6,CP6001A
+Connex,CTAB-1044,CTAB-1044,CTAB-1044
+Coolpad,,7019_msm7627a,Coolpad 7019
+Coolpad,,7560U,Nivo
+Coolpad,,801E,801E
+Coolpad,,8710,8710
+Coolpad,,9960,YL-Coolpad 9960
+Coolpad,,CP5832,5832
+Coolpad,,CP5880,5880
+Coolpad,,CP7728,Coolpad7728
+Coolpad,,CP8870,8870
+Coolpad,,CP9130,N930
+Coolpad,,Coolpad7290,Coolpad 7290
+Coolpad,,Coolpad9080W,Coolpad 9080W
+Coolpad,,dkb,8150
+Coolpad,,dkb,8180
+Coolpad,,dkb,8810
+Coolpad,,msm7627_5820,Coolpad 5820
+Coolpad,,msm7627_SP150,MTS-SP150
+Coolpad,,msm7627_surf,5860
+Coolpad,,msm7627_surf,7260
+Coolpad,,msm7627_w706,Coolpad W706+
+Coolpad,,msm7627_w706T,Coolpad W706+
+Coolpad,,msm7627_w708,Coolpad W708
+Coolpad,,msm7627a_5860S,5860S
+Coolpad,,msm7627a_5870,5870
+Coolpad,,msm7627a_7230,7230
+Coolpad,,msm7627a_7266,7266
+Coolpad,,msm7627a_9120,9120
+Coolpad,,msm7627a_PAP4000,PAP4000
+Coolpad,,msm7627a_cp5910,5910
+Coolpad,,msm7627a_ea58,Coolpad 5010
+Coolpad,,msm7627a_ea92,Coolpad 5210
+Coolpad,,msm7627a_sku3,5110
+Coolpad,,msm7627a_sku3,5860A
+Coolpad,,msm7627a_sku3,7260A
+Coolpad,,msm8660_9900,9900
+Coolpad,,msm8660_CP8950,8950
+Coolpad,3300A,3300A,Coolpad 3300A
+Coolpad,3320A,cp3320a,Coolpad 3320A
+Coolpad,3503I,CP3503I,Coolpad 3503I
+Coolpad,3503I,CP3503I,Coolpad CP3503I
+Coolpad,3505I_A00,CP3505I,Coolpad E503
+Coolpad,3505I_U00,CP3505I_U00,Coolpad E503
+Coolpad,3600i,CP3600I,3600I
+Coolpad,3600i,CP3600I,Coolpad 3600I
+Coolpad,3622A,cp3622a,Coolpad 3622A
+Coolpad,3622A-mpcs,cp3622a,Coolpad 3622A
+Coolpad,3623A,cp3623a,Coolpad 3623A
+Coolpad,3632A,cp3632a,Coolpad 3632A
+Coolpad,3632A-mpcs,cp3632a,Coolpad 3632A
+Coolpad,3636a,cp3636a,cp3636a
+Coolpad,3700A,3700A,CP3700A
+Coolpad,5109,Coolpad5109,Coolpad 5109
+Coolpad,5200,Coolpad5200,Coolpad 5200
+Coolpad,5216D,5216D,Coolpad 5216D
+Coolpad,5217,msm8610,Coolpad 5217
+Coolpad,5218S,msm8x25q_a5y_5218s,Coolpad 5218S
+Coolpad,5219,5219,Coolpad 5219
+Coolpad,5219_C00,5219_C00,Coolpad 5219_C00
+Coolpad,5267,Coolpad5267,Coolpad 5267
+Coolpad,5267C,Coolpad5267,Coolpad 5267
+Coolpad,5270,Coolpad5270,Coolpad 5270
+Coolpad,5367,Coolpad5367,Coolpad 5367
+Coolpad,5367C,Coolpad5367C,Coolpad 5367C
+Coolpad,5370,Coolpad5370,Coolpad 5370
+Coolpad,5380CA,Coolpad5380CA,Coolpad 5380CA
+Coolpad,5860E,CP5860E,5860E
+Coolpad,5891,Coolpad5891,Coolpad 5891
+Coolpad,5891S,Coolpad5891S,Coolpad 5891S
+Coolpad,5951,Coolpad5951,Coolpad 5951
+Coolpad,7061,CP7061,Coolpad 7061
+Coolpad,7230S,Coolpad7230S,Coolpad 7230S
+Coolpad,7232,CP7232,Coolpad 7232
+Coolpad,7251,Coolpad7251,Coolpad 7251
+Coolpad,7270,Coolpad7270,Coolpad 7270
+Coolpad,7270I,7270I,Idea ULTRA Pro
+Coolpad,7275,CP7275,Coolpad 7275
+Coolpad,7295A,Coolpad7295A,Coolpad 7295+
+Coolpad,7295A,Coolpad7295A,Coolpad 7295A
+Coolpad,7296,Coolpad7296,Coolpad 7296
+Coolpad,7620L,Coolpad7620L,Coolpad 7620L
+Coolpad,801EM,801EM,801EM
+Coolpad,8079,Coolpad8079,Coolpad 8079
+Coolpad,8122,Coolpad8122,Coolpad 8122
+Coolpad,8198W,Coolpad8198W,Coolpad 8198W
+Coolpad,8297D,Coolpad8297D,Coolpad 8297D
+Coolpad,8297L-I00,Coolpad8297L-I00,Coolpad 8297L-I00
+Coolpad,8298-M02,CP8298_M02,CP8298_M02
+Coolpad,8676-I03,CP8676_I03,CP8676_I03
+Coolpad,8712,CP8712,Coolpad 8712
+Coolpad,8712SV,Coolpad8712,Coolpad 8712
+Coolpad,8718,Coolpad8718,Coolpad 8718
+Coolpad,8722,CP8722,Coolpad 8722
+Coolpad,8722-U00,CP8722_U00,Coolpad E570
+Coolpad,8722V,CP8722,Coolpad 8722V
+Coolpad,8722_S00,CP8722_S00,Coolpad E570
+Coolpad,8729,Coolpad8729,Coolpad 8729
+Coolpad,8730L,Coolpad8730L,Coolpad 8730L
+Coolpad,8736,8736,Coolpad 8736
+Coolpad,8737A,Coolpad8737A,Coolpad 8737A
+Coolpad,8970L,8970L,Coolpad 8970L
+Coolpad,8971,8971,Coolpad 8971
+Coolpad,9150W,Coolpad9150W,Coolpad 9150W
+Coolpad,9190_T00,Coolpad9190_T00,Coolpad 9190_T00
+Coolpad,9970L,9970L,Coolpad 9970L
+Coolpad,9976A,Coolpad9976A,Coolpad 9976A
+Coolpad,A8,A8,Coolpad A8
+Coolpad,A8-831,A8-831,Coolpad A8-831
+Coolpad,A8-930,A8-930,Coolpad A8-930
+Coolpad,A8-931,A8-931,Coolpad A8-931
+Coolpad,A8-931,A8-931,Coolpad A8-931N
+Coolpad,A8-932,A8-932,Coolpad A8-932
+Coolpad,B770,B770,Coolpad B770
+Coolpad,B770S,CoolpadB770S,Coolpad B770S
+Coolpad,Bs501,cp8870u,Bs 501
+Coolpad,C1-S02,C1-S02,Coolpad R116
+Coolpad,C103,C103,C103
+Coolpad,C106-8,cool_c1,C106-8
+Coolpad,CK2-01,CK2-01,CK2-01
+Coolpad,CK3-01,CK3-01,CK3-01
+Coolpad,CK3-01,CK3-01,CK3-M1
+Coolpad,CM001,CoolpadCM001,Coolpad CM001
+Coolpad,CP5108,msm7627a_a8_5108_new,Coolpad 5108
+Coolpad,CP5210A,msm7627a_d7_5210a,Coolpad 5210A
+Coolpad,CP5310,cp5310,Coolpad 5310
+Coolpad,CP5660S,5560S,5560S
+Coolpad,CP5952,Coolpad5952,Coolpad 5952
+Coolpad,CP8021,Coolpad8021,Coolpad 8021
+Coolpad,CP8089,CP8089,Coolpad 8089
+Coolpad,CP8089Q,CP8089Q,Coolpad 8089Q
+Coolpad,CP8295M,8295M,Coolpad8295M
+Coolpad,CP8735,8735,Coolpad 8735
+Coolpad,CP8750,8750,Coolpad8750
+Coolpad,CP9190L,Coolpad9190L,Coolpad 9190L
+Coolpad,CP9250L,Coolpad9250L,Coolpad 9250L
+Coolpad,CP9970,9970,Coolpad 9970
+Coolpad,CPA520,CoolpadA520,Coolpad A520
+Coolpad,CPT1,CoolpadT1,Coolpad T1
+Coolpad,Cool C1,cool_c1,C106
+Coolpad,Cool C1,cool_c1,C106-6
+Coolpad,Cool C1,cool_c1,C106-7
+Coolpad,Cool C1,cool_c1,C106-9
+Coolpad,Cool C1,cool_c1,C107-9
+Coolpad,Coolmini,Coolmini,Coolmini
+Coolpad,Coolpad 3636a_m,cp3636a,cp3636a
+Coolpad,Coolpad 5370_I00,CoolpadE2,coolpad E2
+Coolpad,Coolpad C1-U02,C103,C1-U02
+Coolpad,Coolpad COL-A0,Civic,COL-A0
+Coolpad,Coolpad COR-I0,clover,Coolpad COR-I0
+Coolpad,Coolpad CVC-A0,Civic,CVC-A0
+Coolpad,Coolpad CVC-M0,Civic,CVC-M0
+Coolpad,Coolpad GRA-M0,GRA,GRA-M0
+Coolpad,Coolpad POL-A0,pollux,POL-A0
+Coolpad,Coolpad VCR-I0,victor,VCR-I0
+Coolpad,Coolpad5218D,msm7627a_a5y_5218d,Coolpad_5218D
+Coolpad,Coolpad5315,msm8610_s10_cp5315,Coolpad 5315
+Coolpad,Coolpad5872,Coolpad5872,Coolpad 5872
+Coolpad,Coolpad5879T,Coolpad5879T,Coolpad 5879T
+Coolpad,Coolpad5891Q,Coolpad5891Q,Coolpad 5891Q
+Coolpad,Coolpad5892,Coolpad5892,Coolpad 5892
+Coolpad,Coolpad5950,Coolpad5950,Coolpad 5950
+Coolpad,Coolpad5950T,Coolpad5950T,Coolpad 5950T
+Coolpad,Coolpad7270_W00,Coolpad7270_W00,Coolpad 7270_W00
+Coolpad,Coolpad7295C,Coolpad7295C,Coolpad 7295C
+Coolpad,Coolpad7295C_C00,Coolpad7295C_C00,Coolpad 7295C_C00
+Coolpad,Coolpad7295I,Coolpad7295I,Spice Mi-515
+Coolpad,Coolpad7295T,Coolpad7295T,Coolpad 7295T
+Coolpad,Coolpad7296S,Coolpad7296S,Coolpad 7296S
+Coolpad,Coolpad7298A,Coolpad7298A,Coolpad 7298A
+Coolpad,Coolpad7298D,Coolpad7298D,Coolpad 7298D
+Coolpad,Coolpad7320,Coolpad7320,Coolpad 7320
+Coolpad,Coolpad7920,7920,Coolpad7920
+Coolpad,Coolpad801ES,801ES,801ES
+Coolpad,Coolpad8085Q,Coolpad8085Q,Coolpad8085Q
+Coolpad,Coolpad8198T,8198T,Coolpad8198T
+Coolpad,Coolpad8297W,Coolpad8297W,Coolpad 8297W
+Coolpad,Coolpad8705,Coolpad8705,Coolpad 8705
+Coolpad,Coolpad8720L,Coolpad8720L,Coolpad 8720L
+Coolpad,Coolpad8908,8908,Coolpad8908
+Coolpad,E561,E561,Coolpad E561
+Coolpad,Flo,7560T,Coolpad Flo
+Coolpad,Forward_EVOLVE,Forward_EVOLVE,Forward_EVOLVE
+Coolpad,Idea ULTRA,Coolpad7295S,Idea ULTRA
+Coolpad,K2L_S00,K2L_S00,Coolpad E580
+Coolpad,Karbonn Titanium S5 Plus,Karbonn,Karbonn Titanium S5 Plus
+Coolpad,MEDION P5001,MEDION,MEDION P5001
+Coolpad,MEDION P5001,P5001,MEDION P5001
+Coolpad,Mtag 353,msm7627a_ea92_mts,Mtag 353
+Coolpad,R106,cpy90_g00,Coolpad R106
+Coolpad,R108,R108,Coolpad R108
+Coolpad,SK3-U00,E561_EU,Coolpad E561_EU
+Coolpad,SS1-03,SS1-03,ivvi SS1-03
+Coolpad,SS2-01,SS2-01,SS2-01
+Coolpad,SS2-01,SS2-01,ivvi SS2-01
+Coolpad,STARADDICT III,cp8861u,STARADDICT III
+Coolpad,Spice Mi-496,Coolpad7268I,Spice Mi-496
+Coolpad,VCR-A0,victor,VCR-A0
+Coolpad,Vodafone Smart 4G,cp8860u,Vodafone Smart 4G
+Coolpad,VodafoneSmart4,VodafoneSmart4,Vodafone Smart 4
+Coolpad,VodafoneSmart4turbo,VodafoneSmart4turbo,Vodafone Smart 4 turbo
+Coolpad,Y72-921,Y72-921,Coolpad Y72-921
+Coolpad,Y72-921,Y72_921,Coolpad E571
+Coolpad,Y803-8,CPY803_8,Coolpad Y803-8
+Coolpad,Y803-9,CPY803_9,Coolpad Y803-9
+Coolpad,Y83-900,Y83-900,Coolpad Y83-900
+Coolpad,Y83-I00,CPY83_I00,Coolpad Y83-I00
+Coolpad,Y83_S00,CPY83_S00,Coolpad E502
+Coolpad,Y83_U00,CPY83_U00,Coolpad E502
+Coolpad,Y90,Y90,Coolpad Y90
+Coolpad,Y91-921,Y91,Coolpad Y891
+Coolpad,Y91-921,Y91,Coolpad Y91-921
+Coolpad,Y92-9,Y92-9,Coolpad Y92-9
+Coolpad,cp7236,msm8610_w7_cp7236,Coolpad 7236
+Coolpad,i1,i1,ivvi i1
+Coolpad,i1-01,i1-01,ivvi i1-01
+Coolpad,i3-M1,i3-M1,ivvi i3-M1
+Coolpad,ivvi SK5,SK5,ivvi SK5
+Coolpad,ivvi SK5_S,SK5_S,ivvi SK5_S
+Coolpad,ivvi V1M-S,V1M-S,ivvi V1M-S
+Coolpad,ivvi i1-S,V4701_FR1,ivvi i1-S
+Coolpad,ivvi i3-01,i3-01,ivvi i3-01
+Coolpad,ivvi i3P-02,i3P-02,ivvi i3P-02
+Coppel,ROCKET,ROCKET,ROCKET
+Coppernic,C-eight,C-eight,C-eight
+Coppernic,C-five,C-five,C-five
+Coppernic,C-five,C-five-WIFI,C-five
+Covia,CP-J55a,x5090_rh_j9_covia,CP-J55a
+Covia,CP-J55aW,CP_J55aW,CP-J55aW
+Covia,CP-L45s,CP-L45s,CP-L45s
+Covia,g06+,g06,g06
+Crema,CREMA0810T,crema0810t,CREMA0810T
+Crosscall,Action-X3,HS8937QC,ACTION-X3
+Crosscall,Action-X3,HS8937QC,Action-X3
+Crosscall,Action-X3,HS8937QCs,ACTION-X3
+Crosscall,Action-X3,HS8937QCs,Action-X3
+Crosscall,ODYSSEY,ODYSSEY3G,ODYSSEY
+Crosscall,TREKKER- X3,HS8952QC,TREKKER-X3
+Crosscall,TREKKER-M1 CORE,HS8909QC,TREKKER-M1 CORE
+Crosscall,Trekker- M1,HS8916QC,Trekker-M1
+Cspire,FT7,FT7_tw,Android Tablet FT7
+Cubot,CUBOT H3,CUBOT_H3,CUBOT H3
+Cubot,CUBOT MAGIC,CUBOT_MAGIC,CUBOT MAGIC
+Cubot,CUBOT MAGIC,CUBOT_R9,CUBOT R9
+Cubot,CUBOT NOTE Plus,CUBOT_NOTE_Plus,CUBOT NOTE Plus
+Cubot,CUBOT X18,CUBOT_X18,CUBOT X18
+Cubot,DINOSAUR,x5623_h6013_cubot,CUBOT DINOSAUR
+Cubot,ECHO,CUBOT_ECHO,CUBOT ECHO
+Cubot,MANITO,CUBOT_MANITO,CUBOT_MANITO
+Cubot,MAX,x6069_cubot_5365u,CUBOT MAX
+Cubot,NOTE S,CUBOT_CHEETAH_2,CUBOT CHEETAH 2
+Cubot,NOTE S,CUBOT_NOTE_S,CUBOT_NOTE_S
+Cubot,RAINBOW 2,RAINBOW_2,RAINBOW 2
+Cubot,Rainbow,RAINBOW,RAINBOW
+Cyrus,CS22,CS22,CS22
+Cyrus,CS24,CS24,CS24
+Cyrus,CS40,CS40,CS40
+DBM Maroc,ACCENT SURF 1000,SURF1000,SURF1000
+DBM Maroc,Accent Speed Y2,Speed-Y2,Speed-Y2
+DBM Maroc,Accent Speed Y3,Speed-Y3,Speed-Y3
+DBM Maroc,FAST A6,FAST_A6,FAST A6
+DBM Maroc,FAST7 4G,FAST7_4G,FAST7_4G
+DBM Maroc,Pearl A2,PEARL_A2,PEARL_A2
+DBM Maroc,Speed X2,Speed-X2,Speed-X2
+DEA Factory,KTAB,KTAB,KTAB
+DEXP,DEXP Ixion X150,Ixion_X150,Ixion X150
+DEXP,DEXP P170,P170,P170
+DEXP,DEXP_B160,B160,B160
+DEXP,EL450,EL450,Ixion EL450
+DEXP,ERA,MS550,MS550
+DEXP,ES355,ES355,Ixion ES355
+DEXP,ES550,ES550,Ixion ES550
+DEXP,ES850,ES850,Ixion ES850
+DEXP,Ixion M355,M355,Ixion M355
+DEXP,Ixion ML350,ML350,Ixion ML350
+DEXP,M340,M340,Ixion M340
+DEXP,M545,M545,Ixion M545
+DEXP,M750,M750,Ixion M750
+DEXP,ML245,ML245,Ixion ML245
+DEXP,MS650,MS650,MS650
+DEXP,XL155,XL155,Ixion XL155
+DEXP,Z155,Z155,Z155
+DEXP,lxion MS255,MS255,Ixion MS255
+DIFRNCE,DIT702201,DIT702201,NID_7010
+DL,3406,G02DL,Tablet DL 3406
+DL,3420,Tablet_DL_3420,Tablet DL 3420
+DL,3420,Tablet_DL_3420,Tablet_DL_3420
+DL,3903,Tablet_DL_3903,Tablet_DL_3903
+DL,Creative Kids,Tablet_DL_3721,Tablet_DL_3721
+DL,Creative Tab,Tablet_DL_3723,Tablet_DL_3723
+DL,DL3920,Tablet_DL_3920,Tablet_DL_3920
+DL,Horizon H8,DL_Horizon_H8,Smartphone DL Horizon H8
+DL,Mobi Tab,Tablet_DL_2810,Tablet_DL_2810
+DL,Mobi Tab,Tablet_DL_2811,Tablet_DL_2811
+DL,Sabich\xc3\xb5es,Tablet_DL_3722,Tablet_DL_3722
+DL,TabF\xc3\xa1cil,Tablet_DL_2820,Tablet_DL_2820
+DL,TabKids Plus,TabKids_Plus,Tablet DL 3411
+DL,TabPhone 710 pro,Tablet_DL_3421,Tablet DL 3421
+DL,X_Quad_Pro,X_Quad_Pro,Tablet DL 3410
+DL,YZU_DS53,Smartphone_YZU_DS53,Smartphone_YZU_DS53
+DL,i-Player_KIDS,Tablet_DL_3910,Tablet_DL_3910
+DNA,DNA TV-hubi,dctiw384,DNA Android TV
+Danew,DSlide 710,Dslide710,Dslide710
+Danew,DSlide 750,Danew_DSlide750,DSlide750
+Danew,Dslide 1013,DSlide1013,DSlide 1013
+Danew,Dslide 1013QC,Dslide1013QC_v2,Dslide1013QC_v2
+Danew,Dslide 714,Dslide714_v2,Dslide714_v2
+Danew,Dslide1014,Dslide1014,Dslide1014
+Danew,Dslide714,Dslide714,Dslide714
+Danew,Dslide971DC,Dslide971DC,Dslide971DC
+Danew,Konnect 504,Konnect_504,Konnect_504
+Danew,Konnect 510 colors,Konnect_510,Konnect_510_colors
+Danew,Konnect 560 Cin\xc3\xa9pix,Konnect_560,Konnect_560
+Danew,Surnaturel_R500,Surnaturel_R500,Surnaturel_R500
+Danew,konnect 601,Konnect_601,Konnect_601
+Datsun,Datsun_D5500,D5500,DATSUN_D5500
+Ddm,ANDY 5EI,AM5E3I047,ANDY 5EI
+Dell,,Dell_Grappa,Dell Aero
+Dell,,Dell_Grappa,Mini_3iG
+Dell,,Streak10Pro,Dell Streak 10 Pro
+Dell,,qsd8250_surf,Dell Mini 5
+Dell,,qsd8250_surf,Dell Streak
+Dell,,streak7,Dell Streak 7
+Dell,,streak7,streak7
+Dell,,streakpro,101DL
+Dell,,streakpro,Dell V04B
+Dell,,streakpro,GS01
+Dell,,venue,BizSmartPhone
+Dell,,venue,Dell Venue
+Dell,Chromebook 11 Model 3180,kefka_cheets,Chromebook 11 Model 3180
+Dell,Chromebook 13 3380,asuka_cheets,Dell Chromebook 13 3380
+Dell,Chromebook 13 7310,lulu_cheets,Dell Chromebook 13 7310
+Dell,Cloud Connect,capri_wyse,CS-1A13
+Dell,Streak,streak,001DL
+Dell,Streak,streak,Dell M01M
+Dell,Streak,streak,Dell Streak
+Dell,Venue 10,SO,Venue 10 5050
+Dell,Venue 7,LW,Venue 7 3741
+Dell,Venue 7,Venue7,Venue 7 3740
+Dell,Venue 7,Venue7,Venue7 3740
+Dell,Venue 7,Venue7,Venue7 3740 LTE
+Dell,Venue 7,thunderbird,Venue 7 3730
+Dell,Venue 7,thunderbird,Venue 7 HSPA+
+Dell,Venue 7040,EP,Venue 10 7040
+Dell,Venue 8,BB,Venue 8 7840
+Dell,Venue 8,BB,Venue 8 7840 LTE
+Dell,Venue 8,Venue8,Venue 8 3840
+Dell,Venue 8,Venue8,Venue8 3840
+Dell,Venue 8,Venue8,Venue8 3840 LTE
+Dell,Venue 8,yellowtail,Venue 8 3830
+Dell,Venue 8,yellowtail,Venue 8 HSPA+
+Denso Wave,BHT-1600,BHT1600,BHT1600
+Dialog Blaze,M50E-1A,M50E-1A,M50E-1A
+DigiLand,CompumaxBlue,mid1024_e,Compumax_Blue_6030-805-0001
+DigiLand,DL1001,DL1001,DL1001
+DigiLand,DL1008M,mid1008l_emmc,DL1008M
+DigiLand,DL1010Q,DL1010Q,DL1010Q
+DigiLand,DL1018A,mid1024_e,DL1018A
+DigiLand,DL1025GH,DL1025GH,DL1025GH
+DigiLand,DL1026,DL1026,DL1026
+DigiLand,DL1168A,mid1102,DL1168A
+DigiLand,DL7006,DL7006,DL7006
+DigiLand,DL700D,DL700D,DL700D
+DigiLand,DL701Q,DL701Q,DL701Q
+DigiLand,DL718M,mid713l_lp,DL718M
+DigiLand,DL721RB,DL721-RB,DL721-RB
+DigiLand,DL785D,DL785D,PLT7803G
+DigiLand,DL8006,DL8006,DL8006
+DigiLand,DL9002,DL9002,DL9002
+DigiLand,KTAB17,KTAB17,KTAB17
+DigiLand,NBDVDTAB9,NBDVDTAB9,NBDVDTAB9
+DigiLand,NS-P16AT08,mid8005,NS-P16AT08
+DigiLand,NS-P16AT785HD,MID7802RA,NS-P16AT785HD
+Digilite,TA70CA1,TA70CA1,TA70CA1
+Digilite,TA70CA2,TA70CA2_1,TA70CA2
+Digilite,TA70CA3,TA70CA3_1,TA70CA3
+Digilite,TR10CD1,TR10CD1_5,TR10CD1
+Digilite,TR10CS1,TR10CS1_3,TR10CS1
+Diginnos,DG-A97QT,DG_A97QT,DG-A97QT
+Diginnos,DG-D07S/GP,DG-D07SGP,DG-D07SGP
+Diginnos,DG-Q08M,DG-Q08M,DG-Q08M
+Digital2,Deluxe,nuclear-D2_Deluxe,Digital2-Deluxe
+Digital2,Platinum,D2-963G,Digital2 Platinum
+Digital2,Plus,Digital2Plus,Digital2 Plus
+DigitalStream,DWA1015D Tablet,DWA1015D,DWA1015D
+Digitron,i-Buddie,TR10CD1_10,TR10CD1
+Digitron,i_Buddie,TR10CS1_12,TR10CS1
+Digix,TAB-740_G,TAB-740_G,TAB-740_G
+Digma,DIGMA CITI 1544 3G CS1154MG,CS1154MG,CITI_1544_3G_CS1154MG
+Digma,DIGMA CITI 7507 4G CS7113PL,CS7113PL,CITI_7507_4G_CS7113PL
+Digma,DIGMA CITI 7543 3G CS7153MG,CS7153MG,CITI_7543_3G_CS7153MG
+Digma,DIGMA CITI 8527 4G CS8139ML,CS8139ML,CITI_8527_4G_CS8139ML
+Digma,DIGMA CITI 8542 4G CS8152ML,CS8152ML,CITI_8542_4G_CS8152ML
+Digma,DIGMA HIT Q500 3G HT5035PG,HT5035PG,HIT Q500 3G HT5035PG
+Digma,DIGMA Optima Prime 3 3G TS7131MG,TS7131MG,Optima_Prime_3_3G_TS7131MG
+Digma,DIGMA Plane 1523 3G PS1135MG,PS1135MG,Plane_1523_3G_PS1135MG
+Digma,DIGMA Plane 1525 3G PS1137MG,PS1137MG,Plane_1525_3G_PS1137MG
+Digma,DIGMA Plane 1537E 3G PS1149MG,PS1149MG,Plane_1537E_3G_PS1149MG
+Digma,DIGMA Plane 1538E 3G PS1150ML,PS1150ML,Plane_1538E_4G_PS1150ML
+Digma,DIGMA Plane 1550S 3G PS1163MG,PS1163MG,Plane_1550S_3G_PS1163MG
+Digma,DIGMA Plane 1551S 4G PS1164ML,PS1164ML,Plane_1551S_4G_PS1164ML
+Digma,DIGMA Plane 7006 4G PS7041PL,PS7041PL,Plane_7006_4G_PS7041PL
+Digma,DIGMA Plane 7535E 3G PS7147MG,PS7147MG,Plane_7535E_3G_PS7147MG
+Digma,DIGMA Plane 7539E 4G PS7155ML,PS7155ML,Plane 7539E 4G PS7155ML
+Digma,DIGMA Plane 7545V 3G PS7151MG,PS7151MG,Plane_7545V_3G_PS7151MG
+Digma,DIGMA Plane 7557 4G PS7171PL,PS7171PL,Plane_7557_4G_PS7171PL
+Digma,DIGMA Plane 8540E 4G PS8156ML,PS8156ML,Plane_8540E_4G_PS8156ML
+Digma,DIGMA Plane 9654M 3G PS9167PG,PS9167PG,Plane_9654M_3G_PS9167PG
+Digma,DIGMA VOX Flash 4G VS5015ML,VS5015ML,VOX Flash 4G VS5015ML
+Digma,DIGMA VOX G450 3G VS4001PG,VS4001PG,VOX G450 3G VS4001PG
+Digma,DIGMA VOX G501 4G VS5033ML,VS5033ML,VOX_G501_4G_VS5033ML
+Digma,DIGMA VOX S513 4G VS5035ML,VS5035ML,VOX_S513_4G_VS5035ML
+Digma,LINX A452 3G,LT4030PG,LINX A452 3G LT4030PG
+Digma,Plane 7546S 3G,PS7158PG,Plane_7546S_3G_PS7158PG
+Digma,Plane 7547S 3G,PS7159PG,Plane_7547S_3G_PS7159PG
+Digma,Plane 8536E 3G PS8148MG,PS8148MG,Plane_8536E_3G_PS8148MG
+Digma,Plane 8555M 4G PS8168ML,PS8168ML,Plane 8555M 4G PS8168ML
+Digma,Plane_7548S_4G_PS7160PL,PS7160PL,Plane_7548S_4G_PS7160PL
+Digma,Plane_8548S_3G,PS8161PG,Plane_8548S_3G_PS8161PG
+Digma,Plane_8549S_4G,PS8162PL,Plane_8549S_4G_PS8162PL
+Digma,VOX E502 4G VS5036PL,VS5036PL,VOX E502 4G VS5036PL
+Digma,VOX FIRE 4G VS5037PL,VS5037PL,VOX FIRE 4G VS5037PL
+Digma,VOX_S508_3G,VS5031PG,VOX S508 3G VS5031PG
+Digma,VOX_S509_3G,VS5032PG,VOX S509 3G VS5032PG
+Dish,AirTV Player,uiw4010ech,AirTV Player
+Dish,EVOLVE,dish_cable_bcm,SH960C-DS
+Ditecma,M1092R,M1092R,M1092R
+Ditecma,M1092Rv4,M1092Rv4,M1092Rv4
+Ditigron,i-Buddie,TR10CD1_11,TR10CD1
+Docomo,Japan,TT01,TT01
+Docomo,MEDIAS TAB UL N-08D,N-08D,N-08D
+Docomo,d-01J,d-01J,d-01J
+Doogee,BL5000,BL5000,BL5000
+Doogee,BL7000,BL7000,BL7000
+Doogee,Mix,MIX,MIX
+Doogee,S30,S30,S30
+Doogee,S60,S60,S60
+Doogee,Shoot_ 1,Shoot_1,Shoot_1
+Doogee,T5,T5,T5
+Doogee,T5S,T5S,T5S
+Doogee,X10,doogee-X10,DOOGEE X10
+Doogee,X20,X20,X20
+Doogee,X20L,X20L,X20L
+Doogee,X30,X30,X30
+Doogee,X5  MAX,X5max,X5max
+Doogee,X5 max pro,X5max_PRO,X5max_PRO
+Doogee,X6pro,x5602_fxkj_k20,X6pro
+Doogee,X7,s6061_dg_a50_m,X7
+Doogee,X7Pro,x6069_dg_a50_37m65,X7pro
+Doogee,X9 Mini,X9_Mini,X9 Mini
+Doogee,X9 Mini,t530_dg_a54,X9 Mini
+Doogee,X9 Pro,X9pro,X9pro
+Doogee,X9S,X9S,X9S
+Doogee,Y6,Y6,Y6
+Doogee,Y6 C,Y6C,Y6C
+Doogee,Y6 Max,Y6_Max,Y6 Max
+Doogee,shoot 2,t591_dga57_we,Shoot_2
+Doopro,C1,C1,C1
+Doopro,C1_Pro,C1_Pro,C1_Pro
+Doopro,P1,P1,P1
+Doopro,P1_Pro,P1_Pro,P1_Pro
+Doopro,P2,br6580_weg_n,P2
+Doopro,P2_Pro,P2_Pro,P2_Pro
+Doopro,P4,P4,P4
+Doopro,P4_Pro,P4_Pro,P4_Pro
+Dopo,DP7856K,DP7856K,DP7856K
+Dopo,DPA23D,polaris-wifionly,DPA23D
+Dopo,DPM1081,RCT6203W46,DPM1081
+Dopo,DPM7827,RCT6773W22,DPM7827
+Dopo,EM63 Tablet,EM63,EM63
+Dopo,GS-918,GS_918,GS-918
+Doppio,Doppio_SL505,Doppio_SL505,SL505
+Doppio,SG402,SG402,SG402
+Doppio,SG504,SG504,SG504
+Doppio,SL452,SL452,SL452
+Doppio,SL513,SL513,SL513
+Doppio,U400,U400,U400
+Doppio,U450,U450,U450
+Doppio,U500,U500,U500
+Doro,8020x,Doro_8020x,Doro_8020x
+Doro,8031,DSB0010,Doro 8031
+Doro,8040,DSB0090,Doro 8040
+Doro,822,DSB0010,Doro 8030
+Doro,822,DSB0010,Doro 8031
+Doro,824,825A,Doro 824
+Doro,825A,825A,Doro 824
+Doro,825A,825A,Doro Liberto 825
+Doro,DSB0010,DSB0010,Doro 8030
+Doro,DSB0010,DSB0010,Doro 8030/8031/8028
+Doro,Doro 8042,DSB0110,Doro 8042
+Doro,Liberto 810,Liberto810,Doro Liberto 810
+Doro,Liberto 810,Liberto810,Doro Liberto 810-orange
+Doro,Liberto 810,Liberto810_S12,Doro Liberto 810
+Doro,Liberto 820,Liberto820,Doro Liberto 820
+Doro,Liberto 820 Mini,820Mini,Doro Liberto 820 Mini
+Doro,Liberto 822 / 8030,DSB0010,Doro 8030
+Doro,Liberto 822 / 8030,DSB0010,Doro 8030/8031/8028
+Doro,Liberto 822 / 8030,DSB0010,Doro 8031
+Doro,Liberto 822 / 8030,DSB0010,Doro Liberto 822
+Doro,Liberto 825,825A,825_T-Mobile
+Dragontouch,K8,K8,K8
+Dragontouch,M10,M10,M10
+Dragontouch,V10,V10,V10
+Dragontouch,X10,X10A,X10
+Dragontouch,X10,tulip-d210,X10
+Dragontouch,X80,X80,X80
+Dragontouch,X80 Plus,X80PLUS,X80 Plus
+Dragontouch,Y88X Plus,Y88X_PLUS,Y88X Plus
+Dragontouch,Y88X Plus,Y88X_PLUS,Y88X_PLUS
+Dreamax,DMX-ST7A,DMX-ST7A,DMX-ST7A
+Dtac,Phone M2,dtacPhoneM2,dtacPhoneM2
+Dtac,Phone S2,dtacPhoneS2,dtac_Phone_S2
+Dtac,Phone S3,dtacPhoneS3,dtacPhoneS3
+Dtac,Phone T2,dtacPhoneT2,dtacPhoneT2
+Dtac,Phone X3,dtacPhoneX3,dtacPhoneX3
+Dtac,dtacPhoneS3,dtacPhoneS3,dtacPhoneS3
+Dtac,dtacPhoneT3,dtacPhoneT3,dtacPhoneT3
+Dtac,dtac_Phone_S2,dtacPhoneS2,dtac_Phone_S2
+Dunns,Dunns Slinger,DunnsSlinger,Dunns Slinger
+E-Boda,Eclipse G400M,Eclipse_G400M,Eclipse_G400M
+E-Boda,Eclipse G500HD,E-Boda_Eclipse_G500HD,Eclipse G500HD
+E-Boda,Eclipse G500M,Eclipse_G500M,Eclipse_G500M
+EBN,NEBUPOS3,UY3A,NEBUPOS3
+ECS,RealPad MA7BX2,RealPad_MA7BX2_1,RealPad MA7BX2
+ECS,TC69CA2,TC69CA2_1,TC69CA2
+ECS,TC70RA1,TC70RA1_2,TC70RA1
+ECS,TF10EA2,TF10EA2_2,TF10EA2
+ECS,TF10EA2,TF10EA2_4,TF10EA2
+ECS,TF10EA2,TF10EA2_P61_2,TF10EA2_P61
+ECS,TF10EA2,TF10EA2_P8_1,TF10EA2_P8
+ECS,TI10RA1,TI10RA1_1,TI10RA1
+ECS,TL10RA2,TL10RA2_1,TL10RA2
+ECS,TP10RA1,TP10RA1_1,TP10RA1
+ECS,TR10CS1,TR10CS1_12,TR10CS1
+ECS,TR10CS1,TR10CS1_8,TR10CS1
+ECS,TR10RS1,TR10RS1_11,TR10RS1
+ECS,TR10RS1,TR10RS1_19,TR10RS1
+ECS,TR10RS1,TR10RS1_2,TR10RS1
+ENTITY,GDENTMY7317,GDENTMY7317,GDENTMY7317
+ESI Enterprises,CKT3,CKT3,CKT3
+ESI Enterprises,DT101Bv51,DT101Bv51,DT101Bv51
+ESI Enterprises,DT7v51B,DT7v51B,DT7v51B
+ESI Enterprises,EPIK Learning Tab 8\'\',ELT0801,ELT0801
+ESI Enterprises,EPIK Learning Tab Jr.,ELT0702,ELT0702
+ESI Enterprises,EPIK_ELT0703,ELT0703,ELT0703
+ESI Enterprises,Monster M7 Tablet,MONSTERM7,M7
+ESI Enterprises,Trinity T101,Trinity_T101,Trinity T101
+ESI Enterprises,Trinity T900,Trinity_T900,Trinity T900
+EXO S.A.,wave-i007w,wave-i007w,wave-i007w
+Echo Mobiles,ECHO_HOLI,HOLI,ECHO_HOLI
+Echo Mobiles,Moon,MOON,MOON
+Edcon,Motion E1.1,MotionE11,MotionE11
+Edcon,Platiunm vp.1,VerssedVP1,Verssed VP1
+Edcon,Platiunm vp.2,VerssedVP2,Verssed VP2
+Edcon,VERSSED platinum vp.2.1,VERSSEDvp2-1,VERSSED vp2.1
+Edcon,Verssed Platinum VP3.0,VERSSED_Vp3,VERSSED vp3
+Eks Mobility,X4U+,X4UPlus,X4UPlus
+Electroland Ghana,NASCO_Allure,NASCO_Allure,NASCO_Allure
+Elephone,P8 Max,P8_Max,P8_Max
+Elevate,LUNA G60,G60,LUNA G60
+Elevate,R50A,R50A,R50A
+Elevate,V55C,V55C,V55C
+Ematic,Cubby,SproutChannelCubby,SproutChannelCubby
+Ematic,EBM104JB,EBM104JB,EBM104JB
+Ematic,EGD078,EGD078,EGD078
+Ematic,EGD103,EGD103,EGD103
+Ematic,EGD170,EGD170,Ematic EGD170
+Ematic,EGD172,EGD172,EGD172
+Ematic,EGD213,EGD213,EGD213
+Ematic,EGQ178,EGQ178,EGQ178
+Ematic,EGQ180,EGQ180,EGQ180
+Ematic,EGQ223,EGQ223,EGQ223
+Ematic,EGQ235SK,EGQ235SK,EGQ235SK
+Ematic,EGQ307,EGQ307,EGQ307
+Ematic,EGQ327M,EGQ327M,EGQ327M
+Ematic,EGQ337,EGQ337,EGQ337
+Ematic,EGQ347,EGQ347,EGQ347
+Ematic,EGQ367,EGQ367,EGQ367
+Ematic,EGQ377,EGQ377,EGQ377
+Ematic,EGQ780,EGQ780,EGQ780
+Ematic,EGS017,EGS017,EGS017
+Ematic,EMATICEGS109,EGS109,EGS109
+Ematic,ETH102,ETH102,ETH102
+Ematic,FunTab 2,FunTab2,FunTab2
+Ematic,FunTab 3,Funtab3,FunTabPlay
+Ematic,FunTab 3,Funtab3,Funtab3
+Ematic,GTB103B,Stealth_GTB103M,GTB103M
+Ematic,PBS Kids PlayPad,PBSKD12,PBSKD12
+Ematic,Sprout Channel Cubby,Cubby,SproutChannelCubby
+Ematic,USA,Jetstream,AGT418
+Emdoor,EM_I8180,em_i8180,em_i8180
+Emerson,EM749/748,EM749_748,EM749_748
+Emerson,EM9,EM9,EM9
+Emtec,F400,f400,f400
+Emtec,Gaming Android Gem Box,F500,Gem Box F500
+Energizer,H550S,HARDCASEH550S,HARDCASEH550S
+Energizer,PowerMaxP550S,PowerMaxP550S,P550S
+Energizer,S550,S550,S550
+Enspert,,E-TAB,E-TAB
+Enspert,,ESP_E301,ESP_E301BK
+Enspert,,ESP_E301,ESP_E301V
+Enspert,,ESP_E301,ESP_E301VD
+Enspert,,ESP_E301,ESP_E301VE
+Enspert,,e201,ESP_E201V7
+Enspert,,e201,enspert_e201
+Enspert,,illuminus,ITP-S100WD
+Enspert,,s8073,Miracle
+Enspert,CINK KING,s9081,CINK KING
+Enspert,CINK KING,s9081,Cynus T2
+Enspert,CINK KING,s9081,IMD501
+Enspert,CINK KING,s9081,freebit PandA
+Enspert,CINK SLIM,s8073,CINK SLIM
+Enspert,CINK SLIM,s8073,Fly_IQ442
+Enspert,CINK SLIM,s8073,WIKO-CINK SLIM
+Enspert,Carrefour CT1010,Carrefour,CT1010
+Enspert,Cynus F3,s7511,Cynus F3
+Enspert,DARKSIDE,s9301,Cinema
+Enspert,DARKSIDE,s9301,DARKSIDE
+Enspert,Lazer X40E,X40E,X40E
+Enspert,MG,MGA930,A930
+Enspert,STAIRWAY,s9111,STAIRWAY
+Enspert,WIKO CINK PEAX,s9091,CINK PEAX
+Enspert,WIKO CINK PEAX,s9091,EverClassic
+Enspert,WIKO CINK+,s7505,CINKPLUS
+Enspert,WIKO SUBLIM,s9070,SUBLIM
+Enspert,Wiko CINK FIVE,s9201,CINK FIVE
+Enspert,Wiko CINK FIVE,s9201,Cynus T5
+Enspert,orion,orion,NGM Orion
+Enspert,vanitysmart,vanitysmart,NGM Vanity Smart
+Entel,OWN I62S,OWN-I62S,OWN-I62S
+Entel,S3015,S3015,S3015
+Envizen,ClickTabDSh18,ClickTabDSh18,ClickTabDSh18
+Envizen,V1018A,V1018A,V1018A
+Envizen,VMD9002,VMD9002,VMD9002
+Envizen Digital,V100MD,V100MD,V100MD
+Envizen Digital,V917G,GK-MID9022,V917G
+Envizen Digital,VMD1029,VMD1029,VMD1029
+Essential Products,PH-1,mata,PH-1
+EssentielB,Black Diamond,bird77_a_cu_ics2,Essentielb-Black Diamond
+EssentielB,Pyxis,pyxis_boulanger,Essentielb-Pixis
+EssentielB,ST7001 Tablet,ST7001,ST7001
+EssentielB,Smart\'TAB 7800,fiber-785q6,Smart\'Tab_7800
+EssentielB,Smart\'TAB 9001,fiber-smart,Smart\'TAB 9001
+Estar,BEAUTY 2 HD Quad core,MID7378,eSTAR BEAUTY 2 HD Quad core
+Estar,GO! HD Quad core 3G,MID7438G,eSTAR GO HD Quad core 3G
+Estar,GO! IPS Quad core 3G,MID7458G,eSTAR GO! IPS Quad core 3G
+Estar,GRAND HD Quad Core,MID1198,eSTAR GRAND HD Quad core
+Estar,Grand IPS Quad core 3G,MID1258G,eSTAR Grand IPS Quad core 3G
+Estar,eSTAR BEAUTY 2 HD Quad core,MID7388,eSTAR BEAUTY 2 HD Quad core
+Estar,eSTAR GRAND HD Quad Core,MID1298,eSTAR GRAND HD Quad core
+Etuline,ETL-S4521,u939e_2,ETL-S4521
+Etuline,ETL-S5042,u970_4,ETL-S5042
+EuroLeague,I7a,Euroleague,EuroleaguePhone
+Evercoss,A75 MAX,A75_MAX,A75 MAX
+Evercoss,A75B,EVERCOSS_A75B,A75B
+Evercoss,M50,EVERCOSS_M50,M50
+Evercoss,M50A,EVERCOSS_M50A,M50A
+Evercoss,One X,A65_sprout,EVERCOSS A65
+Evercoss,R40K,R40K,R40K
+Evercoss,R45,EVERCOSS_R45,R45
+Evercoss,R5C,R5C,R5C
+Evercoss,R6,R6,R6
+Evercoss,R70A,R70A,R70A
+Evercoss,S45,EVERCOSS_S45,S45
+Evercoss,S50,EVERCOSS_S50,S50
+Evercoss,S55A,S55A,S55A
+Evercoss,U50,U50,U50
+Evercoss,U50A,U50A,U50A
+Evercoss,U50A_PLUS,U50A_PLUS,U50A_PLUS
+Evercoss,U50B,U50B,U50B
+Evercoss,U50C,U50C,U50C
+Evercoss,U55,U55,U55
+Evercoss,U60,EVERCOSS_U60,U60
+Evercoss,U70,U70,U70
+Every,E701,E701,E701
+Eviant,EVC10Q,EVIANT_EVT10Q,EVIANT_EVT10Q
+Eviant,EVC8Q,EVIANT_EVC8Q,EVC8Q
+Evolio,M5Pro,Evolio_M5Pro,Evolio_M5Pro
+Evolio,M6,Evolio_M6,Evolio_M6
+Evolio,M8,Evolio_M8,Evolio_M8
+Evolveo,EVOLVEO StrongPhone G2,EVOLVEOG2,EVOLVEO StrongPhone G2
+Evolveo,EVOLVEO StrongPhone G4,EVOLVEOG4,EVOLVEO StrongPhone G4
+Evolveo,StrongPhone Q9,StrongPhoneQ9,StrongPhoneQ9
+Explay,4Game,4Game,4Game
+Explay,ATV,ATV,ATV
+Explay,Air,Air,Air
+Explay,Atom,Atom,Atom
+Explay,Bit,Bit,Bit
+Explay,Brilliant,Cosmic,Brilliant
+Explay,Cosmic,Cosmic,Cosmic
+Explay,Craft,Craft,Craft
+Explay,Discovery,Prime,Discovery
+Explay,Easy,Easy,Easy
+Explay,Favorite,Favorite,Favorite
+Explay,Fog,Fog,Fog
+Explay,Fresh,Fresh,Fresh
+Explay,Fresh,Fresh_NF,Fresh_NF
+Explay,Gravity,T4728,Gravity
+Explay,Hit,Hit,Hit
+Explay,Imperium 7,T4729,Imperium7
+Explay,Imperium 8,T4730,Imperium8
+Explay,Indigo,Indigo,Indigo
+Explay,Joy TV,Joy_TV,Joy_TV
+Explay,Leader,Leader,Leader
+Explay,Light,Light,Light
+Explay,Light 3G,Prime,Light
+Explay,M1 Plus,Fog,M1_Plus
+Explay,Onliner 4,G4187,Onliner4
+Explay,Onyx,Onyx,Onyx
+Explay,Party,Party,Party
+Explay,Phantom,Phantom,Phantom
+Explay,Planet,G4187,Planet
+Explay,Prime,Prime,Prime
+Explay,Pulsar,Pulsar,Pulsar
+Explay,Rio Play,RioPlay,RioPlay
+Explay,Shine,T5246,Shine
+Explay,Style,T5246,Style
+Explay,Surfer777 3G,Leader,Surfer7773G
+Explay,Tab Mini,TabMini,TabMini
+Explay,Tornado,Tornado,Tornado
+Explay,Tornado 3G,Tornado3G,Tornado3G
+Explay,Vega,Vega,Vega
+Explay,Winner,T4728,Winner
+Explay,Winner 7,T4729,Winner7
+Explay,Winner 8,T4730,Winner8
+F2 Mobile,F2_LT5216,LT5216,LT5216
+F2 Mobile,LT16,LT16,LT16
+F2 Mobile,LT18,LT18,LT18
+FBC,M24IS810,MX24,TDA02
+FBC,M24IS820,fst01ms,M24IS820
+FPT Trading,FPT X10,X10,FPT_X10
+FPT Trading,FPT X3,FPT_X3,FPT X3
+FPT Trading,FPT X9,X9,FPT_X9
+FaceVsion,OC1020A,OC1020A,FV-FG6
+Fairphone,FP2,FP2,FP2
+Fantec,FANTEC M200H,M200H,M200H
+Fantec,FANTEC M300H,M300H,FAN-M300H
+FarEasTone,Smart 403,msm8226,Smart 403
+FarEasTone,Smart 505,Smart505,Smart 505
+FarEasTone,Smart501,Smart501,Smart501
+FarEasTone,Smart503,MC2,Smart503
+FarEasTone,Smart601,Smart601,Smart601
+Fero,FERO ROYALE Y2,Royale_Y2,Royale Y2
+Fero,POWER 3,Power_3,Power 3
+Fero,Royale X2,Royale_X2,Royale_X2
+Fero,Royale Y2 Lite,Royale_Y2_Lite,Royale Y2 Lite
+Figo,ATRIUM II F55L2,F55L2,ATRIUM II F55L2
+Finggo,FWSP-S1000,FWSP-S1000-HW,FWSP-S1000
+Finggo,FWTA-T1000,FWTA-T1000,FWTA-T1000
+FirstNationalBank,FNB,SP5045V,SP5045V
+Flash,Ivory,Ivory,Ivory
+Flash,Live,Live,Live
+Flnet,BandOTT,ba101,ba101
+Fluo,F,F,F
+Fluo,F Plus,F_Plus,F_Plus
+Fly,5_S,5_S,5S
+Fly,Champ,Champ,FS529
+Fly,Cirrus 11,Cirrus_11,FS517
+Fly,Cirrus 12,Cirrus_12,FS516
+Fly,Cirrus 13,Cirrus_13,FS518
+Fly,Cirrus 14,Cirrus_14,FS522
+Fly,Cirrus 16,Cirrus_16,FS523
+Fly,Cirrus 17,Cirrus_17,FS525
+Fly,Cirrus 2,Cirrus_2,FS504
+Fly,Cirrus 3,Cirrus_3,FS506
+Fly,Cirrus 4,Cirrus_4,FS507
+Fly,Cirrus 6,Cirrus_6,Cirrus 6
+Fly,Cirrus 6,Cirrus_6,FS508
+Fly,Cirrus 7,Cirrus_7,FS511
+Fly,Cirrus 8,Cirrus_8,FS514
+Fly,Cirrus 9,Cirrus_9,FS553
+Fly,Dune 3,Dune_3,IQ4507
+Fly,Dune 4,Dune_4,Fly IQ4508
+Fly,ERA Nano 7,Fly_IQ4407,IQ4407
+Fly,EVO Chic 1,IQ4405_Quad,Fly IQ4405_Quad
+Fly,Ego Art 2,Fly_Ego_Art_2,Fly Ego Art 2
+Fly,Era Energy 1,IQ4502_Quad,IQ4502 Quad
+Fly,Era Life 2,IQ456,IQ456
+Fly,Era Nano 6,Era_Nano_6,IQ4406
+Fly,Era Nano 8,IQ4400,IQ4400
+Fly,Era Nano 9,IQ436i,IQ436i
+Fly,Era Style 3,IQ4415_Quad,IQ4415 Quad
+Fly,Evo Chic 2,IQ459,IQ459
+Fly,Evo Chic 2,IQ459,IQ459 Quad
+Fly,Evo Energy4,IQ4501,Evo Energy4
+Fly,Evo Tech 3,IQ4414_Quad,IQ4414 Quad
+Fly,FS402,Stratus_2,FS402
+Fly,FS451,Nimbus1,FS451
+Fly,FS502,Cirrus_1,FS502
+Fly,Flylife Connect 10.1,Flylife_Connect_101_3G_2,Flylife Connect 10.1 3G 2
+Fly,Flylife Connect 7 3G 2,Flylife7,Flylife Connect 7 3G 2
+Fly,Flylife Connect 7.85 3G 2,Flylife,Flylife Connect 7.85 3G 2
+Fly,IQ434,IQ434,IQ434
+Fly,IQ4401,IQ4401,IQ4401
+Fly,IQ4409 Quad,IQ4409_Quad,IQ4409 Quad
+Fly,IQ4413 Quad,IQ4413_Quad,IQ4413_Quad
+Fly,IQ4415,IQ4415,IQ4415
+Fly,IQ4416,IQ4416,IQ4416
+Fly,IQ4417 Quad,IQ4417_Quad,IQ4417 Quad
+Fly,IQ4418,IQ4418,Fly IQ4418 AF
+Fly,IQ4418,IQ4418,IQ4418
+Fly,IQ4420 Quad,IQ4420_Quad,IQ4420 Quad
+Fly,IQ4421 Quad,IQ4421_Quad,IQ4421 Quad
+Fly,IQ4490i,IQ4490i,IQ4490i
+Fly,IQ4503,IQ4503,FLY IQ4503
+Fly,IQ4503 Quad,IQ4503_Quad,IQ4503 Quad
+Fly,IQ4504 Quad,IQ4504_Quad,IQ4504 Quad
+Fly,IQ4505,IQ4505,Fly IQ4505
+Fly,IQ4505 Quad,IQ4505_Quad,IQ4505 Quad
+Fly,IQ4509,IQ4509,IQ4509
+Fly,IQ4512 Quad,IQ4512_Quad,IQ4512 Quad
+Fly,IQ4513,IQ4513,IQ4513
+Fly,IQ4513 Octa,IQ4513_Octa,IQ4513 Octa
+Fly,IQ4514 Quad,IQ4514_Quad,Fly IQ4514
+Fly,IQ4514 Quad,IQ4514_Quad,Fly IQ4514 AF
+Fly,IQ4514 Quad,IQ4514_Quad,IQ4514 Quad
+Fly,IQ4515 Quad,IQ4515_Quad,IQ4515 Quad
+Fly,IQ4516 Octa,IQ4516_Octa,IQ4516
+Fly,IQ4516 Octa,IQ4516_Octa,IQ4516 Octa
+Fly,IQ4551,Epic_Note,IQ4551
+Fly,IQ458 Quad Evo Tech 2,IQ458,IQ458 Quad
+Fly,IQ4601,IQ4601,IQ4601
+Fly,IQ4602,Fly_IQ4602,Fly IQ4602
+Fly,IQ4602,IQ4602_Quad,IQ4602 Quad
+Fly,Iris,FLY_IQ4400,FLY_IQ4400_AF
+Fly,Knockout,Knockout,FS524
+Fly,Memory Plus,Memory_Plus,FS528
+Fly,Nimbus 10,Nimbus_10,FS512
+Fly,Nimbus 11,Nimbus_11,FS455
+Fly,Nimbus 12,Nimbus_12,FS510
+Fly,Nimbus 14,Nimbus_14,FS456
+Fly,Nimbus 15,Nimbus_15,FS457
+Fly,Nimbus 16,Nimbus_16,FS459
+Fly,Nimbus 17,Nimbus_17,FS527
+Fly,Nimbus 2,Nimbus_2,FS452
+Fly,Nimbus 4,Nimbus_4,FS551
+Fly,Nimbus 7,Nimbus_7,FS505
+Fly,Nimbus 8,Nimbus_8,FS454
+Fly,Nimbus 9,Nimbus_9,Nimbus 9
+Fly,Nimbus3,Nimbus3,FS501
+Fly,Phoenix 2,IQ4410i,Phoenix 2
+Fly,Power Plus 1,Power_Plus_1,FS521
+Fly,Power Plus 2,Power_Plus_2,FS526
+Fly,Power Plus FHD,Power_Plus_FHD,FS554
+Fly,Power Plus XXL,Power_Plus_XXL,FS530
+Fly,Selfie 1,Selfie_1,FS520
+Fly,Stratus,Stratus_6,FS407
+Fly,Stratus 1,Stratus1,FS401
+Fly,Stratus 3,Stratus_3,FS404
+Fly,Stratus 4,Stratus_4,FS405
+Fly,Stratus 5,Stratus_5,FS406
+Fly,Stratus 7,Stratus_7,FS458
+Fly,Stratus 8,Stratus_8,FS408
+Fly,Stratus 9,Stratus_9,FS409
+Fly,Tornado One,IQ4511_Octa,FLY IQ4511
+Fly,Tornado One,IQ4511_Octa,IQ4511 Octa
+Fly,Tornado One,IQ4511_Octa,IQ4511 TR
+Fossil,Q Founder,grant,Q Founder
+Fossil,Q Wander / Q Marshal / Q Founder 2.0 / Bradshaw / Dylan,gar,Bradshaw
+Fossil,Q Wander / Q Marshal / Q Founder 2.0 / Bradshaw / Dylan,gar,Q Marshal
+Fossil,Q Wander / Q Marshal / Q Founder 2.0 / Bradshaw / Dylan,gar,Q Wander
+Fossil,Wear,mullet,Vapor
+Four Mobile,S710 Ruby,S710_Ruby,S710 Ruby
+Four Mobile,Thunder,S350,Thunder
+Foxconn,,A1,MUCHTEL A1
+Foxconn,,A800,WellcoM-A800
+Foxconn,,Boston,Boston
+Foxconn,,Boston,Orange_Boston
+Foxconn,,FE6,FE6
+Foxconn,,G1305,GSmart-G1305
+Foxconn,,K2,E120
+Foxconn,,K3,E130
+Foxconn,,SF4Y6,SF4Y6
+Foxconn,,a1,Rstream-A1
+Foxconn,,a800,WellcoM-A800
+Foxconn,,a89,WellcoM-A89
+Foxconn,,a99,WellcoM-A99
+Foxconn,,axioo,PICOpad-QGN
+Foxconn,,fb0,FIH-FB0
+Foxconn,,fm600,Camangi-FM600
+Foxconn,,hd710,Commtiva-HD710
+Foxconn,,m500,MUSN-M500
+Foxconn,,magnumhd,cherry-MagnumHD
+Foxconn,,mangrove7,Camangi-Mangrove7
+Foxconn,,mi410,CSL-MI410
+Foxconn,,msm7627_surf,EV-S110
+Foxconn,,msm7627_surf,FIH-F0X
+Foxconn,,msm7627_surf,FIH-FM6
+Foxconn,,msm7627_surf,KT-F100
+Foxconn,,msm7627_surf,KT-S110
+Foxconn,,muchtela2,MUCHTEL-A2
+Foxconn,,musn-t800,Cherry-MUSN-T800
+Foxconn,,superion,cherry mobile-SUPERION
+Foxconn,,t800,MUSN-T800
+Foxconn,,vigo410,Axioo-VIGO410
+Foxconn,,vt100,V-T100
+Foxconn,A5,A5,A5
+Foxconn,CSL Spice MI700,mi700,CSL_Spice_MI700
+Foxconn,CSL Spice MI700,mi700,Spice_MI700
+Foxconn,Casper_VIA_A6108,SI1,Casper_VIA_A6108
+Foxconn,Commtiva N700,n700,Commtiva-N700
+Foxconn,Dolphin 70e Black,dblack,Dolphin 70e Black
+Foxconn,InFocus IN260,IN260,IN260
+Foxconn,MUSN COUPLE,couple,COUPLE
+Foxconn,SH530U,sh530u,SH530U
+Foxconn,SH930W,FCN,SH930W
+Foxconn,SHARP  SH837W,S1U,SH837W
+Foxconn,SHARP SH630E,SAE,SHP-SH630E
+Foxconn,SHARP SH631W,S2U,SH631W
+Foxconn,SHARP SH837W,S1U,SH837W
+Foxconn,ViewPhone3,viewphone3,ViewPhone3
+Foxconn,XOLO,AZ510,X900
+Foxconn,XOLO_X1000,SI1,XOLO_X1000
+Foxconn,vizio VP700,S1U,VP700
+Foxconn,vizio VP800,FCN,VP800
+Foxtel,Foxtel Now box,dwt765fxt,Foxtel Now box
+Freebit,A55J,arima6735_65u_l1,TONE m15
+Freebit,Tone m15,TONE_m15,TONE m15
+Freebox,Mini 4K,fbx6lc,Freebox Player Mini
+Freebox,Mini 4K,fbx6lcv2,Freebox Player Mini v2
+Freetel,FUN PLUS,FUNPLUS,FUN PLUS
+Freetel,ICE2,ICE2,FTE161E
+Freetel,ICE2plus,ICE2plus,FTE161G
+Freetel,ICE3,ICE3,FTE171A
+Freetel,Miyabi 2 Dual,Miyabi2_Dual,FTJ17B00
+Freetel,Priori 5,Priori5,FTJ17C00
+Freetel,Priori4,Priori4,FT162D
+Freetel,Priori4,Priori4,FTJ162D
+Freetel,RAIJIN,RAIJIN,FTJ162E
+Freetel,SAMURAI REI,FTJ161B,FTJ161B
+Freetel,SAMURAI REI 2,SAMURAI_REI2,FTJ17A00
+Fujitsu,ARROWS A SoftBank 101F,SBM101F,101F
+Fujitsu,ARROWS A SoftBank 201F,SBM201F,201F
+Fujitsu,ARROWS A SoftBank 202F,SBM202F,202F
+Fujitsu,ARROWS A SoftBank 301F,SBM301F,301F
+Fujitsu,ARROWS ES IS12F,FJI12,IS12F
+Fujitsu,ARROWS Kiss F-03D,f11sky,F-03D
+Fujitsu,ARROWS Kiss F-03E,F03E,F-03E
+Fujitsu,ARROWS M01,M01,M01
+Fujitsu,ARROWS M305,M305,M305
+Fujitsu,ARROWS M357,M357,M357
+Fujitsu,ARROWS M555,M555,M555
+Fujitsu,ARROWS M555,M555SB,M555
+Fujitsu,ARROWS Me F-11D,F11D,F-11D
+Fujitsu,ARROWS NX F-06E,F06E,F-06E
+Fujitsu,ARROWS S EM01F,EM01F,EM01F
+Fujitsu,ARROWS Tab F-05E,F05E,F-05E
+Fujitsu,ARROWS Tab FJT21,FJT21_jp_kdi,FJT21
+Fujitsu,ARROWS Tab LTE F-01D,blaze_tablet,F-01D
+Fujitsu,ARROWS Tab Wi-Fi FAR70B,FAR70B,FAR70B
+Fujitsu,ARROWS Tab Wi-Fi FAR75A/70A,blaze_tablet,FAR7
+Fujitsu,ARROWS V F-04E,F04E,F-04E
+Fujitsu,ARROWS X F-02E,F02E,F-02E
+Fujitsu,ARROWS X F-10D,F10D,F-10D
+Fujitsu,ARROWS X LTE F-05D,blaze,F-05D
+Fujitsu,ARROWS Z FJL22,FJL22_jp_kdi,FJL22
+Fujitsu,ARROWS Z ISW11F,FJI11,ISW11F
+Fujitsu,ARROWS Z ISW13F,FJI13,ISW13F
+Fujitsu,ARROWS ef FJL21,FJL21,FJL21
+Fujitsu,ARROWS mu F-07D,f11apo,F-074
+Fujitsu,ARROWS mu F-07D,f11apo,F-07D
+Fujitsu,ARROWS mu F-07D,f11apo,FJJB091
+Fujitsu,Disney Mobile on docomo F-07E,F07E,F-07E
+Fujitsu,Disney Mobile on docomo F-08D,blaze,F-08D
+Fujitsu,F-01F,F01F,F-01F
+Fujitsu,F-01H,F01H,F-01H
+Fujitsu,F-01J,F01J,F-01J
+Fujitsu,F-01K,F01K,F-01K
+Fujitsu,F-02F,F02F,F-02F
+Fujitsu,F-02G,F02G,F-02G
+Fujitsu,F-02H,F02H,F-02H
+Fujitsu,F-02K,F02K,F-02K
+Fujitsu,F-03F,F03F,F-03F
+Fujitsu,F-03G,F03G,F-03G
+Fujitsu,F-03H,F03H,F-03H
+Fujitsu,F-04F,F04F,F-04F
+Fujitsu,F-04G,F04G,F-04G
+Fujitsu,F-04H,F04H,F-04H
+Fujitsu,F-04J,F04J,F-04J
+Fujitsu,F-05F,F05F,F-05F
+Fujitsu,F-05G,F05G,F-05G
+Fujitsu,F-06F,F06F,F-06F
+Fujitsu,F-09D ANTEPRIMA,F09D,F-09D
+Fujitsu,F-09E,F09E,F-09E
+Fujitsu,F-12C,f11eif,F-12C
+Fujitsu,FARTM9334P1,FARTM9334,FARTM9334P1
+Fujitsu,FARTM933KZ,FARTM933KZ,FARTM933KZ
+Fujitsu,FARTMB611Y,FARTMB611Y,FARTMB611Y
+Fujitsu,FHMD001,FHMD001,FHMD001
+Fujitsu,M02,M02,M02
+Fujitsu,M305,M305,M305
+Fujitsu,M305,M305SB,M305
+Fujitsu,M363/P,UY1,M363/P
+Fujitsu,M555,M555,M555
+Fujitsu,Patio100,Patio100,Patio100
+Fujitsu,Patio100,Patio100_3G,Patio100_3G
+Fujitsu,REGZA Phone IS11T,TSI11,IS11T
+Fujitsu,REGZA Phone T-01C,tg03,IS04
+Fujitsu,REGZA Phone T-01C,tg03,T-01C
+Fujitsu,REGZA Phone T-01D,blaze,T-01D
+Fujitsu,REGZA Phone T-02D,T02D,T-02D
+Fujitsu,RM02,M02,RM02
+Fujitsu,Raku-Raku SMART PHONE F-12D,F12D,F-12D
+Fujitsu,Raku-Raku SMART PHONE2 F-08E,F08E,F-08E
+Fujitsu,STYLISTIC M350/CA2,M350,M350
+Fujitsu,STYLISTIC M532,mx532,M532
+Fujitsu,STYLISTIC M702,M702,M702
+Fujitsu,STYLISTIC MH350,MH350,MH350
+Fujitsu,STYLISTIC S01,S01,S01-orange
+Fujitsu,SZJ-JS101,SZJ101,SZJ-JS101
+Fujitsu,TM20,STF,TM20
+Fujitsu,TONE m17,TONEm17,TONE-m17
+Fujitsu,arrows Be F-05J,F05J,F-05J
+Fujitsu,arrows M02,M02,M02
+Fujitsu,arrows M03,M03,arrowsM03
+Fujitsu,arrows M04,M04,arrowsM04
+Fujitsu,arrows M04 PREMIUM,M04P,arrowsM04-PREMIUM
+Fujitsu,arrows Tab M01T,M01T,M01T
+Funai Electric,,smdkv210,ALM-001J
+Future Mobile Technology,B-52,176HS1050232,176HS1050232
+Future Mobile Technology,DRONE,FMT-NM7108-01,FMT-NM7108-01
+Future Mobile Technology,Dual 8,FMT-NT8A42-01,FMT-NT8A42-01
+Future Mobile Technology,Eagle,175WT1050231,175WT1050231
+Future Mobile Technology,FMT-NM7054-01,FMT-NM7054-01,FMT-NM7054-01
+Future Mobile Technology,FMT-NM7054-03,FMT-NM7054-03,FMT-NM7054-03
+Future Mobile Technology,FMT-NM7058-03,FMT-NM7058-03,FMT-NM7058-03
+Future Mobile Technology,Falcon,176HS1050531,176HS1050531
+Future Mobile Technology,Flash,FMT-NM7058-02,FMT-NM7058-02
+Future Mobile Technology,Netsurfer STORM,16M4HI105024,16M4HI105024
+Future Mobile Technology,Netsurfer TYPHOON,16M5HI105023,16M5HI105023
+Future Mobile Technology,Tomcat,175HS1050231,175HS1050231
+Future Mobile Technology,Viper,175FT1050241,175FT1050241
+Future Mobile Technology,netsurferDUAL 7,FMT-NM7116-01,FMT-NM7116-01
+G Y P NEW TREE SA,VIEWPAD M10M,M10M,VIEWPAD M10M
+G53,TA71CA3,TA71CA3_1,TA71CA3
+GD Classbook,TA80CA1,TA80CA1_2,TA80CA1
+GSmart,Akta A4,Akta_A4,Akta_A4
+GSmart,Aku A1,Aku_A1,GSmart Aku A1
+GSmart,Alto A2,Alto_A2,GSmart Alto A2
+GSmart,Arty A3,Arty_A3,GSmart Arty A3
+GSmart,Classic,Classic,Classic
+GSmart,Classic_Pro,Classic_Pro,Classic_Pro
+GSmart,Elite,Elite,Elite
+GSmart,GS202+,GSmart_GS202,GSmart GS202+
+GSmart,GSmart SX1,GBC_bravo,GSmart SX1
+GSmart,GX2,GBC_ares,GX2
+GSmart,Guru G1,Guru_G1,GSmart Guru G1
+GSmart,Maya M1,MayaM1,GSmart Maya M1
+GSmart,Maya M1 v2,Maya_M1_v2,GSmart Maya M1 v2
+GSmart,Mika M2,Mika_M2,GSmart Mika M2
+GSmart,Mika M3,Mika_M3,GSmart Mika M3
+GSmart,Rey R3,Rey_R3,GSmart Rey R3
+GSmart,Rio R1,Rio_R1,GSmart Rio R1
+GSmart,Roma R2,Roma_R2,GSmart Roma R2
+GSmart,SX1,bravo,GSmart SX1
+GSmart,Saga_S3,Saga_S3,GSmart Saga S3
+GSmart,Sierra S1,GSmart_Sierra_S1,GSmart Sierra S1
+GSmart,Simba SX1,GBC_bravo,Simba SX1
+GSmart,Simba SX1,bravo,Simba SX1
+GSmart,T4,GSmart_T4,GSmart T4
+GSmart,Tuku T2,Tuku_T2,GSmart Tuku T2
+Galapad,Galapad S6,GALAPAD_S6,GALAPAD_S6
+Galexia,GL9002,GL9002,GL9002
+Garmin,,a10,Garmin-Asus A10
+Garmin,Monterra,monterra,Monterra
+Garmin,Nuvi 3595,scorpio,nuvi 3595
+Garmin,Nuvifone,a50,Garmin-Asus A50
+Garmin,Nuvifone,a50,Garminfone
+Garmin,Nuvifone,a50,nuvifone A50
+Garmin,Nuvifone,a50,n\xc3\xbcvifone A50
+Garmin,nuvi 3590,scorpio,nuvi 3590
+Garmin,nuvi 3592,scorpio,nuvi 3592
+Garmin,nuvi 3595,scorpio,nuvi 3595
+Gasei S.A.,Retailer Stores,SENSE901,SENSE901
+Gasei S.A.,SENSE701,SENSE701,SENSE701
+Geanee,FXC-5A,FXC-5A,FXC-5A
+General Dynamics,GD Tough Mobile,granite,GD Tough Mobile
+General Mobile,4G,gm4g_s_sprout,General Mobile 4G
+General Mobile,4G,gm4gtkc_s_sprout,General Mobile 4G
+General Mobile,4G Dual,gm4g_sprout,General Mobile 4G Dual
+General Mobile,5,gm5_s_sprout,GM 5
+General Mobile,Discovery Air,Discovery_Air,Discovery Air
+General Mobile,Discovery II Mini,Discovery_II_Mini,Discovery II Mini
+General Mobile,E-tab 4,mehmet,e-tab4
+General Mobile,Etab5,Etab5,Etab5
+General Mobile,GM 6 d,GM6_d_sprout,GM 6 d
+General Mobile,GM 6 s,GM6_s_sprout,GM 6
+General Mobile,GM5 Plus,gm5plus_s_sprout,GM 5 Plus
+General Mobile,GM5 Plus Turkcell,gm5plustkc_s_sprout,GM 5 Plus
+General Mobile,GM5 Plus d,gm5plus_sprout,GM 5 Plus d
+GeneralMobile,E-Tab10,blue_eye,E-Tab10
+Geniatech,Enjoy TV Quad-Core Box,ATV581,Enjoy TV Quad-Core Box
+Geniatech,EnjoyTV,enjoytv,ATV495MAX
+Geniatech,Enjoytv_hybrid,enjoytv_hybrid,ATV598MAX
+Gesellschaft f\xc3\xbcr SMK mBH,Tough Mobile,granite,CP600
+Getac,MX50,mx50,mx50
+Getac,Z710,z710,Getac Z710
+Getac,ZX70,zx70,ZX70
+Getac,ZX70,zx70,zx70
+Ghia,ZEUS 3G,N2,GHIA_ZEUS_3G
+Gigabyte,,G1317S,GSmart G1317S
+Gigabyte,9788,9788,9788
+Gigabyte,Boston 4G,boston_4g,Boston 4G
+Gigabyte,E9771,E9771,E9771
+Gigabyte,EL-20-3710,TCV5,EL-20-3050
+Gigabyte,EL-20-3710,TCV5,EL-20-3710
+Gigabyte,GSmart G1310,G1310,GSmart G1310
+Gigabyte,GSmart G1315,G1315,GSmart G1315
+Gigabyte,GSmart G1317,G1317D,GSmart G1317D
+Gigabyte,GSmart G1342,msm7627a,GSmart G1342
+Gigabyte,GSmart G1345,msm7627_sku2,GSmart G1345
+Gigabyte,GSmart G1355,G1355,GSmart G1355
+Gigabyte,GSmart G1362,G1362,GSmart G1362
+Gigabyte,GSmart GS202,GS202,GSmart GS202
+Gigabyte,Hipstreet 9DTB7 / Lazer MY9308P,AMLMY9308P,9DTB7
+Gigabyte,Hipstreet 9DTB7 / Lazer MY9308P,AMLMY9308P,MY9308P
+Gigabyte,P102g,P102g,P102G
+Gigabyte,PAPILIO G1,inhon77_cidals,INHON PAPILIO G1
+Gigabyte,PROSCAN PLT1066 / MAG MAGPAD / TEAC TEACTAB / DOPO GS-1008,MID1005_K,GS-1008
+Gigabyte,PROSCAN PLT1066 / MAG MAGPAD / TEAC TEACTAB / DOPO GS-1008,MID1005_K,MAGPAD
+Gigabyte,PROSCAN PLT1066 / MAG MAGPAD / TEAC TEACTAB / DOPO GS-1008,MID1005_K,PLT1066
+Gigabyte,PROSCAN PLT1066 / MAG MAGPAD / TEAC TEACTAB / DOPO GS-1008,MID1005_K,TEACTAB
+Gigabyte,SAF3011,SAF3011,SAF3011
+Gigabyte,SB506,SB506,SB506
+Gigabyte,SB510 / IBT-102,SB510,SB510
+Gigabyte,TB100,TB100,Gigabyte TB100
+Gigabyte,TB100,TB100,TB100
+Gigabyte,TECNO P3S,P3S,TECNO P3S
+Gigabyte,TM105,TM105,TM105
+Gigabyte,TM105A,TM105A,Aero1021/P1021HCBA4C1VXX
+Gigabyte,TM105A,TM105A,Glacier
+Gigabyte,TM105A,TM105A,Qrypton1010
+Gigabyte,TM105A,TM105A,TM105A
+Gigabyte,TM75A,TM75A,GSmart7Tab
+Gigabyte,TM75A,TM75A,Qrypton7
+Gigabyte,TM75A,TM75A,TM75A
+Gigabyte,TM75A,TM75A,Voyager
+Gigabyte,TM75A-V,TM75A-V,TM75A-V
+Gigabyte,W5510,W5510,W5510
+Gigabyte,W6360,W6360,W6360
+Gigabyte,mexico,Lanix,iliumPAD
+Gigaset,GS160,GS160,Gigaset GS160
+Gigaset,GS170,GS170,Gigaset GS170
+Gigaset,Gigaset GS170,GS170,Gigaset GS170
+Gigaset,Gigaset GS270,Gigaset_GS270,GS270
+Gigaset,Gigaset GS270 plus,Gigaset_GS270_plus,GS270 plus
+Gigaset,Gigaset GS370,GS370,GS370
+Gigaset,Gigaset GS370_Plus,GS370_Plus,GS370_Plus
+Gigaset,Gigaset Maxwell 10,maxwell_10,Maxwell-10
+Gigaset,ME,ME,GS55-6
+Gigaset,ME Pro,MEpro,GS57-6
+Gigaset,ME Pure,MEpure,GS53-6
+Gigaset,Maxwell 10,maxwell_10,80-1
+Gigaset,Maxwell-10,maxwell_10,80-1
+Gigaset,Maxwell-10,maxwell_10,Maxwell-10
+Gigaset,QV1030,FG6Q,Gigaset QV1030
+Gigaset,QV830,UY8,Gigaset QV830
+Gigaset,QV831,UY8,Gigaset QV831
+Gigaset,SL930,lion_s,SL930
+Gini,N6,N6,N6
+Gini,e6_plus,e6,e6
+Gini,e6_plus,e6_plus,e6_plus
+Gini,n7,n7,n7
+Gini,n8,Gini_n8,Gini n8
+Gini,s4,s4,s4
+Gini,s4_pro,s4_pro,s4_pro
+Gini,w5,w5,w5
+Gini,w6,w6,w6
+Ginzzu,GT-1015,GT-1015,GT-1015
+Ginzzu,GT-1045,GT-1045,GT-1045
+Ginzzu,GT-1050,GT-1050,Ginzzu GT-1050
+Ginzzu,GT-7100,GT-7100,GT-7100
+Ginzzu,GT-7115,GT-7115,Ginzzu GT-7115
+Ginzzu,GT-7205,GT-7205,GT-7205
+Ginzzu,GT-7210,GT-7210,Ginzzu GT-7210
+Ginzzu,GT-8105,GT-8105,GT-8105
+Ginzzu,GT-8110,GT-8110,Ginzzu GT-8110
+Ginzzu,RS8501,RS8501,RS8501
+Ginzzu,S5002,S5002,S5002
+Ginzzu,S5021,S5021,S5021
+Ginzzu,S5230,S5230,S5230
+Ginzzu,SMART Race 4G,x2605b_fm45_mtc,SMART Race 4G
+Gionee,A1,GIONEE_SWW1609,GIONEE A1
+Gionee,A1 Lite,GIONEE_SWW1618,A1 lite
+Gionee,A1 Plus,GIONEE_SWW1617,A1 Plus
+Gionee,A1 lite,GIONEE_SWW1618,A1 lite
+Gionee,E8,GiONEE_GN9008,E8
+Gionee,E8,GiONEE_GN9008,GN9008
+Gionee,F100,GIONEE_GBL7358,F100
+Gionee,F100A,GIONEE_GBL7358,F100A
+Gionee,F100B,GIONEE_GBL7370,F100B
+Gionee,F100L,GIONEE_GBL7370,F100L
+Gionee,F100S,GIONEE_GBL7370,F100S
+Gionee,F103,GiONEE_GBL7319,F103
+Gionee,F103 Pro,GIONEE_GBL7360,F103 Pro
+Gionee,F103L,GiONEE_GBL7319,F103L
+Gionee,F103S,GiONEE_F103S,F103S
+Gionee,F105,GiONEE_GBL7335,F105
+Gionee,F105L,GiONEE_GBL7335,F105L
+Gionee,F106,GIONEE_SWG1613,F106
+Gionee,F106L,GIONEE_SW17G03,F106L
+Gionee,F301,F301,F301
+Gionee,F303,F303,F303
+Gionee,F5,GIONEE_SWG1608,F5
+Gionee,F5L,GIONEE_SWG1608,F5L
+Gionee,ForwardZero,V6L,V6L
+Gionee,GIONEE F109,GIONEE_SW17G09,GIONEE F109
+Gionee,GIONEE F109L,GIONEE_SW17G09,GIONEE F109L
+Gionee,GIONEE F109N,GIONEE_SW17G09,GIONEE F109N
+Gionee,GIONEE F205L,GIONEE_SW17G18,GIONEE F205L
+Gionee,GIONEE GN5007,GIONEE_BJ17G16,GIONEE GN5007
+Gionee,GIONEE GN5007L,GIONEE_BJ17G16,GIONEE GN5007L
+Gionee,GIONEE M7L,GIONEE_SW17G07,GIONEE M7L
+Gionee,GIONEE X1,GIONEE_SWW1631,GIONEE X1
+Gionee,GN152,GiONEE_CBL7320,GN152
+Gionee,GN3001,GiONEE_GBL7523,GN3001
+Gionee,GN3001L,GiONEE_GBL7523,GN3001L
+Gionee,GN3002,GIONEE_GBL7356,GN3002
+Gionee,GN3002L,GIONEE_GBL7356L,GN3002L
+Gionee,GN3003,GIONEE_GBL7359,GN3003
+Gionee,GN3003L,GIONEE_GBL7359L,GN3003L
+Gionee,GN5001,GiONEE_BBL7332,GN5001
+Gionee,GN5001L,GiONEE_BBL7332,GN5001L
+Gionee,GN5001S,GiONEE_BBL7332,GN5001S
+Gionee,GN5002,GiONEE_GBL7333,GN5002
+Gionee,GN5003,GiONEE_BBL7337A,GN5003
+Gionee,GN5005,GIONEE_G1605A,GN5005
+Gionee,GN5005,GIONEE_G1605A,GN5005L
+Gionee,GN8001,GiONEE_BBL7505,GN8001
+Gionee,GN8001L,GiONEE_BBL7505,GN8001L
+Gionee,GN8003L,GiONEE_BBL7515A,GN8003L
+Gionee,GN9000,S5_5,GN9000
+Gionee,GN9006,GN9006,GN9006
+Gionee,GN9006,GN9006,GiONEE S7
+Gionee,GN9007,GiONEE_CBL7503,GN9007
+Gionee,GN9010L,GiONEE_CBL7513,GN9010L
+Gionee,GN9012,GIONEE_GBL7529,GN9012
+Gionee,Gtel_X5pro,Gtel_X5pro,Gtel_X5pro
+Gionee,M2,M2,M2
+Gionee,M2017,GIONEE_GBL8918,M2017
+Gionee,M2mini,GiONEE_WBW5612,M2mini
+Gionee,M3,GiONEE_M3,M3
+Gionee,M3,M3,M3
+Gionee,M3S,GiONEE_M3S,M3S
+Gionee,M3mini,GiONEE_WBL7315,M3mini
+Gionee,M4,GiONEE_M3,M4
+Gionee,M5,M5,M5
+Gionee,M5 Lite,GiONEE_BBL7332,M5_lite
+Gionee,M5 Plus,GiONEE_BBL7505,M5 Plus
+Gionee,M5 mini,GiONEE_WBW5616,M5 mini
+Gionee,M5L,M5,M5L
+Gionee,M6,GiONEE_BBL7515A,GN8003
+Gionee,M6,GiONEE_BBL7515A,M6
+Gionee,M6 Lite,GIONEE_WBL7361,M6 lite
+Gionee,M6 Plus,GIONEE_BBL7516A,GN8002
+Gionee,M6 Plus,GIONEE_BBL7516A01,GN8002S
+Gionee,M6 mirror,GIONEE_WBL7372,M6 mirror
+Gionee,M6SLPlus,GIONEE_G1602A,M6SLPlus
+Gionee,M6SPlus,GIONEE_G1602A,M6SPlus
+Gionee,M7,GIONEE_SW17G07,GIONEE M7
+Gionee,P2M,GiONEE_WBW5612,P2M
+Gionee,P3S,GiONEE_WBW5613,P3S
+Gionee,P4,P4,P4
+Gionee,P4S,P4S,P4S
+Gionee,P5 mini,GiONEE_WBW5617,P5 mini
+Gionee,P5L,GiONEE_WBL7352,P5
+Gionee,P5L,GiONEE_WBL7352,P5L
+Gionee,P5W,GiONEE_WBW5615,P5W
+Gionee,P6,P6,P6
+Gionee,P7,GIONEE_G1605A,GIONEE P7
+Gionee,P7,GIONEE_WBL7365,GIONEE P7
+Gionee,P7,GIONEE_WBL7365,P7
+Gionee,P7 Max,GIONEE_WBL5708,P7 Max
+Gionee,P8 Max,GIONEE_WBL7372,P8 Max
+Gionee,P8M,GIONEE_SW17W04,P8M
+Gionee,P8W,GIONEE_WBW5620,P8W
+Gionee,S plus,GiONEE_WBL7511,S_plus
+Gionee,S10,GIONEE_SW17G04,GIONEE S10
+Gionee,S10B,GIONEE_SW17G01,GIONEE S10B
+Gionee,S10BL,GIONEE_SW17G01,GIONEE S10BL
+Gionee,S10C,GIONEE_SW17G02,GIONEE S10C
+Gionee,S10CL,GIONEE_SW17G02,GIONEE S10CL
+Gionee,S10L,GIONEE_SW17G04,GIONEE S10L
+Gionee,S5.1,GN9005,GN9005
+Gionee,S5.1,S5_1,S5.1
+Gionee,S5.5,S5_5,S5.5
+Gionee,S6,GiONEE_CBL7513,GN9010
+Gionee,S6,GiONEE_CBL7513,S6
+Gionee,S6 Pro,GIONEE_GBL7529,GN9012
+Gionee,S6 Pro,GIONEE_GBL7529,S6 Pro
+Gionee,S6s,GIONEE_WBL7519,S6s
+Gionee,S8,GIONEE_WBL7517,GN9011
+Gionee,S9,GIONEE_GBL7553,S9
+Gionee,S9,GIONEE_GBL7558,S9
+Gionee,S_plus,GiONEE_WBL7511,S_plus
+Gionee,V4S,V4S,V4S
+Gionee,V5,V5,V5
+Gionee,W900S,GiONEE_BFL7506A,W900S
+Gionee,W909,GiONEE_BFL7512B,W909
+Gionee,X1,GIONEE_SWW1631,GIONEE X1
+Gionee,X1S,GIONEE_SWW1627,X1S
+Go Mobile,GO Onyx,GO_Onyx_LTE,GO Onyx LTE
+Go Mobile,GO Onyx HD,Go_Onyx_HD,Go Onyx HD
+Go Mobile,GO1004,GO1004,GO1004
+Go Mobile,GO1402S,GO1402S,GO1402S
+GoClever,INSIGNIA 550i,INSIGNIA_550i,INSIGNIA_550i
+GoClever,QUANTUM 1010N,QUANTUM_1010N,QUANTUM_1010N
+GoClever,QUANTUM 400 LITE,QUANTUM_400_LITE,QUANTUM_400_LITE
+GoClever,QUANTUM_550,QUANTUM_550,QUANTUM_550
+GoClever,QUANTUM_700S/QUANTUM 700S,QUANTUM_700S,QUANTUM_700S
+GoClever,TQ700/QUANTUM 700/TAB,TQ700,TQ700
+Google,Android Wear,bluegill,Alberto
+Google,Android Wear,bluegill,EA Connected
+Google,Android Wear,glowlight,GUESS Connect
+Google,Android Wear,shiner,Sofie
+Google,Chromebook,edgar_cheets,Chromebook 14 (CB3-431)
+Google,Chromebook,hana_cheets,Lenovo N23 Yoga/Flex 11 Chromebook
+Google,Chromebook,jerry_cheets,RK3288 Chrome OS Device
+Google,Chromebook,mighty_cheets,RK3288 Chrome OS Device
+Google,Chromebook,reef_cheets,reef
+Google,Chromebook,relm_cheets,Braswell Chrome OS Device
+Google,Chromebook Pixel (2015),samus_cheets,Google Chromebook Pixel (2015)
+Google,Emulator,generic_x86,Android SDK built for x86
+Google,Galaxy S4 Google Play edition,jgedlte,GT-I9505G
+Google,Pixel,sailfish,Pixel
+Google,Pixel 2,walleye,Pixel 2
+Google,Pixel 2 XL,taimen,Pixel 2 XL
+Google,Pixel C,dragon,Pixel C
+Google,Pixel XL,marlin,Pixel XL
+Google,Pixelbook,eve_cheets,Google Pixelbook
+Google,Project Tango Tablet Development Kit,yellowstone,Project Tango Tablet Development Kit
+Google,Project Tango Tablet Development Kit,yellowstone,Yellowstone
+Gplus,FW6950,GPLUS_FW6950,GPLUS_FW6950
+Gplus,S9701,GPLUS_S9701,GPLUS_S9701
+Gradiente,iphone C600,GBC_bravo,iphone C600
+Gradiente,iphone C600,bravo,iphone C600
+Greatwall,T709GW,T709GW,Great Wall T709
+Grundig,GTB1030,TA10CA2,TA10CA2
+Grundig,GTB1050,GTB1050,GTB 1050
+Grundig,GTB850,GTB850,GTB 850
+Grundig,TC69CA2,GTB801,GTB 801
+Gryphon,Veil,granite,Veil
+Gtel,A7100 X3,A7100_X3,A7100_X3
+Gtel,A7101_X3_mini,A7101_X3_mini,A7101_X3_mini
+Gtel,A713_Vivo_Pro,A713_Vivo_Pro,A713_Vivo_Pro
+Gtel,A714 Vivo Play,A714_Vivo_Play,A714_Vivo_Play
+Gtel,A7155_X4_mini,A7155_X4_mini,A7155_X4_mini
+Gtel,A715_Inspire_One,A715_Inspire_One,A715_Inspire_One
+Gtel,A716 Inspire Life,A716_Inspire_Life,A716_Inspire_Life
+Gtel,A726 Infinity Lite,A726_Infinity_Lite,A726_Infinity_Lite
+Gtel,A727_Infinity_Pro,A727_Infinity_Pro,A727_Infinity_Pro
+Gtel,A728_XP2,A728_XP2,A728_XP2
+Gtel,A737_XploraZ,A737_XploraZ,A737_XploraZ
+Gtel,A770_SL8_Pro,A770_SL8_Pro,A770_SL8_Pro
+Gtel,A770_XL7,A770_XL7,A770_XL7
+Gtel,Gtel_Vivo3,Gtel_Vivo3,Gtel_Vivo3
+Gtel,Gtel_X5mini,Gtel_X5mini,Gtel_X5mini
+Gtel,Gtel_X5s,Gtel_X5s,Gtel_X5s
+Gtel,X5,Gtel_X5,Gtel X5
+Gtel,X5plus,Gtel_X5plus,Gtel X5plus
+HKC,A79 Tablet,EM62,A79
+HKT,eye3,UY3-PCW,eye3
+HP,10,spruce,HP 10
+HP,10 Plus,torsa,HP 10 Plus
+HP,7 G2,redwood,HP 7 G2
+HP,7 Plus,Ilex,HP 7 Plus
+HP,7 Plus G2,deschutes,HP 7 Plus G2
+HP,7 Tablet,Mesquite,HP 7
+HP,7 Voice Tab,klondike,HP 7 VoiceTab
+HP,7 VoiceTab,yukon,HP 7 VoiceTab
+HP,7.1,Holly,HP 7.1
+HP,8,Fir,HP 8
+HP,8 G2,maple,HP 8 G2
+HP,Bonsai 10 HD,bonsai10,HP Slate 10 HD
+HP,Chromebook x360 11 G1 EE,snappy_cheets,HP Chromebook x360 11 G1 EE
+HP,HP Chromebook 11 G5 / 11-vxxx,setzer_cheets,HP Chromebook 11 G5 / HP Chromebook 11-vxxx
+HP,HP Chromebook 13 G1,chell_cheets,HP Chromebook 13 G1
+HP,Pro 8 Tablet with Voice,neetu,HP Pro 8 Tablet with Voice
+HP,Pro Slate 10 EE G1,bulldog,HP Pro Slate 10 EE G1
+HP,Pro Slate 10 EE G1,hound,HP Pro Slate 10 EE G1
+HP,Pro Slate 10 EE G1,poodle,HP Pro Slate 10 EE G1
+HP,Pro Slate 10 EE G1,terrier,HP Pro Slate 10 EE G1
+HP,Pro Slate 12,dane,HP Pro Slate 12
+HP,Pro Slate 8,malamute,HP Pro Slate 8
+HP,Slate 10 HD,bonsai10,HP Slate 10 HD
+HP,Slate 10 Plus,linkplus,HP Slate 10 Plus
+HP,Slate 17,franky,HP Slate 17
+HP,Slate 21 Pro,ranger,Slate 21 Pro
+HP,Slate 6 Voice Tab,pomegranate,HP Slate 6 Voice Tab
+HP,Slate 6 Voice Tab II,avocado,HP Slate 6 Voice Tab II
+HP,Slate 6 VoiceTab Plus,mekong,HP Slate 6 VoiceTab Plus
+HP,Slate 7,pine,HP Slate 7
+HP,Slate 7 Beats Special Edition,fairfax,HP Slate 7 Beats Special Edition
+HP,Slate 7 Beats Special Edition,fairfax,HP Slate7 Beats Special Edition
+HP,Slate 7 Extreme,olive,HP Slate7 Extreme
+HP,Slate 7 HD,bonsai10,HP Slate 10 HD
+HP,Slate 7 HD,bonsai7,HP Slate 7 HD
+HP,Slate 7 Voice Tab,almond,HP Slate 7 Voice Tab
+HP,Slate 7 VoiceTab Ultra,charm,HP Slate 7 VoiceTab Ultra
+HP,Slate 8 Plus,vogue,HP Slate 8 Plus
+HP,Slate 8 Pro,dogwood,HP Slate 8 Pro
+HP,Slate21,phobos,Slate 21
+HP,Slate7 Plus,birch,HP Slate 7 Plus
+HP,Slate8 Pro,fig,HP Slate 8 Pro
+HP,SlateBook 10 x2 PC,3645,HP SlateBook 10 x2 PC
+HP,SlateBook 14,200a,HP SlateBook 14 PC
+HP,Tablet 10,balsa,HP_10_Tablet
+HP,Voice Tab 7,almond,HP Slate 7 Voice Tab
+HTC,,express,HTC Flyer
+HTC,,express,PG41200
+HTC,,expresskt,HTC_P515E
+HTC,,rider,HTC_X515E
+HTC,,tagh,HTC Incredible E S715e
+HTC,\t HTC One X9 dual sim,htc_e56ml_dtul,HTC One X9 dual sim
+HTC,\tADR6325,lexikon,ADR6325
+HTC,0P3P5,t6ul,HTC_0P3P5
+HTC,0P4E2,zara,HTC_0P4E2
+HTC,0P9C8,htc_a5dwgl,HTC 0P9C8
+HTC,0P9C8,htc_a5dwgl,HTC Desire 816 dual sim
+HTC,0PFJ50,htc_a51tuhl,HTC_0PFJ50
+HTC,0PK72,htc_hiaur_ml_tuhl,HTC 0PK72
+HTC,0PK72,htc_hiaur_ml_tuhl,HTC One M9PLUS
+HTC,10,htc_pmec2tuhl,HTC 10
+HTC,10,htc_pmec2tuhl,HTC 10 Lifestyle
+HTC,10,htc_pmec2tuhl,HTC 2PS63
+HTC,10,htc_pmec2tuhl,HTC M10u
+HTC,10,htc_pmeuhl,HTC 10
+HTC,10,htc_pmeuhl,HTC 2PS6200
+HTC,10,htc_pmeuhl,HTC M10h
+HTC,10,htc_pmeuhl,HTC_M10h
+HTC,10,htc_pmeuhljapan,HTV32
+HTC,10,htc_pmewhl,2PS64
+HTC,10,htc_pmewl,HTC 10
+HTC,10,htc_pmewl,HTC6545LVW
+HTC,10,htc_pmewl,MSM8996 for arm64
+HTC,10 evo,htc_acauhl,HTC 10 evo
+HTC,10 evo,htc_acauhl,HTC_M10f
+HTC,10 evo,htc_acawhl,HTC 10 evo
+HTC,5060 dual sim,z4dug,HTC Desire 500 dual sim
+HTC,601e,m4,HTC 601e
+HTC,606w,cp3dug,HTC 606w
+HTC,606w,cp3dug,HTC Desire 600
+HTC,606w,cp3dug,HTC Desire 600 dual sim
+HTC,606w,cp3dug,HTC PO49120
+HTC,608t,cp3dtg,HTC 608t
+HTC,609d,cp3dcg,HTC 609d
+HTC,6160,zaradug,HTC 6160
+HTC,619d,zarawl,HTC 619d
+HTC,7060,cp5dug,HTC_7060
+HTC,710C,htc_a5chl,710C
+HTC,802d,m7cdwg,HTC 802d
+HTC,803e,t6ul,HTC 803e
+HTC,8060,t6dug,HTC 8060
+HTC,8088,t6tl,HTC 8088
+HTC,809d,t6dwg,HTC 809d
+HTC,8160,t6uhl,HTC 8160
+HTC,9060,dlxpul,HTC 901e
+HTC,9060,m7,HTC 801e
+HTC,9060,m7cdug,HTC 802w
+HTC,9088,dlpdtu,HTC 9088
+HTC,919d,dlpdwg,HTC 919d
+HTC,A510c,marvelc,HTC_A510c
+HTC,ADR6330VW,blissc,ADR6330VW
+HTC,ADR6425LVW,vigor,ADR6425LVW
+HTC,AT&T HTC One X+,evitareul,HTC EVARE_UL
+HTC,AT&T HTC One X+,evitareul,HTC One X+
+HTC,Amaze_4G,ruby,HTC Amaze 4G
+HTC,Amaze_4G,ruby,HTC Ruby
+HTC,Amaze_4G,ruby,HTC_Amaze_4G
+HTC,Aria,liberty,HTC Aria
+HTC,Aria,liberty,HTC Aria A6380
+HTC,Aria,liberty,HTC Gratia A6380
+HTC,Aria,liberty,HTC Liberty
+HTC,Butterfly,dlxu,HTC Butterfly
+HTC,Butterfly,dlxu,HTC DLX_U
+HTC,Butterfly,dlxu,HTC X920e
+HTC,Butterfly,dlxub1,HTC Butterfly
+HTC,Butterfly,dlxub1,HTC DLXUB1
+HTC,Butterfly 2,htc_b2ul,HTC Butterfly 2
+HTC,Butterfly 2,htc_b2ul,HTC_B810x
+HTC,Butterfly 3,htc_b3tuhl,HTC_B830x
+HTC,Butterfly S,dlxpul,HTC Butterfly s
+HTC,Butterfly S,dlxpul,HTC_Butterfly_s_901s
+HTC,Butterfly s 9060,dlpdug,HTC 9060
+HTC,Chacha,chacha,HTC ChaCha A810b
+HTC,Chacha,chacha,HTC ChaCha A810e
+HTC,Chacha,chacha,HTC ChaChaCha A810e
+HTC,Chacha,chacha,HTC Status
+HTC,D10w,htc_a56dj_pro_dtwl,HTC D10w
+HTC,D316d,htc_v2_c,HTC D316d
+HTC,D610t,htc_a3tl,HTC D610t
+HTC,D616t,htc_a32ml_dtul,HTC D626t
+HTC,D626q,htc_a32ml_dtul,HTC Desire 626 dual sim
+HTC,D626q,htc_a32ml_dtul,HTC_D626q
+HTC,D626t,htc_a32ml_dtul,HTC D626t
+HTC,D628u,htc_v36bml_uhl,HTC_D628u
+HTC,D728w,htc_a50cml_dtul,HTC D728w
+HTC,D728w,htc_a50cml_dtul,HTC Desire 728 dual sim
+HTC,D728x,htc_a50cml_dtul,HTC_D728x
+HTC,D816d,htc_a5dwg,HTC D816d
+HTC,D816d,htc_a5dwg,HTC_D816d
+HTC,D816e,htc_a5dugl,HTC D816e
+HTC,D816h,htc_a5mgp_dug,HTC D816h
+HTC,D816t,htc_a5tl,HTC D816t
+HTC,D816v,htc_a5dwgl,HTC D816v
+HTC,D816w,htc_a5dug,HTC D816w
+HTC,D820 Mini,htc_a31dtul,HTC D820mt
+HTC,D820f,htc_a51tuhl,HTC_D820f
+HTC,D820t,htc_a51dtul,HTC D820t
+HTC,D820u,htc_a51dtul,HTC D820u
+HTC,D820u,htc_a51dtul,HTC_D820u
+HTC,D820ys,htc_a50ml,HTC_D820ts
+HTC,D820ys,htc_a50ml,HTC_D820ys
+HTC,D820ys,htc_a50ml_dtul,HTC_D820ys
+HTC,D826t,htc_a52dtul,HTC D826t
+HTC,DROID DNA,dlx,HTC6435LRA
+HTC,DROID Incredible 4G LTE,fireball,ADR6410LRA
+HTC,DROID Incredible 4G LTE,fireball,ADR6410LVW
+HTC,DROID Incredible 4G LTE,fireball,ADR6410OM
+HTC,Desire,bravo,HTC Desire
+HTC,Desire,bravo,X06HT
+HTC,Desire,bravoc,PB99400
+HTC,Desire 10 compact,htc_a37dj_dugl,HTC 2PZS1
+HTC,Desire 10 compact,htc_a37dj_dugl,HTC Desire 10 compact
+HTC,Desire 10 compact,htc_a37dj_dugl,a37dj dugl
+HTC,Desire 10 lifestyle,htc_a56djdugl,HTC Desire 10 lifestyle
+HTC,Desire 10 lifestyle,htc_a56djuhl,HTC Desire 10 lifestyle
+HTC,Desire 10 lifestyle,htc_a56djuhl,HTC_D10u
+HTC,Desire 10 lifestyle,htc_a56djul,HTC Desire 10 lifestyle
+HTC,Desire 10 pro,htc_a56dj_pro_dtwl,HTC Desire 10 pro
+HTC,Desire 10 pro,htc_a56dj_pro_dugl,HTC Desire 10 pro
+HTC,Desire 10 pro,htc_a56dj_pro_dugl,HTC_D10i
+HTC,Desire 10 pro,htc_a56dj_pro_uhl,HTC 2PYA3
+HTC,Desire 10 pro,htc_a56dj_pro_uhl,HTC Desire 10 pro
+HTC,Desire 200,gtou,HTC Desire 200
+HTC,Desire 200,gtou,HTC_Desire_200
+HTC,Desire 210 dual sim,htc_v0_dug,HTC Desire 210 dual sim
+HTC,Desire 300,g3u,HTC 301e
+HTC,Desire 300,g3u,HTC Desire 300
+HTC,Desire 300,g3u,HTC_0P6A1
+HTC,Desire 300,g3u,HTC_Desire_300
+HTC,Desire 310,htc_v1_dug,HTC D310w
+HTC,Desire 310,htc_v1_dug,HTC Desire 310 dual sim
+HTC,Desire 310,htc_v1_u,HTC Desire 310
+HTC,Desire 310,htc_v1_u,HTC_D310n
+HTC,Desire 310,htc_v1_u,HTC_V1
+HTC,Desire 320,htc_v01_u,HTC 0PF11
+HTC,Desire 320,htc_v01_u,HTC 0PF120
+HTC,Desire 320,htc_v01_u,HTC Desire 320
+HTC,Desire 326G dual sim,htc_v01a_dug,HTC 2PNT1
+HTC,Desire 326G dual sim,htc_v01a_dug,HTC Desire 326G dual sim
+HTC,Desire 500,z4u,HTC Desire 500
+HTC,Desire 500,z4u,HTC_Desire_500
+HTC,Desire 500 dual sim,z4dug,HTC 5060
+HTC,Desire 500 dual sim,z4dug,HTC Desire 500 dual sim
+HTC,Desire 501,htc_csnu,HTC Desire 501
+HTC,Desire 501,htc_csnu,HTC_603h
+HTC,Desire 501 dual sim,csndug,HTC Desire 501 dual sim
+HTC,Desire 5088,z4td,HTC 5088
+HTC,Desire 510,htc_a11chl,0PCV1
+HTC,Desire 510,htc_a11ul,HTC 0PCV20
+HTC,Desire 510,htc_a11ul,HTC Desire 510
+HTC,Desire 510,htc_a11ul,HTC_0PCV2
+HTC,Desire 510,htc_a11ul8x26,HTC Desire 510
+HTC,Desire 512,htc_a11aul8x26,HTC Desire 512
+HTC,Desire 516,htc_v2_dcg,HTC D516d
+HTC,Desire 516,htc_v2_dtg,HTC D516t
+HTC,Desire 516,htc_v2_dug,HTC C2
+HTC,Desire 516,htc_v2_dug,HTC D516w
+HTC,Desire 516,htc_v2_dug,HTC V2
+HTC,Desire 516 dual sim,htc_v2_dcg,HTC Desire 516 dual sim
+HTC,Desire 516 dual sim,htc_v2_dug,HTC Desire 516 dual sim
+HTC,Desire 516 dual sim,htc_v2_dug,HTC V2
+HTC,Desire 520,htc_a12ul,HTC 0PGQ1
+HTC,Desire 526,htc_a13wl,HTC 0PM31
+HTC,Desire 526,htc_a13wl,HTC Desire 526
+HTC,Desire 526,htc_a13wl,HTCD100LVW
+HTC,Desire 526,htc_a13wlpp,HTCD100LVWPP
+HTC,Desire 526G+ dual sim,htc_v02_dug,HTC 0PL41
+HTC,Desire 526G+ dual sim,htc_v02_dug,HTC 0PL4100
+HTC,Desire 526G+ dual sim,htc_v02_dug,HTC Desire 526G dual sim
+HTC,Desire 526G+ dual sim,htc_v02_dug,HTC Desire 526GPLUS dual sim
+HTC,Desire 526G+ dual sim,htc_v02_dug,HTC_D526h
+HTC,Desire 526GPLUS,htc_v02_u,HTC 0PL41
+HTC,Desire 526GPLUS,htc_v02_u,HTC Desire 526G
+HTC,Desire 530,htc_a16ul,HTC 2PST1
+HTC,Desire 530,htc_a16ul,HTC 2PST2
+HTC,Desire 530,htc_a16ul,HTC Desire 530
+HTC,Desire 530,htc_a16ul,HTC_D530u
+HTC,Desire 530,htc_a16wl,HTC 2PST3
+HTC,Desire 530,htc_a16wl,HTC Desire 530
+HTC,Desire 530,htc_a16wl,HTCD160LVW
+HTC,Desire 530,htc_a16wl,HTCD160LVWPP
+HTC,Desire 550/ 555,htc_a15ul,HTC Desire 550
+HTC,Desire 550/ 555,htc_a15ul,HTC Desire 555
+HTC,Desire 600,cp3dug,HTC Desire 600
+HTC,Desire 600 Dual SIM,cp3dug,HTC Desire 600 dual sim
+HTC,Desire 600c Dual SIM,cp3dcg,HTC 609d
+HTC,Desire 600c Dual SIM,cp3dcg,HTC Desire 600c dual sim
+HTC,Desire 601,zara,HTC Desire 601
+HTC,Desire 601,zara,HTC_0P4E2
+HTC,Desire 601,zaracl,HTC Desire 601
+HTC,Desire 601,zaracl,HTC0P4E1
+HTC,Desire 601 dual sim,zaradug,HTC Desire 601 dual sim
+HTC,Desire 606w,cp3dug,HTC 606w
+HTC,Desire 609d,cp3dcg,HTC 609d
+HTC,Desire 610,htc_a3qhdul,HTC Desire 610
+HTC,Desire 610,htc_a3qhdul,HTC_0P9O2
+HTC,Desire 610,htc_a3qhdul,HTC_D610x
+HTC,Desire 610,htc_a3ul,HTC Desire 610
+HTC,Desire 612,htc_a3qhdcl,HTC 0P9O30
+HTC,Desire 612,htc_a3qhdcl,HTC Desire 612
+HTC,Desire 616 dual sim,htc_v3_dug,HTC D616w
+HTC,Desire 616 dual sim,htc_v3_dug,HTC Desire 616 dual sim
+HTC,Desire 616 dual sim,htc_v3_dug,HTC V3
+HTC,Desire 620,htc_a31ul,HTC 0PE64
+HTC,Desire 620,htc_a31ul,HTC Desire 620
+HTC,Desire 620 dual sim,htc_a31dtul,HTC_D620u
+HTC,Desire 620G dual sim,htc_a31mg_dug,HTC 0PE65
+HTC,Desire 620G dual sim,htc_a31mg_dug,HTC Desire 620G dual sim
+HTC,Desire 620G dual sim,htc_a31mg_dug,HTC_D620h
+HTC,Desire 626,htc_a32dcgl,HTC D626d
+HTC,Desire 626,htc_a32ewl,HTCD200LVW
+HTC,Desire 626,htc_a32ewlpp,HTCD200LVWPP
+HTC,Desire 626,htc_a32ul,HTC Desire 626
+HTC,Desire 626,htc_a32ul,HTC_D626x
+HTC,Desire 626,htc_a32ul,HTC_D630x
+HTC,Desire 626,htc_a32ul_emea,HTC Desire 626
+HTC,Desire 626,htc_a32ul_emea,HTC_0PKX2
+HTC,Desire 626 dual sim,htc_a32ml_dtul,HTC Desire 626 dual sim
+HTC,Desire 626G+ dual sim,htc_a32mg_dug,HTC 0PM11
+HTC,Desire 626G+ dual sim,htc_a32mg_dug,HTC Desire 626G dual sim
+HTC,Desire 626G+ dual sim,htc_a32mg_dug,HTC Desire 626GPLUS dual sim
+HTC,Desire 626G+ dual sim,htc_a32mg_dug,HTC_D626ph
+HTC,Desire 626s,htc_a32eul,HTC Desire 625
+HTC,Desire 626s,htc_a32eul,HTC Desire 626s
+HTC,Desire 626s,htc_a32eul_la,HTC Desire 626s
+HTC,Desire 626s,htc_a32ewhl,0PM92
+HTC,Desire 626s,htc_a32ewhl,HTC 0PM92
+HTC,Desire 626s,htc_a32ewhl,HTC Desire 626s
+HTC,Desire 628,htc_v36bml_uhl,HTC Desire 628
+HTC,Desire 628 dual sim,htc_v36bml_dugl,HTC Desire 628 dual sim
+HTC,Desire 630 dual sim,htc_a16dwgl,HTC 2PST5
+HTC,Desire 630 dual sim,htc_a16dwgl,HTC Desire 630 dual sim
+HTC,Desire 650,htc_a17uhl,HTC 2PYR1
+HTC,Desire 650,htc_a17uhl,HTC Desire 650
+HTC,Desire 650,htc_a17uhl,HTC_D650h
+HTC,Desire 650 dual sim,htc_a37_dugl,A37 DUGL
+HTC,Desire 650 dual sim,htc_a37_dugl,HTC Desire 650 dual sim
+HTC,Desire 700 dual sim,cp5dug,HTC Desire 700 dual sim
+HTC,Desire 700 dual sim,cp5dwg,HTC Desire 700 dual sim
+HTC,Desire 700 dual sim,cp5dwg,HTC_709d
+HTC,Desire 7060,cp5dug,HTC_7060
+HTC,Desire 7088,cp5dtu,HTC 7088
+HTC,Desire 709d,cp5dwg,HTC 709d
+HTC,Desire 728,htc_a50cml_tuhl,HTC 2PQ84
+HTC,Desire 728,htc_a50cml_tuhl,HTC Desire 728
+HTC,Desire 728 dual sim,htc_a50cml_dtul,HTC Desire 728 dual sim
+HTC,Desire 728G dual sim,htc_a50cmg_dwg,HTC 2PQ83
+HTC,Desire 728G dual sim,htc_a50cmg_dwg,HTC Desire 728G dual sim
+HTC,Desire 816,htc_a5chl,HTC Desire 816
+HTC,Desire 816,htc_a5ul,HTC Desire 816
+HTC,Desire 816,htc_a5ul,HTC_0P9C2
+HTC,Desire 816,htc_a5ul,HTC_D816x
+HTC,Desire 816 dual sim,htc_a5dug,HTC Desire 816 dual sim
+HTC,Desire 816 dual sim,htc_a5dwg,HTC Desire 816 dual sim
+HTC,Desire 816G dual,htc_a5mgp_dug,HTC Desire 816G dual sim
+HTC,Desire 816G dual sim,htc_a5mg_dug,HTC Desire 816G dual sim
+HTC,Desire 816G dual sim,htc_a5mgp_dug,HTC D816h
+HTC,Desire 816G dual sim,htc_a5mgp_dug,HTC Desire 816G dual sim
+HTC,Desire 820,htc_a51ul,HTC 0PFJ4
+HTC,Desire 820,htc_a51ul,HTC Desire 820
+HTC,Desire 820 dual sim,htc_a51dtul,HTC Desire 820 dual sim
+HTC,Desire 820G PLUS dual sim,htc_a50mgp_dug,HTC Desire 820G PLUS dual sim
+HTC,Desire 820G PLUS dual sim,htc_a50mgp_dug,HTC Desire 820G dual sim
+HTC,Desire 820G PLUS dual sim,htc_a50mgp_dug,HTC_D820pi
+HTC,Desire 820q dual sim,htc_a50dtul,HTC Desire 820q dual sim
+HTC,Desire 820s,htc_a50ml_dtul,HTC D820ts
+HTC,Desire 820s,htc_a50ml_dtul,HTC D820us
+HTC,Desire 820s,htc_a50ml_dtul,HTC Desire 820s dual sim
+HTC,Desire 820s dual sim,htc_a50ml,HTC Desire 820s dual sim
+HTC,Desire 825,htc_a56uhl,HTC 2PUK2
+HTC,Desire 825,htc_a56uhl,HTC Desire 825
+HTC,Desire 825,htc_a56uhl,HTC_D825u
+HTC,Desire 825 dual sim,htc_a56dugl,HTC 2PUK1
+HTC,Desire 825 dual sim,htc_a56dugl,HTC Desire 825 dual sim
+HTC,Desire 826,htc_a52dtul,HTC D826w
+HTC,Desire 826,htc_a52dwgl,HTC D826d
+HTC,Desire 826,htc_a52tuhl,HTC_D826y
+HTC,Desire 826 4G \xe7\xa7\xbb\xe5\x8b\x95\xe5\x85\xac\xe9\x96\x8b\xe7\x89\x88(\xe5\x8f\x8c\xe5\x8d\xa1\xe5\x8f\x8c\xe5\xbe\x85),htc_a52dtul,HTC D826t
+HTC,Desire 826 dual sim,htc_a52dtul,HTC Desire 826 dual sim
+HTC,Desire 826 dual sim,htc_a52dwgl,HTC Desire 826 dual sim
+HTC,Desire 828,htc_a51bml_dtul,HTC D828w
+HTC,Desire 828,htc_a51bml_dtul,HTC_D828x
+HTC,Desire 828,htc_a51bml_tuhl,HTC 2PRE4
+HTC,Desire 828,htc_a51bml_tuhl,HTC Desire 828
+HTC,Desire 828,htc_a51bml_tuhl,HTC_D828g
+HTC,Desire 828 dual sim,htc_a51bml_dtul,HTC Desire 828 dual sim
+HTC,Desire 828 dual sim,htc_a51bml_dwgl,HTC 2PRE2
+HTC,Desire 828 dual sim,htc_a51bml_dwgl,HTC Desire 828 dual sim
+HTC,Desire 830,htc_a51cml_tuhl,HTC Desire 830
+HTC,Desire 830,htc_a51cml_tuhl,HTC_D830x
+HTC,Desire 830 dual sim,htc_a51cml_dtul,HTC 2PVD1
+HTC,Desire 830 dual sim,htc_a51cml_dtul,HTC D830u
+HTC,Desire 830 dual sim,htc_a51cml_dtul,HTC Desire 830 dual sim
+HTC,Desire C,golfc,HTC Desire C
+HTC,Desire C,golfu,HTC Desire C
+HTC,Desire D626w,htc_a32ml_dtul,HTC D626w
+HTC,Desire D820mini,htc_a31dtul,HTC D820mt
+HTC,Desire D820mini,htc_a31dtul,HTC D820mu
+HTC,Desire D826,htc_a52dwgl,HTC D826d
+HTC,Desire EYE,htc_eyetuhl,HTC 0PFH2
+HTC,Desire EYE,htc_eyetuhl,HTC Desire EYE
+HTC,Desire EYE,htc_eyetuhl,HTC_M910x
+HTC,Desire EYE,htc_eyeul,HTC 0PFH11
+HTC,Desire EYE,htc_eyeul,HTC Desire EYE
+HTC,Desire EYE,htc_eyeul_att,HTC Desire Eye
+HTC,Desire HD,ace,001HT
+HTC,Desire HD,ace,Desire HD
+HTC,Desire HD,ace,HTC Desire HD A9191
+HTC,Desire HD,ace,Inspire HD
+HTC,Desire L by HTC,cp2u,Desire L by HTC
+HTC,Desire L dual sim,cp2dug,HTC Desire L dual sim
+HTC,Desire P,magniu,HTC Desire P
+HTC,Desire S,saga,HTC Desire S
+HTC,Desire SV,magnids,HTC Desire SV
+HTC,Desire V,primods,HTC Desire Q
+HTC,Desire V,primods,HTC Desire U
+HTC,Desire V,primods,HTC Desire U dual sim
+HTC,Desire V,primods,HTC Desire V
+HTC,Desire V,primods,HTC PROMIN_U
+HTC,Desire V,primods,HTC PRO_DS
+HTC,Desire V,primods,HTC T327w
+HTC,Desire V,primods,HTC T328w
+HTC,Desire VC,primodd,HTC Desire VC
+HTC,Desire VC,primodd,HTC Desire VC T328d
+HTC,Desire VC,primodd,HTC PRO_DD
+HTC,Desire VC,primodd,HTC T328d
+HTC,Desire X,protou,HTC Desire X
+HTC,Desire X,protou,HTC POO_U
+HTC,Desire X dual sim,protodug,HTC Desire X dual sim
+HTC,Desire XC dual sim,protodcg,HTC Desire XC dual sim
+HTC,Desire320,htc_v01_u,HTC_Desire_320
+HTC,Desire626,htc_a32ul_emea,HTC 0PKX2
+HTC,Desire626,htc_a32ul_emea,HTC Desire 626
+HTC,Desire626s,htc_a32eulatt,HTC 0PM912
+HTC,Desire626s,htc_a32eulatt,HTC Desire 626
+HTC,Desire815G,htc_a5mgp_u,HTC Desire 816G
+HTC,Desrie D530,htc_a16ul,HTC 2PST1
+HTC,Desrie D530,htc_a16ul,HTC Desire 530
+HTC,Droid DNA,dlx,HTC6435LRA
+HTC,Droid DNA,dlx,HTC6435LVW
+HTC,Droid Eris,desirec,Eris
+HTC,Droid Eris,desirec,Pulse
+HTC,Droid Incredible,inc,ADR6300
+HTC,E9pt,htc_a55ml_dtul,HTC E9pt
+HTC,E9pw,htc_a55ml_dtul,HTC E9pw
+HTC,E9pw,htc_a55ml_dtul,HTC_E9pw
+HTC,E9t,htc_a53ml_dtul,HTC E9t
+HTC,E9w,htc_a53ml_dtul,HTC E9w
+HTC,E9x,htc_a53ml_dtul,HTC_E9x
+HTC,EVO 3D,shooter,HTCEVOV4G
+HTC,EVO 3D,shooter,PG86100
+HTC,EVO 3D ISW12HT,shooterk,ISW12HT
+HTC,EVO 3D X515m,shooteru,HTC EVO 3D X515a
+HTC,EVO 3D X515m,shooteru,HTC EVO 3D X515m
+HTC,EVO 3D X515m,shooteru,HTC Inspire 3D
+HTC,EVO 4G LTE,jewel,EVO
+HTC,EVO LTE 4G,jewel,EVO
+HTC,EVO Shift 4G,speedy,PG06100
+HTC,Evo 4G,supersonic,PC36100
+HTC,Explorer A310e,pico,HTC Explorer
+HTC,Explorer A310e,pico,HTC Explorer A310b
+HTC,Explorer A310e,pico,HTC Explorer A310e
+HTC,Flyer,flyer,HTC Flyer
+HTC,Flyer,flyer,HTC Flyer P510e
+HTC,Flyer,flyer,HTC Flyer P511e
+HTC,Flyer,flyer,HTC Flyer P512
+HTC,Flyer,flyer,HTC_Flyer_P512_NA
+HTC,G1,dream,HTC Dream
+HTC,G2,vision,HTC Vision
+HTC,G2,vision,T-Mobile G2
+HTC,HTC Desire 610,htc_a3ul,HTC Desire 610
+HTC,HTC Desire 628 dual sim,htc_v36bml_dugl,HTC 2PVG2
+HTC,HTC Desire 628 dual sim,htc_v36bml_dugl,HTC Desire 628 dual sim
+HTC,HTC One,m7wls,HTC One
+HTC,HTC One mini,m4,HTC One mini
+HTC,HTC U11,htc_ocnuhl,HTC 2PZC100
+HTC,HTC U11 life,htc_ocla1_sprout,HTC U11 life
+HTC,HTC U11 life,htc_oclul,HTC U11 Life
+HTC,HTC U11 life,htc_oclul,HTC U11 life
+HTC,HTC U11+,htc_ocmdtwl,HTC 2Q4D200
+HTC,HTC U11+,htc_ocmdugl,HTC U11 plus
+HTC,HTC U11+,htc_ocmdugl,HTC_2Q4D100
+HTC,HTC6435LVW,dlx,HTC6435LVW
+HTC,HTC909d,dlpdwg,HTC 919d
+HTC,HTCDesire612VZW,htc_a3qhdcl,HTC331ZLVW
+HTC,HTCDesire612VZW,htc_a3qhdcl,HTC331ZLVWPP
+HTC,HTCEVODesign4G,kingdom,HTC Acquire
+HTC,HTCEVODesign4G,kingdom,HTC EVO Design C715e
+HTC,HTCEVODesign4G,kingdom,HTC Hero S
+HTC,HTCEVODesign4G,kingdom,HTC Kingdom
+HTC,HTCEVODesign4G,kingdom,HTCEVODesign4G
+HTC,HTCEVODesign4G,kingdom,PH44100
+HTC,HTCOneMaxVZW,t6wl,HTC6600LVW
+HTC,HTL23,htc_b2wlj,HTL23
+HTC,HTV31,htc_b3uhl,HTV31
+HTC,Hero,hero,ERA G2 Touch
+HTC,Hero,hero,HTC Hero
+HTC,Hero,hero,T-Mobile G2 Touch
+HTC,Hero,hero,T-Mobile_G2_Touch
+HTC,Hero,hero,dopod A6288
+HTC,Hero,heroc,HERO200
+HTC,ISW13HT,valentewx,ISW13HT
+HTC,Incredible 2,vivow,ADR6350
+HTC,Incredible 2,vivow,HTC IncredibleS S710d
+HTC,Incredible S,vivo,HTC Incredible S
+HTC,Incredible S,vivo,HTC_S710E
+HTC,J Butterfly,dlxj,HTL21
+HTC,J One,m7wlj,HTL22
+HTC,J Z321e,valentewxc9,HTC J Z321e
+HTC,KDDI Infobar A02,imnj,HTX21
+HTC,Legend,legend,HTC Legend
+HTC,M10,htc_pmeuhl,HTC 10
+HTC,M8si,htc_m8qltuhl,HTC M8si
+HTC,M8t,htc_m8tl,HTC M8t
+HTC,M9,htc_himaulatt,HTC One M9
+HTC,M9e,htc_himaruhl,HTC M9e
+HTC,M9e,htc_himaruhl,HTC One M9_Prime Camera Edition
+HTC,M9e,htc_himaruhl,HTC One M9s
+HTC,M9e,htc_himaruhl,HTC_M9e
+HTC,M9et,htc_hima_ace_ml_dtul,HTC M9et
+HTC,M9ew,htc_hima_ace_ml_dtul,HTC M9ew
+HTC,M9ew,htc_hima_ace_ml_dtul,HTC_M9ew
+HTC,M9pw,htc_hiau_ml_tuhl,HTC M9pw
+HTC,M9pw,htc_hiaur_ml_tuhl,HTC M9pw
+HTC,M9px,htc_hiaur_ml_tuhl,HTC_M9px
+HTC,M9w,htc_himauhl,HTC M9w
+HTC,Nexus 9,flounder,Nexus 9
+HTC,Nexus 9 LTE,flounder_lte,Nexus 9
+HTC,Nexus One,passion,Nexus One
+HTC,ONE,m7cdug,HTC One dual sim
+HTC,ONE M8s,htc_m8qlul,HTC One M8s
+HTC,ONE M8s,htc_m8qlul,HTC_0PKV1
+HTC,ONE S,ville,HTC One S
+HTC,ONE SV,k2u,HTC K2_U
+HTC,ONE SV,k2u,HTC One SV
+HTC,ONE SV,k2ul,HTC One SV
+HTC,One,m7,HTC 801e
+HTC,One,m7,HTC One
+HTC,One,m7,HTC One 801e
+HTC,One,m7,HTC_PN071
+HTC,One,m7cdtu,HTC 802t
+HTC,One,m7cdtu,HTC 802t 16GB
+HTC,One,m7cdug,HTC 802w
+HTC,One,m7cdug,HTC One dual sim
+HTC,One,m7cdwg,HTC 802d
+HTC,One,m7cdwg,HTC One dual 802d
+HTC,One,m7cdwg,HTC One dual sim
+HTC,One,m7wls,HTC One
+HTC,One,m7wls,HTCONE
+HTC,One,m7wlv,HTC One
+HTC,One,m7wlv,HTC6500LVW
+HTC,One (E8),htc_mecdwg,HTC M8Sd
+HTC,One (E8),htc_mectl,HTC M8St
+HTC,One (E8),htc_mectl,HTC One_E8
+HTC,One (E8),htc_mecul,HTC One_E8
+HTC,One (E8),htc_mecul,HTC_M8Sx
+HTC,One (E8),htc_mecwhl,0PAJ5
+HTC,One (E8) dual sim,htc_mecdug,HTC One_E8 dual sim
+HTC,One (E8) dual sim,htc_mecdug,HTC_M8Sy
+HTC,One (E8) dual sim,htc_mecdwg,HTC 0PAJ4
+HTC,One (E8) dual sim,htc_mecdwg,HTC M8Sd
+HTC,One (E8) dual sim,htc_mecdwg,HTC One_E8 dual sim
+HTC,One (E8) \xe6\x97\xb6\xe5\xb0\x9a\xe7\x89\x88,htc_mectl,HTC M8St
+HTC,One (E8) \xe6\x97\xb6\xe5\xb0\x9a\xe7\x89\x88   4G LTE\xe5\x8f\x8c\xe5\x8d\xa1\xe5\x8f\x8c\xe5\xbe\x85\xe8\x81\x94\xe9\x80\x9a\xe7\x89\x88,htc_mecdug,HTC M8Sw
+HTC,One (E8) \xe6\x99\x82\xe5\xb0\x9a\xe7\x89\x884G LTE \xe7\xa7\xbb\xe5\x8a\xa8\xe7\x89\x88,htc_mectl,HTC M8Ss
+HTC,One (M8 EYE),htc_melsuhl,HTC 0P6B900
+HTC,One (M8 EYE),htc_melsuhl,HTC One_M8 Eye
+HTC,One (M8 Eye),htc_melsuhl,HTC 0P6B9
+HTC,One (M8 Eye),htc_melsuhl,HTC One_M8 Eye
+HTC,One (M8),htc_m8,HTC M8w
+HTC,One (M8),htc_m8,HTC One_M8
+HTC,One (M8),htc_m8,HTC_0P6B
+HTC,One (M8),htc_m8,HTC_0P6B6
+HTC,One (M8),htc_m8,HTC_M8x
+HTC,One (M8),htc_m8dug,HTC One_M8 dual sim
+HTC,One (M8),htc_m8dwg,HTC M8d
+HTC,One (M8),htc_m8whl,831C
+HTC,One (M8),htc_m8wl,HTC One_M8
+HTC,One (M8),htc_m8wl,HTC6525LVW
+HTC,One (M8) (4G LTE \xe5\x8f\x8c\xe5\x8d\xa1\xe5\x8f\x8c\xe5\xbe\x85 \xe8\x81\x94\xe9\x80\x9a\xe7\x89\x88),htc_m8dug,HTC M8e
+HTC,One 801e,m7,HTC One 801e
+HTC,One 801e,m7,HTC One 801s
+HTC,One A9,htc_hiaetuhl,HTC A9w
+HTC,One A9,htc_hiaeuhl,HTC One A9
+HTC,One A9,htc_hiaeuhl,HTC_A9u
+HTC,One A9,htc_hiaeul,HTC One A9
+HTC,One A9,htc_hiaewhl,2PQ93
+HTC,One A9s,htc_e36_ml_uhl,HTC 2PWD1
+HTC,One A9s,htc_e36_ml_uhl,HTC One A9s
+HTC,One A9s,htc_e36_ml_uhl,HTC_A9sx
+HTC,One A9s,htc_e36_ml_ul,HTC 2PWD2
+HTC,One A9s,htc_e36_ml_ul,HTC One A9s
+HTC,One Dual 802d,m7cdwg,HTC One dual 802d
+HTC,One Dual Sim,m7cdwg,HTC One dual sim
+HTC,One E8 dual,htc_mecdwg,HTC_M8Sd
+HTC,One E9 dual sim,htc_a53ml_dtul,HTC 0PL31
+HTC,One E9 dual sim,htc_a53ml_dtul,HTC One E9 dual sim
+HTC,One E9PLUS dual sim,htc_a55ml_dtul,HTC One E9PLUS dual sim
+HTC,One E9s dual sim,htc_a50aml,HTC D826sw
+HTC,One E9s dual sim,htc_a50aml,HTC One E9s dual sim
+HTC,One E9s dual sim,htc_a50aml,HTC_E9sx
+HTC,One Google Play edition,m7,HTC One
+HTC,One M8 eye 4G LTE,htc_melstuhl,HTC M8Et
+HTC,One M8 eye 4G LTE,htc_melsuhl,HTC M8Ew
+HTC,One M9,htc_himauhl,0PJA10
+HTC,One M9,htc_himauhl,HTC 0PJA10
+HTC,One M9,htc_himauhl,HTC One M9
+HTC,One M9,htc_himauhl,HTC_0PJA10
+HTC,One M9,htc_himauhl,HTC_M9u
+HTC,One M9,htc_himaul,HTC One M9
+HTC,One M9,htc_himaulatt,HTC One M9
+HTC,One M9,htc_himawhl,0PJA2
+HTC,One M9,htc_himawhl,HTC One M9
+HTC,One M9,htc_himawl,HTC6535LRA
+HTC,One M9,htc_himawl,HTC6535LVW
+HTC,One M9+,htc_hiau_ml_tuhl,HTC 0PK71
+HTC,One M9+,htc_hiau_ml_tuhl,HTC M9pt
+HTC,One M9+,htc_hiau_ml_tuhl,HTC One M9PLUS
+HTC,One M9+,htc_hiau_ml_tuhl,HTC_M9pw
+HTC,One M9+ (Prime Camera Edition),htc_hiaur2_ml_tuhl,HTC 0PK71
+HTC,One M9+ (Prime Camera Edition),htc_hiaur2_ml_tuhl,HTC One M9PLUS_Prime Camera Edition
+HTC,One M9PLUS,htc_hiau_ml_tuhl,HTC One M9PLUS
+HTC,One ME dual sim,htc_hima_ace_ml_dtul,HTC 0PLA1
+HTC,One ME dual sim,htc_hima_ace_ml_dtul,HTC One ME dual sim
+HTC,One S,ville,HTC One S
+HTC,One S,ville,HTC VLE_U
+HTC,One S,villec2,HTC One S
+HTC,One S,villec2,HTC Z560e
+HTC,One S Special Edition,villeplus,HTC One S Special Edition
+HTC,One S9,htc_himar2uhl,HTC 2PRG100
+HTC,One S9,htc_himar2uhl,HTC One S9
+HTC,One S9,htc_himar2uhl,HTC_S9u
+HTC,One SC,cp2dcg,HTC One SC
+HTC,One SC,cp2dcg,HTC One SC T528d
+HTC,One SV,k2cl,C525c
+HTC,One SV,k2plccl,HTC One SV
+HTC,One SV,k2ul,HTC K2_UL
+HTC,One SV,k2ul,HTC One SV
+HTC,One SV BLK,k2plccl,HTC One SV
+HTC,One SV BLK,k2plccl,HTC One SV BLK
+HTC,One V,primoc,HTC One V
+HTC,One V,primou,HTC ONE V
+HTC,One V,primou,HTC One V
+HTC,One VX,totemc2,HTC One VX
+HTC,One X,endeavoru,HTC One X
+HTC,One X,endeavoru,HTC S720e
+HTC,One X,evita,HTC One X
+HTC,One X+,enrc2b,HTC One X+
+HTC,One X+,evitareul,HTC One X+
+HTC,One X10,htc_e66_dtwl,HTC 2PXH1
+HTC,One X10,htc_e66_dtwl,HTC One X10
+HTC,One X10,htc_e66_dugl,HTC 2PXH2
+HTC,One X10,htc_e66_dugl,HTC One X10
+HTC,One X10,htc_e66_dugl,HTC_X10u
+HTC,One X10,htc_e66_uhl,HTC 2PXH3
+HTC,One X9,htc_e56ml_tuhl,HTC 2PS5200
+HTC,One X9 dual sim,htc_e56ml_dtul,HTC One X9 dual sim
+HTC,One X9 dual sim,htc_e56ml_dtul,HTC X9u
+HTC,One X9 dual sim,htc_e56ml_dtul,HTC_X9u
+HTC,One XL,evita,HTC One X
+HTC,One XL,evita,HTC One XL
+HTC,One XL,evita,HTC_One_XL
+HTC,One XL,evitautl,HTC EVA_UTL
+HTC,One max,t6ul,HTC One max
+HTC,One max,t6ul,HTC_One_max
+HTC,One max,t6whl,HTC0P3P7
+HTC,One mini,htc_m4,HTC One mini
+HTC,One mini,m4,HTC One mini
+HTC,One mini,m4,HTC_One_mini_601e
+HTC,One mini,m4,HTC_PO582
+HTC,One mini 2,htc_memul,HTC One mini 2
+HTC,One mini 2,htc_memul,HTC_M8MINx
+HTC,One mini 2,htc_memul,HTC_One_mini_2
+HTC,One mini 601E,m4,HTC_One_mini_601e
+HTC,One remix,htc_memwl,HTC6515LVW
+HTC,One_E8,htc_mecul_emea,HTC One_E8
+HTC,Onex X,endeavoru,HTC One X
+HTC,PO091,csndug,HTC PO091
+HTC,Puccini,puccinilte,HTC PG09410
+HTC,Puccini,puccinilte,HTC-P715a
+HTC,Rhyme S510b,bliss,HTC Rhyme S510b
+HTC,S720e,endeavoru,HTC S720e
+HTC,Salsa C510e,icong,HTC Salsa C510b
+HTC,Salsa C510e,icong,HTC Salsa C510e
+HTC,Sensation 4G,pyramid,HTC Sensation
+HTC,Sensation 4G,pyramid,HTC Sensation 4G
+HTC,Sensation 4G,pyramid,HTC Sensation XE with Beats Audio
+HTC,Sensation 4G,pyramid,HTC Sensation XE with Beats Audio Z715a
+HTC,Sensation 4G,pyramid,HTC Sensation XE with Beats Audio Z715e
+HTC,Sensation 4G,pyramid,HTC Sensation Z710a
+HTC,Sensation 4G,pyramid,HTC Sensation Z710e
+HTC,Sensation 4G,pyramid,HTC-Z710a
+HTC,Sensation XL with Beats Audio X315e,runnymede,HTC Sensation XL with Beats Audio X315b
+HTC,Sensation XL with Beats Audio X315e,runnymede,HTC Sensation XL with Beats Audio X315e
+HTC,Sensation XL with Beats Audio X315e,runnymede,HTC-X315E
+HTC,Sensation XL with Beats Audio X315e,runnymede,Sensation XL with Beats Audio
+HTC,T329d,protodcg,HTC T329d
+HTC,T528w,cp2dug,HTC Desire L dual sim
+HTC,Telstra Signature\xe2\x84\xa2 Premium,htc_hiaeuhl,HTC 2PQ910
+HTC,Thunderbolt,mecha,ADR6400L
+HTC,Thunderbolt,mecha,HTC Mecha
+HTC,U Play,htc_alpine_dugl,HTC U Play
+HTC,U Play,htc_alpine_dugl,HTC_U-2u
+HTC,U Play,htc_alpine_uhl,HTC 2PZM3
+HTC,U Play,htc_alpine_uhl,HTC U Play
+HTC,U Play,htc_e36_ml_uhl,HTC 2PWD1
+HTC,U Ultra,htc_ocedtwl,HTC U-1w
+HTC,U Ultra,htc_ocedugl,HTC U Ultra
+HTC,U Ultra,htc_ocedugl,HTC_U-1u
+HTC,U Ultra,htc_oceuhl,HTC 2PZF1
+HTC,U Ultra,htc_oceuhl,HTC U Ultra
+HTC,U11,htc_ocndtwl,HTC U-3w
+HTC,U11,htc_ocndugl,HTC U11
+HTC,U11,htc_ocndugl,HTC_U-3u
+HTC,U11,htc_ocnuhl,HTC 2PZC100
+HTC,U11,htc_ocnuhl,HTC U11
+HTC,U11,htc_ocnuhljapan,601HT
+HTC,U11,htc_ocnuhljapan,HTV33
+HTC,U11,htc_ocnwhl,2PZC5
+HTC,U11,htc_ocnwhl,HTC U11
+HTC,Velocity 4G,holiday,HTC PH39100
+HTC,Velocity 4G,holiday,HTC Raider X710e
+HTC,Velocity 4G,holiday,HTC Velocity 4G
+HTC,Velocity 4G,holiday,HTC Velocity 4G X710s
+HTC,Velocity 4G,holiday,HTC-X710a
+HTC,WF5w,htc_a50bml,HTC WF5w
+HTC,Wildfire,buzz,HTC Wildfire
+HTC,Wildfire CDMA,bee,HTC Bee
+HTC,Wildfire CDMA,bee,HTC Wildfire
+HTC,Wildfire S,marvel,HTC Wildfire S
+HTC,Wildfire S,marvel,HTC Wildfire S A510b
+HTC,Wildfire S,marvel,HTC Wildfire S A510e
+HTC,Wildfire S,marvel,HTC-A510a
+HTC,Wildfire S A515c,marvelc,HTC Wildfire S A515c
+HTC,Wildfire S A515c,marvelc,HTC-PG762
+HTC,Wildfire S A515c,marvelc,USCCADR6230US
+HTC,X2-HT,htc_ocla1_sprout,X2-HT
+HTC,desire 400 dual sim,cp2dug,HTC Desire 400 dual sim
+HTC,desire 608t,cp3dtg,HTC 608t
+HTC,desire 610,htc_a3qhdul,HTC Desire 610
+HTC,desire x,protou,HTC Desire X
+HTC,first,mystul,HTC first
+HTC,myTouch 3G,sapphire,HTC Magic
+HTC,myTouch 3G,sapphire,T-Mobile myTouch 3G
+HTC,myTouch 3G Slide,espresso,T-Mobile myTouch 3G Slide
+HTC,myTouch 4G,glacier,HTC Glacier
+HTC,myTouch 4G,glacier,HTC Panache
+HTC,myTouch 4G Slide,doubleshot,myTouch_4G_Slide
+HYUNDAI_MAESTRO,HDT_1064GS,HDT_1064GS,HDT_1064GS
+Hafury,HAFURY MIX,HAFURY_MIX,HAFURY MIX
+Hafury,HAFURY UMAX,HAFURY_UMAX,HAFURY UMAX
+Haier,A-TT00,A-TT00,A-TT00
+Haier,A36C5H,A36C5H,Andromax A36C5H
+Haier,A42P,A42P,Haier A42P
+Haier,AD6B1H,AD6B1H,Smartfren Andromax AD6B1H
+Haier,AL40,AL40,Haier_AL40
+Haier,AP54,ts18_ap54_kliver,AP54
+Haier,AT7003,AT7003,AT7003
+Haier,Beeline Smart 3,Beeline_Smart3,Beeline Smart 3
+Haier,C46B2H,C46B2H,Andromax C46B2H
+Haier,CDP7TAB4C8,CDP7TAB4C8,CDP7TAB4C8
+Haier,CDP8TAB16SD,CDP8TAB16SD,CDP8TAB16SD
+Haier,CEDTAB70616W8,CEDTAB70616W8,CEDTAB70616W8
+Haier,CETAB10KML9,CETAB10KML9,CETAB10KML9
+Haier,CETAB7ML9,CETAB7ML9,CETAB7ML9
+Haier,CETAB9ML9,CETAB9ML9,CETAB9ML9
+Haier,CMP_765,CMP_765,CMP_765
+Haier,CT1030,CT1030,CT1030
+Haier,CT301_W818,msm7627a,CT301_W818
+Haier,CT825,fiber-a31stm,CT825
+Haier,CYCLONE_ODYSSEY,CYCLONE_ODYSSEY,CYCLONE_ODYSSEY
+Haier,D2-721,D2-721G,D2-721G
+Haier,D2-751G,d2PAD,D2-751G
+Haier,D2-927G,D2-927G,D2-927G
+Haier,D2-961G,D2-961G,D2-961G
+Haier,Fast,HM-G551-FL,Beeline Fast
+Haier,G21,HM-G303-W,G21
+Haier,G30,G30,G30
+Haier,G31s,G31s,G31s
+Haier,G40,G40,G40
+Haier,G50,HM-G551-FL,G50
+Haier,G55,G55,G55
+Haier,G7,HM-G552-FL,G7
+Haier,G7,HM-G552-FL,HM-G552-FL
+Haier,G700,G700,G700
+Haier,G7s,G7s,G7s
+Haier,GF88,I7A-LE,I7A-LE
+Haier,HG-9041,HG-9041,HG-9041
+Haier,HM-I557-FL,HM-I557-FL,HM-I557-FL
+Haier,HM-N501-FL,HM-N501-FL,HM-N501-FL
+Haier,HS-10DTB4,HS-10DTB4,HS-10DTB4
+Haier,HS-7DTB25,HS-7DTB25,HS-7DTB25
+Haier,HS-7DTB29-8GB,HS-7DTB29-8GB,HS-7DTB29-8GB
+Haier,HS-9DTB37,HS_9DTB37,HS_9DTB37
+Haier,HT-I860,HT-I860,HT-I860
+Haier,HW-I509-W,HM-I509-W,FORZA
+Haier,Haier,Homesurf744,Binatone Homesurf744 / Hubble Smart7 (Homesurf744)
+Haier,Haier,PAD69H,PAD69H
+Haier,Haier,PAD_D85,pad_d85
+Haier,Haier,W627,W627
+Haier,Haier,W861,W861
+Haier,Haier Leisure L7,Haier_Leisure_L7,HM-N700-FL
+Haier,HaierG61,HM-G701-FL,HM-G701-FL
+Haier,HomeSurf742_AT7003,HomeSurf742_AT7003,HomeSurf742_AT7003
+Haier,Homesurf844,Homesurf844,Binatone Homesurf844 / Hubble Smart8 (Homesurf844)
+Haier,Hyasong T1,HyasongT1,HyasongT1
+Haier,I50,i50_b1b8,I50
+Haier,INGO-TAB,INGO-TAB,INGO-TAB
+Haier,Kogan Agora 8,Kogan_Agora_8,Kogan Agora 8
+Haier,Konnect_350,Konnect_350,Konnect_350
+Haier,L11,HM-G152-FL,HM-G152-FL
+Haier,L50,M916-D500-PAK,L50
+Haier,L52,Haier_L52,L52
+Haier,LE32U5000A,LE32U5000A,LE32U5000A
+Haier,LE39M7000CF,LE39M7000CF,LE39M7000CF
+Haier,LE40U5000A,LE40U5000A,LE40U5000A
+Haier,LE43B7600A,LE43B7600A,LE43B7600A
+Haier,LE43U5000A,LE43U5000A,LE43U5000A
+Haier,LE48M7000CF,LE48M7000CF,LE48M7000CF
+Haier,LE49U5000A,LE49U5000A,LE49U5000A
+Haier,LE55M7000CF,LE55M7000CF,LE55M7000CF
+Haier,Logicom S9782,Logicom-S9782,Logicom-S9782
+Haier,M7808,M7808,M7808
+Haier,MD-01P,MD-01P,MD-01P
+Haier,MD210,MD210,MD210
+Haier,MEGAFON MS3A,Megafon,MS3A
+Haier,MT-700,MT-700,MT-700
+Haier,MXG308,MXG308,MXG308
+Haier,MXG408,MXG408,MXG408
+Haier,NEO10-1,NEO10-1,NEO10-1
+Haier,NEO7-1,NEO7-1,NEO7-1
+Haier,NEO7-2,NEO7-2,NEO7-2
+Haier,NEO8-1,NEO8-1,NEO8-1
+Haier,P2,P2,P2
+Haier,PAD1021,PAD1021,PAD1021
+Haier,PAD1042,PAD1042,PAD1042
+Haier,PAD712,PAD712,PAD712
+Haier,PAD722,PAD722,PAD722
+Haier,PAD841,PAD841,PAD841
+Haier,PADCT1010W,PADCT1010W,PADCT1010W
+Haier,PAD_1042,PAD_1042,PAD_1042
+Haier,PNDPP410GP,PNDPP410GP,PNDPP410GP
+Haier,PNDPP44Q7GPBLK,PNDPP44Q7GPBLK,PNDPP44Q7GPBLK
+Haier,PNDPP47GP,PNDPP47GP,PNDPP47GP
+Haier,SP-5100,SP-5100,SP-5100
+Haier,Skill,Skill,Skill
+Haier,Smartfren Andromax AD681H,AD681H,Smartfren Andromax AD681H
+Haier,Smartfren Andromax AD9A1H,AD9A1H,Smartfren Andromax AD9A1H
+Haier,StarQ_Q5002,StarQ_Q5002,Q5002
+Haier,T50,Haier_T50,Haier T50
+Haier,T52P,T52P,Haier T52P
+Haier,T54P,Haier_T54P,Haier T54P
+Haier,T785B,T785B,T785B
+Haier,TAB-700,TAB_700,TAB-700
+Haier,TAB-700,TAB_700,TAB700MPG
+Haier,TMK27A2,TMK27A2,TMK27A2
+Haier,V3,V3,V3
+Haier,Voyage V6,HM-V6,HM-V6
+Haier,W717,W717,W717
+Haier,W757,W757,W757
+Haier,W860,W860,W860
+Haier,haier lesure L7,Haier_Leisure_L7,HM-N700-FL
+Haier,i50,i50,Haier_i50
+Handheld Group,Algiz RT7,algizRT7,Algiz RT7
+Handheld Group,HandHeld NAUTIZ X2,NAUTIZ_X2,NAUTIZ_X2
+Handheld Group,Nautiz_X9,Nautiz_X9,Nautiz_X9
+HannSpree,HSG1279,HANNSpad,HSG1279
+HannSpree,HSG1341,mid1024_e,HSG1341
+HannSpree,HSG1351,rk3368_32,HSG1351
+HannSpree,HSG1360,HANNSPAD,HSG1360
+Harris,12131-1000,msm8660_cougar,Harris 12131-1000
+Harris,LMC-1000,granite,LMC-1000
+Harris,RF-3590-RT,msm8660_cougar,Harris 12131-1000
+Helio,S10,S10,S10
+Helio,S2,WBL7519SY,S2
+Helio,S25,HelioS25,S25
+HighScreen,Bay,Bay,Bay
+HighScreen,Easy Power,Easy-Power,Easy-Power
+HighScreen,Easy Power Pro,Easy-Power-Pro,Easy-Power-Pro
+HighScreen,Easy XL,Easy_XL,Easy_XL
+HighScreen,Easy XL Pro,Easy_XL_Pro,Easy_XL_Pro
+HighScreen,Fest,Fest,Fest
+HighScreen,Fest XL,FestXL,FestXL
+HighScreen,Fest XL PRO,FestXL-Pro,FestXL-Pro
+HighScreen,K2050 C1 Fest Pro,Fest-Pro,Fest-Pro
+HighScreen,Power Five,PowerFive,PowerFive
+HighScreen,Power Four,PowerFour,PowerFour
+HighScreen,Power Ice,BBL7353RV,Power Ice
+HighScreen,Power Ice EVO,PowerIceEvo,Power Ice Evo
+HighScreen,Power Rage,PowerRage,Power Rage
+HighScreen,PowerIceMax,PowerIceMax,Power Ice Max
+HighScreen,PowerRageEvo,PowerRageEvo,Power Rage Evo
+HighScreen,Prime L,PrimeL,Prime L
+HighScreen,Tasty,Tasty,Tasty
+Hipstreet,785TB4,785TB4,785TB4
+Hipstreet,7DTB25,7DTB25,7DTB25
+Hipstreet,7DTB37,7DTB37,7DTB37
+Hipstreet,9DTB38,9DTB38,9DTB38
+Hipstreet,9DTB39,9DTB39,9DTB39
+Hipstreet,Beeline Smart 4,Beeline_Smart_4,Beeline Smart 4
+Hipstreet,Beeline Smart 5,Beeline_Smart_5,Beeline Smart 5
+Hipstreet,CP-VL5A,CP-VL5A,CP-VL5A
+Hipstreet,ETAB_M7023G,ETAB_M7023G,ETAB_M7023G
+Hipstreet,Electron,8DTB38,8DTB38
+Hipstreet,Electron 2,8DTB40,8DTB40
+Hipstreet,F100,f100_65u,f100_65u
+Hipstreet,HS-10DTB12,Hipstreet,HS-10DTB12
+Hipstreet,HS-10DTB12A,10DTB12A,10DTB12A
+Hipstreet,HS-10DTB12A,RCT6203W46,HS_10DTB12A
+Hipstreet,HS-10DTB41,HS-10DTB41-8GB,HS-10DTB41-8GB
+Hipstreet,HS-10DTB8,HS-10DTB8,HS-10DTB8
+Hipstreet,HS-7DTB27,HS-7DTB27,HS-7DTB27
+Hipstreet,HS-7DTB35,HS-7DTB35,HS-7DTB35
+Hipstreet,HS-7DTB35,RCT6773W22,HS_7DTB35
+Hipstreet,HS-7DTB39,HS-7DTB39,HS-7DTB39
+Hipstreet,HS-7DTB40,HS-7DTB40-8GB,HS-7DTB40-8GB
+Hipstreet,HS-9DTB7A,HS-9DTB7A,HS-9DTB7A
+Hipstreet,Joey Jet 2,Joey_Jet_2,Dtac phone Joey Jet 2
+Hipstreet,LS-4004,LS-4004,LS-4004
+Hipstreet,LS-5013,LS-5013,LS-5013
+Hipstreet,LS-5017,LS-5017,LS-5017
+Hipstreet,LS-5507,LYF_LS_5507,LS-5507
+Hipstreet,LS-6001,LS-6001,LS-6001
+Hipstreet,Micron,7DTB41,7DTB41
+Hipstreet,Nanho T775,Nanho_T775,Nanho_T775
+Hipstreet,Phantom,Phantom,10DTB10
+Hipstreet,Phantom2,10DTB44,10DTB44
+Hipstreet,Phoenix2,Phoenix2,Phoenix2
+Hipstreet,Pilot,10DTB42,10DTB42
+Hipstreet,Synergy,11DTB1,11DTB1
+Hipstreet,Yupiroid,Yupiroid,Yupiroid
+Hisense,,AD683G,AD683G
+Hisense,,AD685G,New Andromax-i
+Hisense,,E820,HS-E820
+Hisense,,E910,E910
+Hisense,,E910,HS-E910
+Hisense,,E912,HS-E912
+Hisense,,E912S,HS-E912S
+Hisense,,E920,HS-E920
+Hisense,,E926,E926
+Hisense,,E930,HS-E930
+Hisense,,E956,HS-E956
+Hisense,,E956Q,HS-E956Q
+Hisense,,EG870,HS-EG870
+Hisense,,EG876,HS-EG876
+Hisense,,EG901,HS-EG901
+Hisense,,EG909,HS-EG909
+Hisense,,EG950,HS-EG950
+Hisense,,EG970,HS-EG970
+Hisense,,P4013,MEDION-P4013
+Hisense,,SIMPlus,MegaFon SIM+
+Hisense,,T818,HS-T818
+Hisense,,TP9101,HS-M170AT
+Hisense,,TP9102,M1101AT
+Hisense,,U2,U2
+Hisense,,U8,HS-U8
+Hisense,,U820,HS-U820
+Hisense,,U820A,HS-U820
+Hisense,,U820A,U1+
+Hisense,,U820AVN,HS-U820
+Hisense,,U860,HS-U860
+Hisense,,U909,HS-U909
+Hisense,,U909B,HS-U909B
+Hisense,,U909B_6,HS-U909
+Hisense,,U909B_MN,U2S
+Hisense,,U912,HS-U912
+Hisense,,U950,HS-U950
+Hisense,,U950_6,HS-U950
+Hisense,,U950_MN,U3
+Hisense,,U950_ae,HS-U950
+Hisense,,U958,HS-U958
+Hisense,,U960Q,HS-U960Q
+Hisense,,W2400,W2400
+Hisense,,m3101,M3101BW
+Hisense,,m370,M370BW
+Hisense,,t909,HS-T909
+Hisense,,t950,HS-T950
+Hisense,,t958,HS-T958
+Hisense,,t960,HS-T960
+Hisense,55H6SG,Vision,Vision
+Hisense,A2,HS8937QC,Hisense A2
+Hisense,A2M,HS8953QC,Hisense A2M
+Hisense,A2T,HS8953QC,Hisense A2T
+Hisense,AGM  X2,HS8976QC,AGM X2
+Hisense,AGM A7,HS8909QC,AGM A7
+Hisense,AJM X2,HS8976QC,AGM X2
+Hisense,Andromax-c,AD686G,Andromax-c
+Hisense,C-4,C_4,C-4
+Hisense,C1,HS8929QC,Hisense C1
+Hisense,C1AE,HS8929QC,Hisense C1
+Hisense,C1AE-1,HS8929QC,Hisense C1
+Hisense,C1AE-2,HS8929QC,Hisense C1
+Hisense,C1BE,HS8929QC,Hisense C1
+Hisense,C1M,HS8929QC,Hisense C1M
+Hisense,C1T,HS8929QC,Hisense C1T
+Hisense,C20F,HS8929QC,Hisense C20
+Hisense,C20FE-1,HS8929QC,Hisense C20
+Hisense,C20S,C20S,Hisense C20S
+Hisense,C20W,HS8929QC,Hisense C20
+Hisense,C30,HS8937QC,Hisense C30
+Hisense,C30,HS8937QC,Hisense C30_02
+Hisense,C30 Lite,HS6737MT,Hisense C30 Lite
+Hisense,C30 Lite,HS6737MT,STARACTIVE 2
+Hisense,C30 Lite,HS6737MT,SX40
+Hisense,CMB405,L690AE,CMB405
+Hisense,CMB501,u970_carrefour,CMB501
+Hisense,CMB510,L696,CMB510
+Hisense,D1-M,D1_M,Hisense D1-M
+Hisense,D2-M,HS6735MT,D2-M
+Hisense,D5,HS8909QC,Hisense D5
+Hisense,E10,HS8909QC,E10
+Hisense,E100T,E100T,Hisense E100T
+Hisense,E100TAE,E100TAE,LT-W1
+Hisense,E200T,E200T,HS-E200T
+Hisense,E2070,mt8312,E2070
+Hisense,E20T,HS8952QC,Hisense E20T
+Hisense,E2371CH,rk3026,E2371CH
+Hisense,E260T,E260T,HS-E260T
+Hisense,E260U,E260U,Hisense E260U
+Hisense,E270BSA,E270BSA,E270BSA
+Hisense,E360M,e360m,Hisense E360M
+Hisense,E50-T,HS8909QC,Hisense E50-T
+Hisense,E51-F,HS8909QC,Hisense E51
+Hisense,E51-M,HS8909QC,Hisense E51-M
+Hisense,E51-W,HS8909QC,Hisense E51
+Hisense,E600MH02,E600MH02,HS-E600M
+Hisense,E601M,E601M,E601M
+Hisense,E602T,E602T,Hisense E602T
+Hisense,E613M,E613M,Hisense E613M
+Hisense,E620M,E602M,Hisense E602M
+Hisense,E621T,E621T,Hisense E621T
+Hisense,E622M,E622M,Hisense E622M
+Hisense,E625T,E625T,Hisense E625T
+Hisense,E70-T,HS8929QC,Hisense E70-T
+Hisense,E71-M,HS8929QC,Hisense E71-M
+Hisense,E71-T,HS8929QC,Hisense E71-T
+Hisense,E75M,HS8929QC,Hisense E75M
+Hisense,E75T,HS8929QC,Hisense E75T
+Hisense,E76,HS8937QC,Hisense E76
+Hisense,E76E_11,HS8937QC,Hisense E76
+Hisense,E77M,HS8937QC,Hisense E77M
+Hisense,E77MINI,HS8937QC,Hisense E77MINI
+Hisense,E860,E860,E860
+Hisense,E9,HS8937QC,Hisense E9
+Hisense,EG606,EG606_TW,EG606
+Hisense,EG680,eg980ae,EG680
+Hisense,EG68AE,EG668AE,LT668
+Hisense,EG929,EG929_TW,EG929
+Hisense,EG936D,EG936D,HS-EG936D
+Hisense,EG950,EG950TW,EG950
+Hisense,EG970,EG970TW,EG970
+Hisense,EG978,EG978,HS-EG978
+Hisense,EG98,EG98,EG98
+Hisense,EG98,EG98TW,EG98
+Hisense,EG981,EG981,HS-EG981
+Hisense,F10,HS6737MT,BM001
+Hisense,F10,HS6737MT,Hisense F10
+Hisense,F10,HS6737MT,Hisense L675 Pro
+Hisense,F10,HS6737MT,RIVIERA F10
+Hisense,F102,HS6737MT,Hisense F102
+Hisense,F102,HS6737MT,Hisense Hi 3
+Hisense,F20,HS8909QC,F20
+Hisense,F20,HS8909QC,Hisense F20
+Hisense,F20T,HS8909QC,Hisense F20T
+Hisense,F21T,HS8909QC,Hisense F21T
+Hisense,F22,HS6737MT,F22
+Hisense,F22,HS6737MT,Hisense F22
+Hisense,F22,HS8917QC,Hisense F22
+Hisense,F22M,HS8917QC,Hisense F22M
+Hisense,F23,HS6737MT,Hisense F23
+Hisense,F23,HS6737MT,Hisense T203
+Hisense,F23,HS6737MT,RIVIERA F23
+Hisense,F23,HS8917QC,Hisense F23
+Hisense,F23M,HS8917QC,Hisense F23M
+Hisense,F270BW,F270BW,F270BW
+Hisense,F30,HS6735MT,F30
+Hisense,F30,HS6735MT,Hisense F30
+Hisense,F31,HS8937QC,Hisense F31
+Hisense,F31E_11,HS8937QC,Hisense F31
+Hisense,F31M,HS8937QC,Hisense F31M
+Hisense,F32,HS8937QC,Hisense F32
+Hisense,F5070,mt8389,F5070
+Hisense,F5180,f5180,F5180
+Hisense,F5281CH,rk3288,F5281CH
+Hisense,G1,G1,G1
+Hisense,G2-3GP,G2-3GP,G2-3GP
+Hisense,G610M,G610M,Hisense G610M
+Hisense,H800T,H800T,HS-H800T
+Hisense,H910,HS8929QC,Hisense H910
+Hisense,H910,HS8939QC,Hisense H910
+Hisense,H910-F01,HS8939QC,Hisense H910
+Hisense,HLTE100M,HS9850SC,HLTE100M
+Hisense,HLTE200T,HS8917QC,HLTE200T
+Hisense,HLTE300T,HS8937QC,HLTE300T
+Hisense,HS- G610,HS8916QC,HS-G610
+Hisense,HS- L682,HS8916QC,HS-L682
+Hisense,HS-E600M,E600M,HS-E600M
+Hisense,HS-E620M,E620M,HS-E620M
+Hisense,HS-E917,E917,HS-E917
+Hisense,HS-E936,E936,HS-E936
+Hisense,HS-E968,E968,HS-E968
+Hisense,HS-EG916,EG916,HS-EG916
+Hisense,HS-EG929,EG929,HS-EG929
+Hisense,HS-EG929,EG929,msm8625
+Hisense,HS-EG939,EG939,HS-EG939
+Hisense,HS-EG958,EG958,HS-EG958
+Hisense,HS-EG966,EG966,HS-EG966
+Hisense,HS-EG971,EG971,HS-EG971
+Hisense,HS-EG980,eg980,HS-EG980
+Hisense,HS-EG98C,EG98C,HS-EG98C
+Hisense,HS-G610,HS8916QC,HS-G610
+Hisense,HS-I630M,msm8226,HS-I630M
+Hisense,HS-I630T,msm8226,HS-I630T
+Hisense,HS-T9,T9,HS-T9
+Hisense,HS-T926,t926,HS-T926
+Hisense,HS-T928,t928,HS-T928
+Hisense,HS-T939,HS-T939,HS-T939
+Hisense,HS-T959,t959,HS-T959
+Hisense,HS-T959S,t959s,HS-T959S
+Hisense,HS-T959S1,t959s1,HS-T959S1
+Hisense,HS-T966,HS-T966,HS-T966
+Hisense,HS-T967,HS-T967,HS-T967
+Hisense,HS-T968,t968,HS-T968
+Hisense,HS-T968S,t968s,HS-T968S
+Hisense,HS-T970,t970,HS-T970
+Hisense,HS-T978,t978,HS-T978
+Hisense,HS-T980,t980,HS-T980
+Hisense,HS-U601,HS7731SP,HS-U601
+Hisense,HS-U820,U820B,HS-U820
+Hisense,HS-U9,U9,HS-U9
+Hisense,HS-U912,U912A_1,HS-U912
+Hisense,HS-U912,U912B,HS-U912
+Hisense,HS-U912,U912C,HS-U912
+Hisense,HS-U929,u929de,HS-U929
+Hisense,HS-U929,u929de_3,HS-U929
+Hisense,HS-U936,U936,HS-U936
+Hisense,HS-U939,u939,HS-U939
+Hisense,HS-U939,u939e_1,HS-U939
+Hisense,HS-U939,u939e_3,HS-U939
+Hisense,HS-U939,u939e_4,HS-U939
+Hisense,HS-U939,u939e_5,HS-U939
+Hisense,HS-U950,U950_5,HS-U950
+Hisense,HS-U961,HS6572MT,HS-U961
+Hisense,HS-U961,u961,HS-U961
+Hisense,HS-U961,u961e_1,HS-U961
+Hisense,HS-U966,u966,HS-U966
+Hisense,HS-U966,u966ae,HS-U966
+Hisense,HS-U970,u970e_6,HS-U970
+Hisense,HS-U970,u970s_export,HS-U970
+Hisense,HS-U970E,u970t,HS-U970E
+Hisense,HS-U971,U971AE,HS-U971
+Hisense,HS-U978,u978,HS-U978
+Hisense,HS-U98,U98,U98
+Hisense,HS-U98,U98_FR,HS-U98
+Hisense,HS-U980,u980,HS-U980
+Hisense,HS-U980,u980b,HS-U980
+Hisense,HS-U980,u980be,HS-U980
+Hisense,HS-U980,u980be_1,HS-U980
+Hisense,HS-U980,u980be_2,HS-U980
+Hisense,HS-U980,u980ce_1,HS-U980
+Hisense,HS-U980,u980ce_3,HS-U980
+Hisense,HS-U980,u980ce_4,HS-U980
+Hisense,HS-U980,u980ce_5,HS-U980
+Hisense,HS-X5T,X5T,HS-X5T
+Hisense,HS-X68T,x68t,HS-X68T
+Hisense,HS-X6T,X6T,HS-X6T
+Hisense,HS-X8C,x8c,HS-X8C
+Hisense,HS-X8T,X8T,HS-X8T
+Hisense,HS-X8U,x8u,HS-X8U
+Hisense,Hisense E76MINIM,HS8937QC,Hisense E76MINIM
+Hisense,Hisense E77,HS8937QC,Hisense E77
+Hisense,Hisense F24,HS6737MT,Hisense F24
+Hisense,Hisense F8 MINI,HSSC9850,Hisense F8 MINI
+Hisense,Hisense M36,HS8909QC,Hisense M36
+Hisense,Hisense P1,HS8953QC,Hisense P1
+Hisense,Hisense T5,HS6737MT,Hisense T5
+Hisense,I300T,I300T,Hisense I300T
+Hisense,I56D2G,HS8929QC,Andromax I56D2G
+Hisense,I630U,I630U,Hisense I630U
+Hisense,I631M,i631m,Hisense I631M
+Hisense,I632M,I632M,Hisense I632M
+Hisense,I632T,I632T,Hisense I632T
+Hisense,I635T,HS8916QC,Hisense I635T
+Hisense,I639M,I639M,Hisense I639M
+Hisense,I639T,I639T,Hisense I639T
+Hisense,I639T,I639TA,Hisense I639T
+Hisense,I639T,I639TA1,Hisense I639T
+Hisense,IRON  2,HS8937QC,IRON 2
+Hisense,K1,HS8937QC,Hisense K1
+Hisense,K220_FHD,mst628,K220_FHD
+Hisense,L635E_1,HS8916QC,Trekker-M1
+Hisense,L671,HS8929QC,HS-L671
+Hisense,L671,HS8929QC,Hisense L671
+Hisense,L671W,HS8929QC,HS-L671
+Hisense,L671W,HS8929QC,Hisense L671
+Hisense,L671WE_1,HS8929QC,Hisense L671
+Hisense,L671WE_2,HS8929QC,Hisense L671
+Hisense,L675,HS6735MT,Hisense L675
+Hisense,L676BE-1,HS8929QC,Hisense L676
+Hisense,L676BE-2,HS8929QC,Hisense L676
+Hisense,L678,HS8916QC,Hisense L678
+Hisense,L681,HS8916QC,L681
+Hisense,L682,HS8916QC,HS-L682
+Hisense,L682,HS8916QC,Hisense L682
+Hisense,L691,l691,HS-L691
+Hisense,L691,l691e_2,HS-L691
+Hisense,L691AE,msm8226,HS-L691
+Hisense,L695,HS8929QC,HS-L695
+Hisense,L695W,HS8929QC,HS-L695
+Hisense,L695W,HS8929QC,Hisense L695
+Hisense,L695WE_2,HS8929QC,Hisense L695
+Hisense,L697,HS8952QC,L697
+Hisense,L730,HS8937QC,STARADDICT 6
+Hisense,LED32G180,hisenseLED32G180,LED32G180
+Hisense,LED32K220,mst628,LED32K220
+Hisense,LED32K280J3D,mt5880,LED32K280J3D
+Hisense,LED32K360,mt5880,LED32K360
+Hisense,LED32K360J,mt5880,LED32K360J
+Hisense,LED32K360J3D,mt5880,LED32K360J3D
+Hisense,LED32K360X3D,mt5880,LED32K360X3D
+Hisense,LED32K370,mt5880,LED32K370
+Hisense,LED32K600J,mt5880,LED32K600J
+Hisense,LED32K600X3D,mt5880,LED32K600X3D
+Hisense,LED32K610X3D,mt5880,LED32K610X3D
+Hisense,LED32L288,mt5880,LED32L288
+Hisense,LED39K280J3D,mt5880,LED39K280J3D
+Hisense,LED39K360J,mt5880,LED39K360J
+Hisense,LED39K360X3D,mt5880,LED39K360X3D
+Hisense,LED39K600X3D,mt5880,LED39K600X3D
+Hisense,LED39K600X3DU,mst901,LED39K600X3DU
+Hisense,LED39K610X3D,mt5880,LED39K610X3D
+Hisense,LED39K680X3DU,mt5327,LED39K680X3DU
+Hisense,LED40K260X3D,mt5880,LED40K260X3D
+Hisense,LED40K360J,mt5880,LED40K360J
+Hisense,LED40K360X3D,mt5880,LED40K360X3D
+Hisense,LED40K370,mt5880,LED40K370
+Hisense,LED40K681X3DU,msd6a918,LED40K681X3DU
+Hisense,LED40L288,mt5880,LED40L288
+Hisense,LED42G200,hisenseLED42G200,LED42G200
+Hisense,LED42K280J3D,mt5880,LED42K280J3D
+Hisense,LED42K330X3D,mt5880,LED42K330X3D
+Hisense,LED42K360J,mt5880,LED42K360J
+Hisense,LED42K360X3D,mt5880,LED42K360X3D
+Hisense,LED42K370,mt5880,LED42K370
+Hisense,LED42K380U,msd6a918,LED42K380U
+Hisense,LED42K560X3D,hisenseLED42K560X3D,LED42K560X3D
+Hisense,LED42K600A3D,mt5880,LED42K600A3D
+Hisense,LED42K600X3D,mt5880,LED42K600X3D
+Hisense,LED42K610J3DP,mt5880,LED42K610J3DP
+Hisense,LED42K610X3D,mt5880,LED42K610X3D
+Hisense,LED42K660X3D,hisenseLED42K660X3D,LED42K660X3D
+Hisense,LED42K680X3DU,mt5327,LED42K680X3DU
+Hisense,LED42L288,mt5880,LED42L288
+Hisense,LED46K260X3D,mt5880,LED46K260X3D
+Hisense,LED46K280J3D,mt5880,LED46K280J3D
+Hisense,LED46K330X3D,mt5880,LED46K330X3D
+Hisense,LED46K360J,mt5880,LED46K360J
+Hisense,LED46K360X3D,mt5880,LED46K360X3D
+Hisense,LED46K660X3D,hisense6a801,LED46K660X3D
+Hisense,LED47K560J3D,hisenseLED47K560J3D,LED47K560J3D
+Hisense,LED47K600X3D,mt5880,LED47K600X3D
+Hisense,LED47K610J3DP,mt5880,LED47K610J3DP
+Hisense,LED48K360X3D,mt5880,LED48K360X3D
+Hisense,LED48K370,mt5880,LED48K370
+Hisense,LED48K380U,msd6a918,LED48K380U
+Hisense,LED48K681X3DU,msd6a918,LED48K681X3DU
+Hisense,LED48L288,mt5880,LED48L288
+Hisense,LED50G05,hisenseLED50G05,LED50G05
+Hisense,LED50K260X3D,mt5880,LED50K260X3D
+Hisense,LED50K360J,mt5880,LED50K360J
+Hisense,LED50K360X3D,mt5880,LED50K360X3D
+Hisense,LED50K370,mt5880,LED50K370
+Hisense,LED50K380U,msd6a918,LED50K380U
+Hisense,LED50K610X3D,mt5880,LED50K610X3D
+Hisense,LED50K660X3D,hisenseLED50K660X3D,LED50K660X3D
+Hisense,LED50K680X3DU,mt5327,LED50K680X3DU
+Hisense,LED50L288,mt5880,LED50L288
+Hisense,LED50XT880G3D,hisenseLED50XT880G3D,LED50XT880G3D
+Hisense,LED50XT880G3DU,mst901,LED50XT880G3DU
+Hisense,LED50XT900X3DU,mt5327,LED50XT900X3DU
+Hisense,LED55K260X3D,mt5880,LED55K260X3D
+Hisense,LED55K360X3D,mt5880,Hisense LED55K360X3D
+Hisense,LED55K370,mt5880,LED55K370
+Hisense,LED55K380U,msd6a918,LED55K380U
+Hisense,LED55K600A3D,mt5880,LED55K600A3D
+Hisense,LED55K600X3D,mt5880,LED55K600X3D
+Hisense,LED55K610X3D,mt5880,LED55K610X3D
+Hisense,LED55K680X3DU,mt5327,LED55K680X3DU
+Hisense,LED55L288,mt5880,LED55L288
+Hisense,LED55XT780G3D,hisenseLED55XT780G3D,LED55XT780G3D
+Hisense,LED55XT810X3DU,msd6a918,LED55XT810X3DU
+Hisense,LED55XT880G3DU,mst901,LED55XT880G3DU
+Hisense,LED55XT900X3DU,mt5327,LED55XT900X3DU
+Hisense,LED58K280J,mt5880,LED58K280J
+Hisense,LED58K280U,mt5327,LED58K280U
+Hisense,LED58K610X3D,mt5880,LED58K610X3D
+Hisense,LED58K680X3DU,mt5327,LED58K680X3DU
+Hisense,LED58XT880G3D,hisenseLED58XT880G3D,LED58XT880G3D
+Hisense,LED58XT880J3DU,mst901,LED58XT880J3DU
+Hisense,LED60K380,mt5327,LED60K380
+Hisense,LED65K560J3DTB,hisenseLED65K560J3DTB,LED65K560J3DTB
+Hisense,LED65K560J3DTR,hisenseLED65K560J3DTR,LED65K560J3DTR
+Hisense,LED65K600X3D,mt5880,LED65K600X3D
+Hisense,LED65K680X3DU,mt5327,LED65K680X3DU
+Hisense,LED65XT780G3D,hisenseLED65XT780G3D,LED65XT780G3D
+Hisense,LED65XT800X3DU,mt5327,LED65XT800X3DU
+Hisense,LED65XT810X3DU,msd6a918,LED65XT810X3DU
+Hisense,LED65XT880G3D,hisenseLED65XT880G3D,LED65XT880G3D
+Hisense,LED65XT880G3DF,hisenseLED65XT880G3DF,LED65XT880G3DF
+Hisense,LED65XT880G3DU,mst901,LED65XT880G3DU
+Hisense,LED65XT890G3D,hisenseLED65XT890G3D,LED65XT890G3D
+Hisense,LED65XT900G3DU,mst901,LED65XT900G3DU
+Hisense,LED65XT900X3DU,mt5327,LED65XT900X3DU
+Hisense,LED75XT890G3D,mst901,LED75XT890G3D
+Hisense,LED75XT910G3DU,mt5327,LED75XT910G3DU
+Hisense,LED84XT900G3D,hisenseLED84XT900G3D,LED84XT900G3D
+Hisense,LED85XT910G3DU,mt5327,Vision20
+Hisense,LT100K6900A,mt5327,LT100K6900A
+Hisense,LT610,LT610,LT610
+Hisense,M10-M,HS9830SP,Hisense M10-M
+Hisense,M20- T,HS8909QC,Hisense M20-T
+Hisense,M20-M,HS9830SP,Hisense M20-M
+Hisense,M30,HS8909QC,Hisense M30
+Hisense,M30M,HS9830SP,Hisense M30M
+Hisense,M30T,HS8909QC,Hisense M30T
+Hisense,M3101BCD,m3101bcd,M3101BCD
+Hisense,M36,HS8909QC,Hisense M36
+Hisense,M470BSA,m470,M470BSA
+Hisense,M470BSD,m470bsd,M470BSD
+Hisense,M470BSE,m470bse,M470BSE
+Hisense,M470BSG,m470bsg,M470BSG
+Hisense,M470BSS,m470bss,M470BSS
+Hisense,M701,M701,M701
+Hisense,M821,HS8916QC,M821
+Hisense,M821H,HS8916QC,M821H
+Hisense,M821T,HS8916QC,SMART 4G HD Voice
+Hisense,MEDION E4001,E4001,MEDION E4001
+Hisense,MEDION X4701,x4701,MEDION X4701
+Hisense,Oysters Pacific 800,x4701ae,Oysters Pacific 800
+Hisense,PX1900,atm7039c,PX1900
+Hisense,PX1900ES,atm7039c,PX7
+Hisense,PX2000,hisensepx2000,PX2000
+Hisense,PX2700,g18ref,PX2700
+Hisense,PX2800,hisensepx2800,PX2800
+Hisense,PX3000,mt5880,Hisense PX3000
+Hisense,PX3000,mt5880,PX3000
+Hisense,PX3100,mt5880,PX3100
+Hisense,PX510,PX510,PX510
+Hisense,PX530,PX8,PX8
+Hisense,S1,HS8937QC,S1
+Hisense,S51,HS6737MT,S51
+Hisense,SKi630t,msm8226,SKi630t
+Hisense,STARSHINE 4,HS6572MT,STARSHINE 4
+Hisense,STARTRAIL  9,HS6737MT,S40
+Hisense,STARTRAIL  9,HS6737MT,STARTRAIL 9
+Hisense,STARTRAIL 6 4G,L681,STARTRAIL 6 4G
+Hisense,SX41,HS6737MT,SX41
+Hisense,Sero 7,rk3168,E2171CA
+Hisense,Sero 7,rk3168,E2171MX
+Hisense,Sero 7,rk3168,E2171TK
+Hisense,Sero 8,rk3188,E2281
+Hisense,Sero 8,rk3188,E2281CA
+Hisense,Sero 8,rk3188,E2281MX
+Hisense,Sero 8,rk3188,E2281TK
+Hisense,Sero 8,rk3188,E2281UK
+Hisense,Sero 8 pro,rk3288,F5281
+Hisense,Sero7,rk3168,E2171SS
+Hisense,Sero7 LE,rk3026,E2371
+Hisense,Sero8,rk3188,E2281SS
+Hisense,SoundTab MA-317,rk3028a,Hisense SoundTab MA-317
+Hisense,SoundTab MA-327,rk3028a,Hisense SoundTab MA-327
+Hisense,T963,HS7331CSC,Hisense T963
+Hisense,TV,hisense_gx1200v,hisense_gx1200v
+Hisense,U601S,HS7731CSP,Hisense U601S
+Hisense,U602,HS6580MT,HS-U602
+Hisense,U606,U606,STARSHINE III
+Hisense,U606AE,U606AE,HS-U606
+Hisense,U606AE,U606AE,PHS-402
+Hisense,U607,U607,Bouygues Telecom Bs 403
+Hisense,U609,U609,HS-U609
+Hisense,U610,U610,HS-U610
+Hisense,U610,U610E_1,HS-U610
+Hisense,U688,U688,HS-U688
+Hisense,U688BE,MSM8212,HS-U688
+Hisense,U800,U800,HS-U800
+Hisense,U800E-1,U800E_1,HS-U800
+Hisense,U800E-1,U800E_1,HS-U800E-1
+Hisense,U963,HS7331CSC,Hisense U963
+Hisense,U963,HS7331CSC,RIVIERA U963
+Hisense,U966,u966e_1,U966
+Hisense,U970,u970e_8,U970
+Hisense,U988,U988,HS-U988
+Hisense,U988AE,MSM8212,HS-U988
+Hisense,U988E-1,U988E_1,HS-U988
+Hisense,U988E-2,U988E_2,HS-U988
+Hisense,U989,HS6580MT,Hisense U989
+Hisense,U989 Pro,HS6580MT,Hisense U989 Pro
+Hisense,VH777,VH777,VH777
+Hisense,VIDAA_TV,Hi3751,VIDAA_TV
+Hisense,VIDAA_TV,Hi3751v551,VIDAA_TV
+Hisense,VIDAA_TV,Hi3751v620,VIDAA_TV
+Hisense,VIDAA_TV,MSD6A648,VIDAA_TV
+Hisense,VIDAA_TV,MSD6A828,VIDAA_TV
+Hisense,VIDAA_TV,MSD6A838,VIDAA_TV
+Hisense,VIDAA_TV,MSD6A938,VIDAA_TV
+Hisense,VIDAA_TV,mt5861,VIDAA_TV
+Hisense,VIDAA_TV,mt5890,VIDAA_TV
+Hisense,Vidaa,helium3,H7
+Hisense,Vision,Vision,Vision
+Hisense,Vision 2.5,vision2_5,vision2_5
+Hisense,W2,EG606_YE,W2
+Hisense,W270BD,W270BD,W270BD
+Hisense,WA912,U912ATW,WA912
+Hisense,WA960,U960Q_1,WA960
+Hisense,WM8,wm8980s,WM8
+Hisense,X1E1,X1E1,HS-X1
+Hisense,XOLO,us9230e1,XOLO T1000
+Hisense,c20,HS8929QC,Hisense C20
+Hisense,c20ae,HS8929QC,C20
+Hisense,c20fe-3,HS8929QC,Hisense C20
+Hisense,e76mini,HS8937QC,Hisense E76mini
+Hisense,l676be,HS8929QC,Hisense L676
+Hisense,l691,msm8226,HS-L691
+Hisense,l830,HS8937QC,Hisense L830
+Hisense,l830,HS8937QC,STARXTREM 6
+Hisense,lt971,LT971,LT971
+Hisense,u972,HS7731SP,U972
+Hisense,vision2_1,vision2_1,vision2_1
+Hoffmann,X Max,X-Max,X-Max
+"Hon Hai Precision Industry Co., Ltd.",,EP10_wifi,PocketBook A10
+"Hon Hai Precision Industry Co., Ltd.",,EP5A_wifi,PocketBook A7
+"Hon Hai Precision Industry Co., Ltd.",Germany,S9714,LIFETAB_S9714
+"Hon Hai Precision Industry Co., Ltd.",nabi_XD,XD,NABIXD-NV10C
+Honda,A-DA,e1853,14A-DA
+Honda,A-DA,e1853,MY15ADA
+Honda,A-DA,sakura,MY18ADA
+Honda,A-DA,vcm30t30,MY17ADA
+Honda,A-DA,vcm30t30,MY18ADA
+Honda,Accord,koelsch,MY16ADA
+Honda,MY15ADA,koelsch,MY15ADA
+Honda,NSX,koelsch,MY15ADA
+Honda,Pilot,koelsch,MY15ADA
+Honda,Ridgeline,koelsch,MY15ADA
+Honda,Spirior,koelsch,MY15ADA
+Honda,Unit Assy AVN,h16,SiRFSoC Android
+Honeywell,70eL00,dblack,Dolphin 70e Black
+Honeywell,70eLGN,dblack_gn,Dolphin 70e Black
+Honeywell,70eLGN,dblack_go,Dolphin 70e Black
+Honeywell,70eLW0,dblack_wo,Dolphin 70e Black
+Honeywell,70eLWN,dblack_wn,Dolphin 70e Black
+Honeywell,CK75,CK75,CX75 AC0
+Honeywell,CK75,CK75,CX75 AN0
+Honeywell,CN51,CN51_NC0,CN51 NC0
+Honeywell,CN51,CN51_NCF,CN51 NCF
+Honeywell,CN51,CN51_NCU,CN51 NCU
+Honeywell,CN51,CN51_NN0,CN51 NN0
+Honeywell,CN51,CN51_QC0,CN51 QC0
+Honeywell,CN51,CN51_QCF,CN51 QCF
+Honeywell,CN51,CN51_QCU,CN51 QCU
+Honeywell,CN51,CN51_QN0,CN51 QN0
+Honeywell,CN75,CN75,CX75 NC0
+Honeywell,CN75,CN75,CX75 NCF
+Honeywell,CN75,CN75,CX75 QC0
+Honeywell,CN75,CN75,CX75 QCF
+Honeywell,CN75E,CN75E,CX75 NC0
+Honeywell,CN75E,CN75E,CX75 NCF
+Honeywell,CN75E,CN75E,CX75 QC0
+Honeywell,CN75E,CN75E,CX75 QCF
+Honeywell,CT50,CT50L0N-CS12S,CT50
+Honeywell,CT50,CT50L0N-CS15S,CT50
+Honeywell,CT50,CT50L0N-CS16S,CT50
+Honeywell,CT50,CT50LFN-CS16S,CT50
+Honeywell,CT50,CT50LUN-CS12S,CT50
+Honeywell,CT50,CT50LUN-CS15S,CT50
+Honeywell,CT50,CT50LUN-CS16S,CT50
+Honeywell,CT60,CT60-L0N-ASC,CT60
+Honeywell,D75E,75E-L0N,D75E
+Honeywell,Dolphin 70e Black,dblack_gn,Dolphin 70e Black
+Honeywell,Dolphin 70e Black,dblack_go,Dolphin 70e Black
+Honeywell,Dolphin 70e Black,dblack_wn,Dolphin 70e Black
+Honeywell,Dolphin 70e Black,dblack_wo,Dolphin 70e Black
+Honeywell,Dolphin CT50,CT50L0N-CS13S,CT50
+Honeywell,Dolphin CT50,CT50LFN-CS13S,CT50
+Honeywell,Dolphin CT50,CT50LUN-CS13S,CT50
+Honeywell,EDA50,eda50-011,EDA50
+Honeywell,EDA50,eda50-111,EDA50
+Honeywell,EDA50,eda50-111,Glory50
+Honeywell,EDA50,eda50-211,EDA50
+Honeywell,EDA50K,eda50k-0,EDA50K
+Honeywell,EDA50K,eda50k-1,EDA50K
+Honeywell,EDA50K,eda50k-1,Glory EDA50K
+Honeywell,EDA70,eda70-0,EDA70
+Honeywell,EDA70,eda70-3,EDA70
+Honeywell,EdA50,eda50-211,EDA50
+Hotwav,HOT 6,HOT_6,HOT 6
+Hotwav,Magic 6,Magic_6,Magic 6
+Hotwav,Magic 8,Magic_8,Magic 8
+How,1001-G,1001-G,1001-G
+How,HT-704,HT704,HT-704
+How,HT-704plus,HT704plus,HT-704plus
+How,HT704-G,704-G,704-G
+Huawei,,C8600,C8600
+Huawei,,CHT8000,CHT8000
+Huawei,,HuaweiU8180,Huawei Ideos X1
+Huawei,,HuaweiU8180,HuaweiU8180
+Huawei,,HuaweiU8180,IDEOS X1
+Huawei,,HuaweiU8180,Kyivstar Terra
+Huawei,,HuaweiU8180,Starshine
+Huawei,,HuaweiU8180,Stockholm
+Huawei,,HuaweiU8180,U8180
+Huawei,,Pulse,Pulse
+Huawei,,T8300,HUAWEI T8300
+Huawei,,T8600,HUAWEI T8600
+Huawei,,T8828,HUAWEI T8828
+Huawei,,U8110,EQ U8110
+Huawei,,U8110,Huawei
+Huawei,,U8110,Huawei U8110
+Huawei,,U8110,MTC_A
+Huawei,,U8110,Pulse Mini
+Huawei,,U8110,TSP21
+Huawei,,U8110,Turkcell T10
+Huawei,,U8110,U8110
+Huawei,,U8110,life:) Android
+Huawei,,U8300,U8300
+Huawei,,U8500,HUAWEI IDEOS U8500
+Huawei,,U8500,MTC_EVO
+Huawei,,dtab01,dtab01
+Huawei,,hwC8813Q,HUAWEI C8813Q
+Huawei,,hwC8860E,HUAWEI C8860E
+Huawei,,hwG520-T10,HUAWEI G520-T10
+Huawei,,hwS42HW,S42HW
+Huawei,,hwS7-901w,A01HW
+Huawei,,hwT8830Pro,T8830Pro
+Huawei,,hwU9202L,U9202L-1
+Huawei,,hwU9202L,U9202L-3
+Huawei,,hwc8500,C8500
+Huawei,,hwc8511,C8511
+Huawei,,hwc8511,MTS-SP101
+Huawei,,hwc8512,C8512
+Huawei,,hwc8600,C8600
+Huawei,,hwc8650,C8650
+Huawei,,hwc8650e,HUAWEI C8650+
+Huawei,,hwc8655,HUAWEI C8655
+Huawei,,hwc8800,C8800
+Huawei,,hwc8800,MTS-SP140
+Huawei,,hwc8810,HUAWEI C8810
+Huawei,,hwc8812E,HUAWEI C8812E
+Huawei,,hwc8813,HUAWEI C8813
+Huawei,,hwc8825D,HUAWEI C8825D
+Huawei,,hwc8860E,HUAWEI C8860E
+Huawei,,hwc8860V,C8860V
+Huawei,,hwc8950D,HUAWEI C8950D
+Huawei,,hwcm980,CM980
+Huawei,,hwh866c,H866C
+Huawei,,hwh866c,HUAWEI H866C
+Huawei,,hwh867g,Huawei-H867G
+Huawei,,hwh868c,HUAWEI H868C
+Huawei,,hwh881c,HUAWEI H881C
+Huawei,,hwm650,Express
+Huawei,,hwm650,M650
+Huawei,,hwm660,M660
+Huawei,,hwm860,HUAWEI-M860
+Huawei,,hwm865c,M865C
+Huawei,,hwm866,HUAWEI M866
+Huawei,,hwm866,M866
+Huawei,,hwm866,USCCADR3310
+Huawei,,hwm886,M886
+Huawei,,hwm920,HUAWEI-M920
+Huawei,,hwm931,HUAWEI-M931
+Huawei,,hwp2-0000,HUAWEI P2-0000
+Huawei,,hwp2-6011,HUAWEI P2-6011
+Huawei,,hwp2-6011,HUAWEI P2-6011-orange
+Huawei,,hws10101u,MediaPad 10 FHD
+Huawei,,hws10101w,GT01
+Huawei,,hws10101w,MediaPad 10 FHD
+Huawei,,hws10201u,MediaPad 10 LINK
+Huawei,,hws7300c,HUAWEI MediaPad
+Huawei,,hws7300u,HUAWEI MediaPad
+Huawei,,hws7300u,Huawei S7-312u
+Huawei,,hws7300u,MediaPad
+Huawei,,hws7300u,SpringBoard
+Huawei,,hws7300w,HUAWEI MediaPad
+Huawei,,hws7930w,MediaPad 7 Lite
+Huawei,,hwt8620,T8620
+Huawei,,hwt8830,T8830
+Huawei,,hwt8833,HUAWEI T8833
+Huawei,,hwt8950,HUAWEI T8950
+Huawei,,hwt8950N,HUAWEI T8950N
+Huawei,,hwt8951,HUAWEI T8951
+Huawei,,hwt9200,T9200
+Huawei,,hwt9510e,T9510E
+Huawei,,hwu8180,Netphone 501
+Huawei,,hwu8180,U8180
+Huawei,,hwu8185,U8185
+Huawei,,hwu8186,U8186
+Huawei,,hwu8230,U8230
+Huawei,,hwu8350,Barcelona
+Huawei,,hwu8350,GM FOX
+Huawei,,hwu8350,HuaweiU8350
+Huawei,,hwu8350,MTC Pro
+Huawei,,hwu8350,Personal U8350
+Huawei,,hwu8350,Temptation
+Huawei,,hwu8350,U8350
+Huawei,,hwu8350,U8350-51
+Huawei,,hwu8500,Grameenphone Crystal
+Huawei,,hwu8500,HUAWEI_IDEOS_U8500
+Huawei,,hwu8500,HuaweiU8500
+Huawei,,hwu8500,ICE
+Huawei,,hwu8500,MF8503
+Huawei,,hwu8500,MTC Evo
+Huawei,,hwu8500,MegaFon U8500
+Huawei,,hwu8500,U8500
+Huawei,,hwu8510,Beeline_E500
+Huawei,,hwu8510,GM Ultimate Slim
+Huawei,,hwu8510,Huawei IDEOS X3
+Huawei,,hwu8510,HuaweiU8510
+Huawei,,hwu8510,MTC Bravo
+Huawei,,hwu8510,S41HW
+Huawei,,hwu8510,U8510
+Huawei,,hwu8520,U8520
+Huawei,,hwu8600,U8600
+Huawei,,hwu8650,HUAWEI SONIC
+Huawei,,hwu8650,HUAWEI_IDEOS_U8650
+Huawei,,hwu8650,HuaweiU8650
+Huawei,,hwu8650,Kyivstar Aqua
+Huawei,,hwu8650,MTC 955
+Huawei,,hwu8650,SONIC
+Huawei,,hwu8650,Turkcell T20
+Huawei,,hwu8650,U8650
+Huawei,,hwu8650,U8650-1
+Huawei,,hwu8651,Astro
+Huawei,,hwu8651,Prism
+Huawei,,hwu8651,U8651
+Huawei,,hwu8651,U8651T
+Huawei,,hwu8652-51,U8652-51
+Huawei,,hwu8655,Etisalat
+Huawei,,hwu8655,HUAWEI IDEOS Y 200
+Huawei,,hwu8655,Personal U8655-51
+Huawei,,hwu8655,STARTRAIL II
+Huawei,,hwu8655,U8655
+Huawei,,hwu8655,U8655-1
+Huawei,,hwu8655,U8655-51
+Huawei,,hwu8660,SONIC
+Huawei,,hwu8661,HUAWEI U8661
+Huawei,,hwu8666,MTC Fit
+Huawei,,hwu8666,U8666-1
+Huawei,,hwu8666,U8666-51
+Huawei,,hwu8666-51,U8666-51
+Huawei,,hwu8666e,HUAWEI U8666E
+Huawei,,hwu8666e,MegaFon SP-A3
+Huawei,,hwu8666e-51,HUAWEI U8666E
+Huawei,,hwu8666e-51,HUAWEI U8666E-51
+Huawei,,hwu8666n,HUAWEI U8666N
+Huawei,,hwu8667,U8667
+Huawei,,hwu8680,T-Mobile myTouch
+Huawei,,hwu8681,HUAWEI U8681
+Huawei,,hwu8730,T-Mobile myTouch Q
+Huawei,,hwu8800,IDEOS X5
+Huawei,,hwu8800,MTC Neo
+Huawei,,hwu8800,U8800
+Huawei,,hwu8800,Ucell
+Huawei,,hwu8800,u8800
+Huawei,,hwu8800Pro,HUAWEI_IDEOS_X5
+Huawei,,hwu8800Pro,HuaweiU8800Pro
+Huawei,,hwu8800Pro,IDEOS X5
+Huawei,,hwu8800Pro,MTC Neo
+Huawei,,hwu8800Pro,RBM_HD
+Huawei,,hwu8800Pro,U8800 Pro
+Huawei,,hwu8800Pro,U8800Pro
+Huawei,,hwu8815,HUAWEI Ascend G 300
+Huawei,,hwu8815,HUAWEI U8815
+Huawei,,hwu8815,HUAWEI_Ascend G 300
+Huawei,,hwu8815,Personal U8815-51
+Huawei,,hwu8815,U8815
+Huawei,,hwu8815,U8815-51
+Huawei,,hwu8815n,HUAWEI U8815N
+Huawei,,hwu8815n,U8815N
+Huawei,,hwu8816,MTC Viva
+Huawei,,hwu8816,U8816
+Huawei,,hwu8818,HUAWEI U8818
+Huawei,,hwu8818,U8818
+Huawei,,hwu8820,U8820
+Huawei,,hwu8825-1,Bs 401
+Huawei,,hwu8825-1,HUAWEI Ascend G 330
+Huawei,,hwu8825-1,HUAWEI U8825-1
+Huawei,,hwu8825D,HUAWEI U8825D
+Huawei,,hwu8850,007HW
+Huawei,,hwu8860,GS02
+Huawei,,hwu8860,HUAWEI_U8860
+Huawei,,hwu8860,TURKCELL MaxiPRO5
+Huawei,,hwu8860,U8860
+Huawei,,hwu8860,U8860-51
+Huawei,,hwu8867Z,U8867Z
+Huawei,,hwu8950-1,HUAWEI U8950-1
+Huawei,,hwu8950-51,HUAWEI U8950-51
+Huawei,,hwu8950D,HUAWEI U8950D
+Huawei,,hwu8950N-1,HUAWEI U8950N-1
+Huawei,,hwu8950N-51,HUAWEI U8950N-51
+Huawei,,hwu9200,U9200
+Huawei,,hwu9200,U9200E
+Huawei,,hwu9200-92,GS03
+Huawei,,hwu9200-92,U9200
+Huawei,,hwu9200E,U9200E
+Huawei,,hwu9201L,201HW
+Huawei,,hwu9500,U9500E
+Huawei,,hwu9501L,HW-01E
+Huawei,,hwu9508,HUAWEI U9508
+Huawei,,hwu9510,HUAWEI U9510
+Huawei,,hwu9510,U9510
+Huawei,,hwu9510e,HUAWEI U9510E
+Huawei,,hwu9700L,GL07S
+Huawei,,hwum840,UM840
+Huawei,,hwy210-0010,HUAWEI Y210-0010
+Huawei,,hwy210-0100,HUAWEI Ascend Y 210
+Huawei,,hwy210-0100,HUAWEI Y210-0100
+Huawei,,hwy210-0151,HUAWEI Y210-0151
+Huawei,,hwy210-0200,HUAWEI Ascend Y 210D
+Huawei,,hwy210-0200,HUAWEI Asend Y 210D
+Huawei,,hwy210-0200,HUAWEI Y210-0200
+Huawei,,hwy210-0200,Leopard MF808
+Huawei,,hwy210-0200,NATCOM N8302
+Huawei,,hwy210-0200,VIETTEL V8404
+Huawei,,hwy210-0251,HUAWEI Y210-0251
+Huawei,,hwy210-2010,HUAWEI Y210-2010
+Huawei,,msm7201a,Pulse
+Huawei,,msm7201a,U8230
+Huawei,,msm7225,Beeline_E300
+Huawei,,msm7225,Grameenphone Crystal
+Huawei,,msm7225,HUAWEI IDEOS U8500
+Huawei,,msm7225,HUAWEI_IDEOS_U8500
+Huawei,,msm7225,Huawei
+Huawei,,msm7225,HuaweiU8300
+Huawei,,msm7225,Ideos
+Huawei,,msm7225,MTC Evo
+Huawei,,msm7225,Pulse Mini
+Huawei,,msm7225,RBM C
+Huawei,,msm7225,S31HW
+Huawei,,msm7225,Smile
+Huawei,,msm7225,Tactile internet
+Huawei,,msm7225,Turkcell T10
+Huawei,,msm7225,U8110
+Huawei,,msm7225,U8300
+Huawei,,msm7225,U8500
+Huawei,,msm7225,Vodafone 845
+Huawei,,msm7227,004HW
+Huawei,,msm7230,IDEOS X5
+Huawei,,msm7230,u8800
+Huawei,,msm7625,C8600
+Huawei,,msm7625,HUAWEI-M860
+Huawei,,msm7625,Ideos
+Huawei,,msm7625,M860
+Huawei,,msm7625,U8180
+Huawei,,orinoquiac8688V,ORINOQUIA C8688V
+Huawei,,qsd8k_s7,HUAWEI-S7
+Huawei,,qsd8k_s7,IDEOS S7
+Huawei,,qsd8k_s7,Ideos S7
+Huawei,,qsd8k_s7,Oysters SmaKit S7
+Huawei,,qsd8k_s7,S7
+Huawei,,qsd8k_slim,IDEOS S7 Slim
+Huawei,,u8800,u8800
+Huawei,A199,hwa199,HUAWEI A199
+Huawei,ATH-TL00,HWATH,ATH-TL00
+Huawei,ATH-TL00H,HWATH,ATH-TL00H
+Huawei,ATH-UL00,HWATH,ATH-UL00
+Huawei,Ascend D,hwu9500,U9500
+Huawei,Ascend G510,hwG510-0251,HUAWEI G510-0251
+Huawei,Ascend G525,hwG525-U00,HUAWEI Ascend G525
+Huawei,Ascend G525,hwG525-U00,HUAWEI G525-U00
+Huawei,B199,hwB199,HUAWEI B199
+Huawei,C199,hwC199,HUAWEI C199
+Huawei,C199s,hwC199s,HUAWEI C199s
+Huawei,C8812,hwc8812,HUAWEI C8812
+Huawei,C8813D,hwc8813,HUAWEI C8813D
+Huawei,C8813DQ,hwC8813DQ,HUAWEI C8813DQ
+Huawei,C8815,hwC8815,HUAWEI C8815
+Huawei,C8816,hwC8816,HUAWEI C8816
+Huawei,C8816D,hwC8816D,HUAWEI C8816D
+Huawei,C8817D,hwC8817D,C8817D
+Huawei,C8817E,hwC8817E,HUAWEI C8817E
+Huawei,C8817L,hwC8817L,HUAWEI C8817L
+Huawei,C8818,hwC8818,HUAWEI C8818
+Huawei,C8826D,hwc8826D,HUAWEI C8826D
+Huawei,C8850,hwc8850,HUAWEI-C8850
+Huawei,CHC-U03,hwCHC-H,CHC-U03
+Huawei,CHC-U23,hwCHC-H,CHC-U23
+Huawei,CHM-CL00,hwCHM-Q,CHM-CL00
+Huawei,CHM-U01,hwCHM-H,CHM-U01
+Huawei,CM990,hwCM990,CM990
+Huawei,CUN-AL00,HWCUN-L6735,CUN-AL00
+Huawei,CUN-TL00,HWCUN-L6735,CUN-TL00
+Huawei,Che1-CL10,Che1,Che1-CL10
+Huawei,Che1-CL20,Che1,Che1-CL20
+Huawei,Che1-L04,Che1,Che1-L04
+Huawei,Che2-L11,hwChe2,Che2-L11
+Huawei,Che2-L23,hwChe2,Che2-L23
+Huawei,Che2-TL00,hwChe2,Che2-TL00
+Huawei,Che2-TL00H,hwChe2,Che2-TL00H
+Huawei,Che2-TL00M,hwChe2,Che2-TL00M
+Huawei,Che2-UL00,hwChe2,Che2-UL00
+Huawei,Cherry Mini,hwCHC-H,CHC-U01
+Huawei,China,m330,M330
+Huawei,Copper Plus,HWH1611-Q,H1611
+Huawei,Copper Plus,HWH1611-Q,HUAWEI H1611
+Huawei,D2,hwD2-0082,HUAWEI D2-0082
+Huawei,D2,hwD2-2010,HUAWEI D2-2010
+Huawei,D2,hwD2-6070,HUAWEI D2-6070
+Huawei,DAV,HWP8max,HUAWEI P8max
+Huawei,ECO,HWLUA-L6735,HUAWEI LUA-L03
+Huawei,ECO,HWLUA-L6735,HUAWEI LUA-L13
+Huawei,ECO,HWLUA-L6735,HUAWEI LUA-L23
+Huawei,ECO,HWLUA-U6582,HUAWEI LUA-U03
+Huawei,ECO,HWLUA-U6582,HUAWEI LUA-U23
+Huawei,ES8100,hwes8100,ES8100
+Huawei,ES8500,hwes8500,HuaweiES8500
+Huawei,FRD-L02,HWFRD,FRD-L02
+Huawei,Fusion 2,hwu8665,Huawei-U8665
+Huawei,G350,hwg350,HUAWEI G350
+Huawei,G350,hwg350,HUAWEI G350-U00
+Huawei,G350-U20,HWG350,HUAWEI G350-U20
+Huawei,G506,hwG506-U151,HUAWEI G506-U151
+Huawei,G510,hwG510-0010,HUAWEI G510-0010
+Huawei,G510,hwG510-0100,HUAWEI G510-0100
+Huawei,G510,hwG510-0100,HuaweiG510-0100
+Huawei,G510,hwG510-0100,HuaweiG510-0100-orange
+Huawei,G510,hwG510-0200,HUAWEI Ascend G510
+Huawei,G510,hwG510-0200,HUAWEI G510-0200
+Huawei,G510,hwG510-0200,Orange Daytona
+Huawei,G520,hwG520-5000,HUAWEI G520-5000
+Huawei,G521-L076,HWG521-L,HUAWEI G521-L076
+Huawei,G521-L176,HWG521-L,HUAWEI G521-L176
+Huawei,G526,hwG526-L11,G526-L11
+Huawei,G526,hwG526-L22,G526-L22
+Huawei,G526,hwG526-L33,G526-L33
+Huawei,G527,hwG527-U081,G527-U081
+Huawei,G535-L11,hwG535-L11,HUAWEI G535-L11
+Huawei,G535-L11,hwG535-L11,Kestrel
+Huawei,G535-L11,hwG535-L11,Orange Gova
+Huawei,G535-L11,hwG535-L11,Speedsurfer
+Huawei,G535-L11,hwG535-L11,Ultym5
+Huawei,G6,hwG6-T00,HUAWEI G6-T00
+Huawei,G6-C00,hwG6-C00,HUAWEI G6-C00
+Huawei,G6-L11,hwG6-L11,HUAWEI G6-L11
+Huawei,G6-L22,hwG6-L22,HUAWEI G6-L22
+Huawei,G6-L33,hwG6-L33,HUAWEI G6-L33
+Huawei,G6-U00,hwG6-U00,HUAWEI G6-U00
+Huawei,G6-U10,hwG6-U10,HUAWEI G6-U10
+Huawei,G6-U251,hwG6-U251,HUAWEI G6-U251
+Huawei,G6-U34,hwG6-U34,HUAWEI G6-U34
+Huawei,G606,HWG606,HUAWEI G606-T00
+Huawei,G606-T00,HWG606-T00,HUAWEI G606-T00
+Huawei,G610,hwG610-T00,HUAWEI G610-T00
+Huawei,G610,hwG610-U00,G610-U00
+Huawei,G610,hwG610-U00,HUAWEI G610-U00
+Huawei,G610,hwG610-U30,HUAWEI G610-U30
+Huawei,G610-T01,hwG610-T01,HUAWEI G610-T01
+Huawei,G610-T11,hwG610-T11,HUAWEI G610-T11
+Huawei,G610-U15,hwG610-U15,HUAWEI G610-U15
+Huawei,G610-U20,hwG610-U20,HUAWEI G610-U20
+Huawei,G610C,hwG610-C00,HUAWEI G610-C00
+Huawei,G615-U10,hwG615-U10,G615-U10
+Huawei,G615-U10,hwG615-U10,HUAWEI G615-U10
+Huawei,G616-L076,HWG616-L,HUAWEI G616-L076
+Huawei,G620-A2,hwG620-A2,HUAWEI G620-A2
+Huawei,G620-L72,hwG620-L72,HUAWEI G620-L72
+Huawei,G620-L75,hwG620-L75,G620-L75
+Huawei,G620S-L01,hwG620S-L01,G620S-L01
+Huawei,G620S-L02,hwG620S-L02,G620S-L02
+Huawei,G620S-L03,hwG620S-L03,G620S-L03
+Huawei,G620S-L03,hwG620S-L03,HUAWEI G620
+Huawei,G620S-L03,hwG620S-L03,Personal Huawei G620S
+Huawei,G620S-UL00,hwG620S-UL00,G620S-UL00
+Huawei,G621-TL00,hwG621-TL00,G621-TL00
+Huawei,G621-TL00M,hwG621-TL00,G621-TL00M
+Huawei,G628-TL00,HWG628-TL,HUAWEI G628-TL00
+Huawei,G629-UL00,HWG629-UL,HUAWEI G629-UL00
+Huawei,G630,hwG630-T00,HUAWEI G630-T00
+Huawei,G630-U00,hwG630-U00,HUAWEI G630-U00
+Huawei,G630-U10,hwG630-U10,G630-U10
+Huawei,G630-U20,hwG630-U20,G630-U20
+Huawei,G630-U251,hwG630-U251,G630-U251
+Huawei,G630-U251,hwG630-U251,HUAWEI G630-U251
+Huawei,G660-L075,hwG660-L075,HUAWEI G660-L075
+Huawei,G7 Plus,HWRIO,HUAWEI RIO-TL00
+Huawei,G7 Plus,HWRIO,HUAWEI RIO-UL00
+Huawei,G7-L01,hwG7-L01,G7-L01
+Huawei,G7-L01,hwG7-L01,HUAWEI G7-L01
+Huawei,G7-L02,hwG7-L02,HUAWEI G7-L02
+Huawei,G7-L03,hwG7-L03,G7-L03
+Huawei,G7-L03,hwG7-L03,HUAWEI G7
+Huawei,G7-L03,hwG7-L03,HUAWEI G7-L03
+Huawei,G7-L11,hwG7-L11,HUAWEI G7-L11
+Huawei,G7-TL00,hwG7-TL00,G7-TL00
+Huawei,G7-TL00,hwG7-TL00,HUAWEI G7-TL00
+Huawei,G7-UL20,hwG7-UL20,HUAWEI G7-UL20
+Huawei,G700,hwG700-T00,HUAWEI G700-T00
+Huawei,G700,hwG700-U00,HUAWEI G700-U00
+Huawei,G700-T01,hwG700-T01,HUAWEI G700-T01
+Huawei,G700-U10,hwG700-U10,HUAWEI G700-U10
+Huawei,G700-U20,hwG700-U20,HUAWEI G700-U20
+Huawei,G716,hwG716-L070,HUAWEI G716-L070
+Huawei,G718,hwg718,HUAWEI G718
+Huawei,G730,hwG730-C00,HUAWEI G730-C00
+Huawei,G730,hwG730-T00,HUAWEI G730-T00
+Huawei,G730,hwG730-U00,HUAWEI G730-U00
+Huawei,G730-L075,hwG730-L075,HUAWEI G730-L075
+Huawei,G730-U10,hwG730-U10,HUAWEI G730-U10
+Huawei,G730-U251,hwG730-U251,HUAWEI G730-U251
+Huawei,G730-U27,hwG730-U27,HUAWEI G730-U27
+Huawei,G730-U30,hwG730-U30,HUAWEI G730-U30
+Huawei,G735-L03,hwG735,G735-L03
+Huawei,G735-L12,hwG735,G735-L12
+Huawei,G735-L23,hwG735,G735-L23
+Huawei,G740,hwG740-L00,G740-L00
+Huawei,G740,hwG740-L00,Orange Yumo
+Huawei,G750-T00,hwG750-T00,HUAWEI G750-T00
+Huawei,G750-T01,hwG750-T01,HUAWEI G750-T01
+Huawei,G750-T01M,hwG750-T01M,HUAWEI G750-T01M
+Huawei,G750-T20,hwG750-T20,HUAWEI G750-T20
+Huawei,G750-U10,hwG750-U10,HUAWEI G750-U10
+Huawei,G7500,HWG7500,HUAWEI G7500
+Huawei,G8,HWRIO,HUAWEI RIO-L02
+Huawei,G8,HWRIO,HUAWEI RIO-L03
+Huawei,G8,HWRIO,RIO-L03
+Huawei,G8,hwRIO-L02,HUAWEI RIO-L02
+Huawei,G8,hwRIO-L03,HUAWEI RIO-L03
+Huawei,G9 Plus,HWMLA,HUAWEI MLA-TL00
+Huawei,G9 Plus,HWMLA,HUAWEI MLA-TL10
+Huawei,G9 Plus,HWMLA,HUAWEI MLA-UL00
+Huawei,G9 Plus,HWMLA,MLA-TL00
+Huawei,G9 Plus,HWMLA,MLA-UL00
+Huawei,G9\xe9\x9d\x92\xe6\x98\xa5\xe7\x89\x88,HWVNS-Q,HUAWEI VNS-AL00
+Huawei,GR3,HWTAG-L6753,HUAWEI TAG-L01
+Huawei,GR3,HWTAG-L6753,HUAWEI TAG-L03
+Huawei,GR3,HWTAG-L6753,HUAWEI TAG-L13
+Huawei,GR3,HWTAG-L6753,HUAWEI TAG-L21
+Huawei,GR3,HWTAG-L6753,HUAWEI TAG-L22
+Huawei,GR3,HWTAG-L6753,HUAWEI TAG-L23
+Huawei,GR3 2017,HWDIG-L8940,DIG-L01
+Huawei,GR3 2017,HWDIG-L8940,DIG-L21
+Huawei,GR3 2017,HWDIG-L8940,DIG-L22
+Huawei,GR3 Smart touch,HWTAG-L6753,HUAWEI TAG-L32
+Huawei,GR5,HWKII-Q,HUAWEI KII-L03
+Huawei,GR5,HWKII-Q,HUAWEI KII-L05
+Huawei,GR5,HWKII-Q,HUAWEI KII-L21
+Huawei,GR5,HWKII-Q,HUAWEI KII-L22
+Huawei,GR5,HWKII-Q,HUAWEI KII-L23
+Huawei,GR5,HWKII-Q,HUAWEI KII-L33
+Huawei,GR5,HWKII-Q,KII-L21
+Huawei,GR5W,HWH1621-Q,H1621
+Huawei,GT3,HWNMO-H,HUAWEI NMO-L21
+Huawei,GT3,HWNMO-H,HUAWEI NMO-L22
+Huawei,GT3,HWNMO-H,HUAWEI NMO-L23
+Huawei,GT3,HWNMO-H,HUAWEI NMO-L31
+Huawei,GX8,hwRIO-L01,HUAWEI
+Huawei,GX8,hwRIO-L01,HUAWEI RIO-L01
+Huawei,Gran_Roraima,hws7721u,Orinoquia Gran Roraima + S7-722u
+Huawei,H30-C00,hwH30-C00,H30-C00
+Huawei,H30-L01,hwH30,HONOR H30-L01
+Huawei,H30-L01M,hwH30,HONOR H30-L01M
+Huawei,H30-L02,hwH30,H30-L02
+Huawei,H30-L02,hwH30,HONOR H30-L02
+Huawei,H30-T00,hwH30-T00,H30-T00
+Huawei,H60,hwH60,H60-L01
+Huawei,H60-J1,hwH60,HW-H60-J1
+Huawei,H60-L01,hwH60,H60-L01
+Huawei,H60-L02,hwH60,H60-L02
+Huawei,H60-L03,hwH60,H60-L03
+Huawei,H60-L04,hwH60,H60-L04
+Huawei,H60-L11,hwH60,H60-L11
+Huawei,H60-L12,hwH60,H60-L12
+Huawei,H60-L21,hwH60,H60-L21
+Huawei,H60-L21,hwH60-L21,H60-L21
+Huawei,H871G,hwh871g,HUAWEI H871G
+Huawei,H882L,hwh882l,H882L
+Huawei,H891L,hwH891L,HUAWEI H891L
+Huawei,H892L,hwH892L,HUAWEI H892L
+Huawei,HONOR 4X,hwChe2,Che2-L12
+Huawei,HUAWEI GR5 2017,HWBLN-H,BLL-L21
+Huawei,HUAWEI GR5 2017,HWBLN-H,BLL-L22
+Huawei,HUAWEI GR5 2017,HWBLN-H,HUAWEI BLL-L21
+Huawei,HUAWEI GR5 2017,HWBLN-H,HUAWEI BLL-L22
+Huawei,HUAWEI Mate 9 lite,HWBLN-H,BLL-L23
+Huawei,HUAWEI Mate 9 lite,HWBLN-H,HUAWEI BLL-L23
+Huawei,HUAWEI MediaPad M3 Lite,HWCPN-Q,701HW
+Huawei,HUAWEI MediaPad M3 Lite,HWCPN-Q,702HW
+Huawei,HUAWEI MediaPad M3 Lite,HWCPN-Q,CPN-AL00
+Huawei,HUAWEI MediaPad M3 Lite,HWCPN-Q,CPN-L09
+Huawei,HUAWEI MediaPad M3 Lite,HWCPN-Q,CPN-W09
+Huawei,HUAWEI MediaPad M3 Lite 10 wp,HWHDN-H,HDN-L09
+Huawei,HUAWEI MediaPad M3 Lite 10 wp,HWHDN-H,HDN-W09
+Huawei,HUAWEI MediaPad T3 10,HWAGS-Q,AGS-L03
+Huawei,HUAWEI MediaPad T3 10,HWAGS-Q,AGS-L09
+Huawei,HUAWEI MediaPad T3 10,HWAGS-Q,AGS-W09
+Huawei,HUAWEI Y3 2017,HWCRO-L6737M,CRO-L02
+Huawei,HUAWEI Y3 2017,HWCRO-L6737M,CRO-L22
+Huawei,HUAWEI Y3 2017,HWCRO-L6737M,HUAWEI CRO-L02
+Huawei,HUAWEI Y3 2017,HWCRO-L6737M,HUAWEI CRO-L22
+Huawei,HUAWEI Y5 lite 2017,HWCRO-L6737M,CRO-L03
+Huawei,HUAWEI Y5 lite 2017,HWCRO-L6737M,CRO-L23
+Huawei,HUAWEI Y5 lite 2017,HWCRO-L6737M,HUAWEI CRO-L03
+Huawei,HUAWEI Y5 lite 2017,HWCRO-L6737M,HUAWEI CRO-L23
+Huawei,HUAWEI Y6 2017,HWMYA-L6737,MYA-L11
+Huawei,HUAWEI Y6II,HWCAM-H,HUAWEI CAM-L53
+Huawei,HUAWEI nova 2 Plus,HWBAC,BAC-L21
+Huawei,HUAWEI nova 2 Plus,HWBAC,BAC-L22
+Huawei,HUWEI MediaPad T3,HWKobe-Q,KOB-L09
+Huawei,HUWEI MediaPad T3,HWKobe-Q,KOB-W09
+Huawei,HW-03E,HW-03E,HW-03E
+Huawei,HWT31,hwfdra04l,HWT31
+Huawei,Hol-T00,HWHol-T,Hol-T00
+Huawei,Hol-U10,HWHol-U,Hol-U10
+Huawei,Hol-U19,HWHol-U,Hol-U19
+Huawei,Honor 4A,hnSCC-Q,SCC-U21
+Huawei,Honor 4A,hnSCL-Q,SCL-AL00
+Huawei,Honor 4A,hnSCL-Q,SCL-CL00
+Huawei,Honor 4A,hnSCL-Q,SCL-TL00
+Huawei,Honor 4A,hnSCL-Q,SCL-TL00H
+Huawei,Honor 5A,HWLYO-L6735,HUAWEI LYO-L21
+Huawei,Honor 5A,HWLYO-L6735,LYO-L21
+Huawei,Honor 5C,HNNEM-H,NEM-L21
+Huawei,Honor 5C,HNNEM-H,NEM-L22
+Huawei,Honor 5C,HNNEM-H,NEM-L51
+Huawei,Honor 5X,HNKIW-Q,KIW-L21
+Huawei,Honor 5X,HNKIW-Q,KIW-TL00H
+Huawei,Honor 6A,HWDLI-Q,DLI-L22
+Huawei,Honor 6A,HWDLI-Q,DLI-TL20
+Huawei,Honor 6X,HWBLN-H,BLN-L24
+Huawei,Honor 7,HWPLK,PLK-AL10
+Huawei,Honor 7,HWPLK,PLK-CL00
+Huawei,Honor 7,HWPLK,PLK-L01
+Huawei,Honor 7,HWPLK,PLK-TL00
+Huawei,Honor 7,HWPLK,PLK-TL01H
+Huawei,Honor 7,HWPLK,PLK-UL00
+Huawei,Honor 7X,HWBND-H,BND-L21
+Huawei,Honor 7X,HWBND-H,BND-L24
+Huawei,Honor 7i,HWATH,ATH-AL00
+Huawei,Honor 7i,HWATH,ATH-CL00
+Huawei,Honor 8,HWFRD,FRD-AL00
+Huawei,Honor 8,HWFRD,FRD-AL10
+Huawei,Honor 8,HWFRD,FRD-DL00
+Huawei,Honor 8,HWFRD,FRD-L04
+Huawei,Honor 8,HWFRD,FRD-L09
+Huawei,Honor 8,HWFRD,FRD-L14
+Huawei,Honor 8,HWFRD,FRD-L19
+Huawei,Honor 8,HWFRD,FRD-TL00
+Huawei,Honor 8 Pro,HWDUK,DUK-L09
+Huawei,Honor 8 Smart,HWVNS-H,VEN-L22
+Huawei,Honor 9,HWSTF,STF-AL00
+Huawei,Honor 9,HWSTF,STF-AL10
+Huawei,Honor 9,HWSTF,STF-L09
+Huawei,Honor 9,HWSTF,STF-TL10
+Huawei,Honor Box,m321,M321
+Huawei,Honor Box Pro,hwHiTV-M1,HiTV-M1
+Huawei,Honor Box voice,HWM311,M311
+Huawei,Honor Magic,HWNTS,HUAWEI NTS-AL00
+Huawei,Honor Magic,HWNTS,NTS-AL00
+Huawei,Honor V10,HWBKL,BKL-AL00
+Huawei,Honor V10,HWBKL,BKL-AL20
+Huawei,Honor V10,HWBKL,BKL-TL10
+Huawei,Honor V8,HWKNT,KNT-AL10
+Huawei,Honor V8,HWKNT,KNT-AL20
+Huawei,Honor V8,HWKNT,KNT-TL10
+Huawei,Honor V8,HWKNT,KNT-UL10
+Huawei,Honor V9,HWDUK,DUK-AL20
+Huawei,Honor V9,HWDUK,DUK-TL30
+Huawei,Honor View 10,HWBKL,BKL-L09
+Huawei,Honor3,hwH30-T10,H30-T10
+Huawei,Honor3,hwH30-U10,H30-U10
+Huawei,Honor3,hwhn3-u00,HUAWEI HN3-U00
+Huawei,Honor3,hwhn3-u01,HUAWEI HN3-U01
+Huawei,Huawei Nova 2,HWPIC,PIC-LX9
+Huawei,IDEOS,U8150,Comet
+Huawei,IDEOS,U8150,Ideos
+Huawei,IDEOS,u8150,Ideos
+Huawei,Ice-Twist,Ice-Twist,Ice-Twist
+Huawei,Ideos X5,hwu8800-51,Huawei U8800-51
+Huawei,Ideos X5,hwu8800-51,IDEOS X5
+Huawei,Ideos X5,hwu8800-51,U8800
+Huawei,Ideos X5,hwu8800-51,U8800-51
+Huawei,Kiwi-2,HWH710VL-Q,H1622
+Huawei,LISZT,hwliszt,HUAWEI M2-A01L
+Huawei,LISZT,hwliszt,HUAWEI M2-A01W
+Huawei,M2,HWMozart,HUAWEI M2-801L
+Huawei,M2,HWMozart,HUAWEI M2-801W
+Huawei,M2,HWMozart,HUAWEI M2-802L
+Huawei,M2,HWMozart,HUAWEI M2-803L
+Huawei,M220,hwmediaqm220,M220
+Huawei,M220,hwmediaqm220,M220c
+Huawei,M220,hwmediaqm220,dTV01
+Huawei,M3,hwbeethoven,BTV-DL09
+Huawei,M3,hwbeethoven,BTV-W09
+Huawei,M310,hwsingleboxm310w,M310
+Huawei,M620,M620,M620
+Huawei,M620,M620,TB01
+Huawei,M835,hwm835,HUAWEI-M835
+Huawei,M860,M860,M860
+Huawei,M865,hwm865,M865
+Huawei,M865,hwm865,USCCADR3305
+Huawei,M868,hwm868,HUAWEI M868
+Huawei,MAIMANG 6,HWRNE,RNE-AL00
+Huawei,MS4C,hwMS4C,MS4C
+Huawei,MT1,hwmt1-u06,HUAWEI MT1-U06
+Huawei,MT2-L01,hwmt2-l01,HUAWEI MT2-L01
+Huawei,MT2-L02,hwmt2-l02,HUAWEI MT2-L02
+Huawei,MT2-L03,hwMT2L03,MT2L03
+Huawei,MT2-L05,hwmt2-l05,HUAWEI MT2-L05
+Huawei,MT2L03LITE,hwMT2L03LITE,MT2L03
+Huawei,Mate,hwmt1-t00,HUAWEI MT1-T00
+Huawei,Mate 10,HWALP,ALP-AL00
+Huawei,Mate 10,HWALP,ALP-L09
+Huawei,Mate 10,HWALP,ALP-L29
+Huawei,Mate 10,HWALP,ALP-TL00
+Huawei,Mate 10 Pro,HWBLA,BLA-AL00
+Huawei,Mate 10 Pro,HWBLA,BLA-L09
+Huawei,Mate 10 Pro,HWBLA,BLA-L29
+Huawei,Mate 10 Pro,HWBLA,BLA-TL00
+Huawei,Mate 10 lite,HWRNE,RNE-L01
+Huawei,Mate 10 lite,HWRNE,RNE-L03
+Huawei,Mate 10 lite,HWRNE,RNE-L21
+Huawei,Mate 10 lite,HWRNE,RNE-L23
+Huawei,Mate 7,hwmt7,HUAWEI MT7-CL00
+Huawei,Mate 7,hwmt7,HUAWEI MT7-J1
+Huawei,Mate 7,hwmt7,HUAWEI MT7-L09
+Huawei,Mate 7,hwmt7,HUAWEI MT7-TL00
+Huawei,Mate 7,hwmt7,HUAWEI MT7-TL10
+Huawei,Mate 7,hwmt7,HUAWEI MT7-UL00
+Huawei,Mate 8,HWNXT,HUAWEI NXT-AL10
+Huawei,Mate 8,HWNXT,HUAWEI NXT-CL00
+Huawei,Mate 8,HWNXT,HUAWEI NXT-DL00
+Huawei,Mate 8,HWNXT,HUAWEI NXT-L09
+Huawei,Mate 8,HWNXT,HUAWEI NXT-L29
+Huawei,Mate 8,HWNXT,HUAWEI NXT-TL00
+Huawei,Mate 8,HWNXT,HUAWEI NXT-TL00B
+Huawei,Mate 8,HWNXT,NXT-AL10
+Huawei,Mate 8,HWNXT,NXT-CL00
+Huawei,Mate 8,HWNXT,NXT-DL00
+Huawei,Mate 8,HWNXT,NXT-L09
+Huawei,Mate 8,HWNXT,NXT-L29
+Huawei,Mate 8,HWNXT,NXT-TL00
+Huawei,Mate 9,HWMHA,MHA-AL00
+Huawei,Mate 9,HWMHA,MHA-L09
+Huawei,Mate 9,HWMHA,MHA-L29
+Huawei,Mate 9,HWMHA,MHA-TL00
+Huawei,Mate 9 Pro,HWLON,LON-AL00
+Huawei,Mate 9 Pro,HWLON,LON-L29
+Huawei,Mate S,HWCRR,HUAWEI CRR-CL00
+Huawei,Mate S,HWCRR,HUAWEI CRR-CL20
+Huawei,Mate S,HWCRR,HUAWEI CRR-L09
+Huawei,Mate S,HWCRR,HUAWEI CRR-TL00
+Huawei,Mate S,HWCRR,HUAWEI CRR-UL00
+Huawei,Mate S,HWCRR,HUAWEI CRR-UL20
+Huawei,Mate2,hwmt2-c00,HUAWEI MT2-C00
+Huawei,MediaPad,hwt1701,HUAWEI MediaPad T1 7.0 3G
+Huawei,MediaPad,hwt1701,T1 7.0
+Huawei,MediaPad,hwt1701,T1-701u
+Huawei,MediaPad,hwt1701,T1-701ua
+Huawei,MediaPad,hwt1701,T1-701us
+Huawei,MediaPad,hwt1701,T1-701w
+Huawei,MediaPad,hwt1701,Telpad QS
+Huawei,MediaPad 10 FHD,hws10101l,MediaPad 10 FHD
+Huawei,MediaPad 10 Link,hws10201w,MediaPad 10 LINK
+Huawei,MediaPad 10 Link,hws10201w,dtab 01
+Huawei,MediaPad 10 Link+,hws10231l,402HW
+Huawei,MediaPad 10 Link+,hws10231l,MediaPad 10 Link+
+Huawei,MediaPad 10 Link+,hws10231l,S10-232L
+Huawei,MediaPad 10 Link+,hws10231l,SpeedTAB
+Huawei,MediaPad 7 Lite,hws7930u,MediaPad 7 Lite
+Huawei,MediaPad 7 Lite Quad,hws7961w,Telpad QS
+Huawei,MediaPad 7 Lite Quad,hws7961w,Telpad Quad S
+Huawei,MediaPad 7 Vogue,hws7601us,MediaPad 7 Vogue
+Huawei,MediaPad 7 Youth2,hws7721u,MediaPad 7 Youth 2
+Huawei,MediaPad 7 Youth2,hws7721u,S7-721u
+Huawei,MediaPad M1 8.0,hws8301l,403HW
+Huawei,MediaPad M1 8.0,hws8301l,CNPC Security Pad S1
+Huawei,MediaPad M1 8.0,hws8301l,HUAWEI MediaPad M1 8.0
+Huawei,MediaPad M1 8.0,hws8301l,MediaPad M1 8.0
+Huawei,MediaPad M1 8.0,hws8301l,MediaPad M1 8.0 (LTE)
+Huawei,MediaPad M1 8.0,hws8301l,MediaPad M1 8.0 (WIFI)
+Huawei,MediaPad M1 8.0,hws8301l,S8-303L
+Huawei,MediaPad M1 8.0,hws8301l,S8-303LT
+Huawei,MediaPad M1 8.0,hws8301l,S8-306L
+Huawei,MediaPad M3 Lite 10,HWBAH-Q,BAH-AL00
+Huawei,MediaPad M3 Lite 10,HWBAH-Q,BAH-L09
+Huawei,MediaPad M3 Lite 10,HWBAH-Q,BAH-W09
+Huawei,MediaPad T2 10.0 Pro,hwfdr,605HW
+Huawei,MediaPad T2 10.0 Pro,hwfdr,606HW
+Huawei,MediaPad T2 10.0 Pro,hwfdr,FDR-A05L
+Huawei,MediaPad T2 10.0 pro,HWFDR,FDR-A01L
+Huawei,MediaPad T2 10.0 pro,HWFDR,FDR-A01w
+Huawei,MediaPad T2 10.0 pro,HWFDR,FDR-A03L
+Huawei,MediaPad T2 7.0,hwbgo,BGO-DL09
+Huawei,MediaPad T2 7.0,hwbgo,BGO-L03
+Huawei,MediaPad T2 8.0 Pro,hwjdn,JDN-AL00
+Huawei,MediaPad T2 8.0 Pro,hwjdn,JDN-L01
+Huawei,MediaPad T2 8.0 Pro,hwjdn,JDN-W09
+Huawei,MediaPad T3 7,HWBG2,BG2-U01
+Huawei,MediaPad T3 7,hwbg2,BG2-W09
+Huawei,MediaPad Vogue,hws7601u,MediaPad 7 Lite II
+Huawei,MediaPad Vogue,hws7601u,MediaPad 7 Vogue
+Huawei,MediaPad X1 7.0,hw7d501l,7D-501u
+Huawei,MediaPad X1 7.0,hw7d501l,MediaPad X1
+Huawei,MediaPad X1 7.0,hw7d501l,MediaPad X1 7.0
+Huawei,MediaPad X1 7.0,hw7d501l,X1 7.0
+Huawei,MediaPad Youth,hws7701w,MediaPad 7 Youth
+Huawei,MediaPad7,hws7601w,MediaPad 7 Vogue
+Huawei,Nexus 6P,angler,Nexus 6P
+Huawei,P10,HWVTR,VTR-AL00
+Huawei,P10,HWVTR,VTR-L09
+Huawei,P10,HWVTR,VTR-L29
+Huawei,P10,HWVTR,VTR-TL00
+Huawei,P10 Plus,HWVKY,VKY-AL00
+Huawei,P10 Plus,HWVKY,VKY-L09
+Huawei,P10 Plus,HWVKY,VKY-L29
+Huawei,P10 Plus,HWVKY,VKY-TL00
+Huawei,P10 lite,HWWAS-H,WAS-L03T
+Huawei,P10 lite,HWWAS-H,WAS-LX1
+Huawei,P10 lite,HWWAS-H,WAS-LX1A
+Huawei,P10 lite,HWWAS-H,WAS-LX2
+Huawei,P10 lite,HWWAS-H,WAS-LX2J
+Huawei,P10 lite,HWWAS-H,WAS-LX3
+Huawei,P2,hwp2-6070,HUAWEI P2-6070
+Huawei,P6,hwp6-c00,HUAWEI P6-C00
+Huawei,P6,hwp6-t00,HUAWEI P6-T00
+Huawei,P6,hwp6-t00,HUAWEI P6-T00V
+Huawei,P6,hwp6-u06,HUAWEI Ascend P6
+Huawei,P6,hwp6-u06,HUAWEI P6-U06
+Huawei,P6,hwp6-u06,HUAWEI P6-U06-orange
+Huawei,P6S,hwP6s-l04,P6 S-L04
+Huawei,P6S-L04,hwp6s-l04,302HW
+Huawei,P6S-U06,hwp6s-u06,HUAWEI P6 S-U06
+Huawei,P7,hwp7,HUAWEI P7-L00
+Huawei,P7,hwp7,HUAWEI P7-L05
+Huawei,P7,hwp7,HUAWEI P7-L07
+Huawei,P7,hwp7,HUAWEI P7-L10
+Huawei,P7,hwp7,HUAWEI P7-L11
+Huawei,P7,hwp7,HUAWEI P7-L12
+Huawei,P7 mini,hwP7Mini,HUAWEI P7 mini
+Huawei,P7-L09,hwp7,HUAWEI P7-L09
+Huawei,P8,HWGRA,HUAWEI GRA-CL00
+Huawei,P8,HWGRA,HUAWEI GRA-CL10
+Huawei,P8,HWGRA,HUAWEI GRA-L09
+Huawei,P8,HWGRA,HUAWEI GRA-TL00
+Huawei,P8,HWGRA,HUAWEI GRA-UL00
+Huawei,P8,HWGRA,HUAWEI GRA-UL10
+Huawei,P8 Lite,hwALE-H,503HW
+Huawei,P8 Lite,hwALE-H,ALE-L02
+Huawei,P8 Lite,hwALE-H,ALE-L21
+Huawei,P8 Lite,hwALE-H,ALE-L23
+Huawei,P8 Lite,hwALE-H,Autana LTE
+Huawei,P8 Lite,hwALE-Q,HUAWEI ALE-CL00
+Huawei,P8 Lite,hwALE-Q,HUAWEI ALE-L04
+Huawei,P8 lite 2017,HWPRA-H,PRA-LA1
+Huawei,P8 lite 2017,HWPRA-H,PRA-LX1
+Huawei,P8 \xe9\x9d\x92\xe6\x98\xa5\xe7\x89\x88,hwALE-H,ALE-TL00
+Huawei,P8 \xe9\x9d\x92\xe6\x98\xa5\xe7\x89\x88,hwALE-H,ALE-UL00
+Huawei,P8max,HWP8max,HUAWEI P8max
+Huawei,P9,HWEVA,EVA-AL00
+Huawei,P9,HWEVA,EVA-AL10
+Huawei,P9,HWEVA,EVA-CL00
+Huawei,P9,HWEVA,EVA-DL00
+Huawei,P9,HWEVA,EVA-L09
+Huawei,P9,HWEVA,EVA-L19
+Huawei,P9,HWEVA,EVA-L29
+Huawei,P9,HWEVA,EVA-TL00
+Huawei,P9 Lite PREMIUM,HWVNS-Q,HUAWEI VNS-L52
+Huawei,P9 Plus,HWVIE,VIE-AL10
+Huawei,P9 Plus,HWVIE,VIE-L09
+Huawei,P9 Plus,HWVIE,VIE-L29
+Huawei,P9 lite,HWVNS-H,HUAWEI VNS-L21
+Huawei,P9 lite,HWVNS-H,HUAWEI VNS-L22
+Huawei,P9 lite,HWVNS-H,HUAWEI VNS-L23
+Huawei,P9 lite,HWVNS-H,HUAWEI VNS-L31
+Huawei,P9 lite,HWVNS-H,HUAWEI VNS-L53
+Huawei,P9 lite,HWVNS-Q,HUAWEI VNS-L62
+Huawei,P9 lite smart,HWDIG-L8940,DIG-L03
+Huawei,P9 lite smart,HWDIG-L8940,DIG-L23
+Huawei,PE-CL00,hwPE,PE-CL00
+Huawei,PE-TL00M,hwPE,PE-TL00M
+Huawei,PE-TL10,hwPE,PE-TL10
+Huawei,PE-TL20,hwPE,PE-TL20
+Huawei,PE-UL00,hwPE,PE-UL00
+Huawei,Prism II,hwu8686,Prism II
+Huawei,Q22,HWQ22,Q22
+Huawei,RIO-CL00,hwRIO-CL00,HUAWEI RIO-CL00
+Huawei,S10,hws10103l,MediaPad 10 FHD
+Huawei,S10,hws10201l,MediaPad 10 LINK
+Huawei,S7,hws7601c,MediaPad 7 Vogue
+Huawei,S7,hws7601w,MediaPad 7 Vogue
+Huawei,S7,hws7701u,MediaPad 7 Youth
+Huawei,S7,hws7930u,Orinoquia Roraima S7-932u
+Huawei,S7,hws7951w,MediaPad 7 Lite+
+Huawei,S7,hws7951w,Telpad Dual S
+Huawei,SC-CL00,HWSC-CL00,HUAWEI SC-CL00
+Huawei,SC-UL10,HWSC-UL10,HUAWEI SC-UL10
+Huawei,Sensa LTE,HWH710VL-Q,H710VL
+Huawei,Sensa LTE,HWH715BL-Q,H715BL
+Huawei,ShotX,HWATH,HUAWEI ATH-UL01
+Huawei,ShotX,HWATH,HUAWEI ATH-UL06
+Huawei,T-Mobile Pulse,U8100,Huawei_8100-9
+Huawei,T-Mobile Pulse,U8100,Tactile internet
+Huawei,T-Mobile Pulse,U8100,U8100
+Huawei,T-Mobile Pulse,U8100,Videocon_V7400
+Huawei,T1,hwt1821l,T1-821L
+Huawei,T1,hwt1821l,T1-821W
+Huawei,T1,hwt1821l,T1-821w
+Huawei,T1,hwt1821l,T1-823L
+Huawei,T1,hwt1823l,T1-823L
+Huawei,T1 10,hwt1a21l,HUAWEI MediaPad T1 10 4G
+Huawei,T1 10,hwt1a21l,T1-A21L
+Huawei,T1 10,hwt1a21l,T1-A21W
+Huawei,T1 10,hwt1a21l,T1-A21w
+Huawei,T1 10,hwt1a21l,T1-A22L
+Huawei,T1 10,hwt1a21l,T1-A23L
+Huawei,T101,hwt101,T-101
+Huawei,T101,hwt101,T101 PAD
+Huawei,T102,hwt102,QH-10
+Huawei,T102,hwt102,T102 PAD
+Huawei,T801,hwt801,T801 PAD
+Huawei,T802,hwt802,MT-803G
+Huawei,T802,hwt802,T802 PAD
+Huawei,T8808D,hwT8808D,HUAWEI T8808D
+Huawei,TANGO,HWTAG-L6753,HUAWEI TAG-AL00
+Huawei,TANGO,HWTAG-L6753,HUAWEI TAG-CL00
+Huawei,TANGO,HWTAG-L6753,HUAWEI TAG-TL00
+Huawei,U8120,U8120,Vodafone 845
+Huawei,U8220,U8220,Pulse
+Huawei,U8220,U8220,U8220
+Huawei,U8220,U8220,U8220PLUS
+Huawei,U8230,U8230,U8230
+Huawei,U8652,hwu8652,Huawei-U8652
+Huawei,U8652,hwu8652,U8652
+Huawei,U8687,hwu8687,Huawei-U8687
+Huawei,U8812D,hwu8812D,U8812D
+Huawei,U8832D,hwu8832D,U8832D
+Huawei,U8836D,hwu8836D,U8836D
+Huawei,U8850,hwu8850,HUAWEI-U8850
+Huawei,U9000,hwu9000,HUAWEI-U9000
+Huawei,UNION,hwY538,Y538
+Huawei,V858,hwu8160,Huawei 858
+Huawei,V858,hwu8160,MTC 950
+Huawei,V858,hwu8160,MTC Mini
+Huawei,V858,hwu8160,Vodafone 858
+Huawei,Vogue7,hws7601u,MediaPad 7 Classic
+Huawei,Vogue7,hws7601u,MediaPad 7 Lite II
+Huawei,Vogue7,hws7601u,MediaPad 7 Vogue
+Huawei,WATCH,sturgeon,HUAWEI WATCH
+Huawei,WATCH,sturgeon,HUAWEI-WATCH
+Huawei,Watch 2,sawfish,LEO-BX9
+Huawei,Watch 2,sawshark,LEO-DLXX
+Huawei,X2,HWGemini,GEM-701L
+Huawei,X2,HWGemini,GEM-702L
+Huawei,X2,HWGemini,GEM-703L
+Huawei,X2,HWGemini,GEM-703LT
+Huawei,Y210,oay210,Orinoquia Auyantepui Y210
+Huawei,Y220,HWY220-U,Y220-U00
+Huawei,Y220,HWY220-U,Y220-U05
+Huawei,Y220,HWY220-U,Y220-U17
+Huawei,Y220-T10,hwy220-t10,HUAWEI Y220-T10
+Huawei,Y220-U10,HWY220-U,Y220-U10
+Huawei,Y220T,hwy220t,HUAWEI Y 220T
+Huawei,Y221-U03,HWY221-U,HUAWEI Y221-U03
+Huawei,Y221-U03,QAY221-U,ORINOQUIA Auyantepui+Y221-U03
+Huawei,Y221-U12,HWY221-U,HUAWEI Y221-U12
+Huawei,Y221-U22,HWY221-U,HUAWEI Y221-U22
+Huawei,Y221-U33,HWY221-U,HUAWEI Y221-U33
+Huawei,Y221-U43,HWY221-U,HUAWEI Y221-U43
+Huawei,Y221-U53,HWY221-U,HUAWEI Y221-U53
+Huawei,Y300,hwY300-0100,HUAWEI Ascend Y300
+Huawei,Y300,hwY300-0100,HUAWEI Y300-0100
+Huawei,Y300,hwY300-0151,HUAWEI Y300-0151
+Huawei,Y300,hwY300-0151,Pelephone-Y300-
+Huawei,Y300-0000,hwY300-0000,HUAWEI Y300-0000
+Huawei,Y301A1,hwY301A1,Huawei Y301A1
+Huawei,Y301A2,hwY301A2,Huawei Y301A2
+Huawei,Y310-5000,hwy310-5000,HUAWEI Y310-5000
+Huawei,Y310-T10,hwy310-t10,HUAWEI Y310-T10
+Huawei,Y320,hwy320-c00,HUAWEI Y320-C00
+Huawei,Y320-T00,HWY320-T00,HUAWEI Y320-T00
+Huawei,Y320-U01,HWY320,HUAWEI Y320-U01
+Huawei,Y320-U01,HWY320,Y320-U01
+Huawei,Y320-U10,HWY320-U,HUAWEI Y320-U10
+Huawei,Y320-U151,HWY320-U,HUAWEI Y320-U151
+Huawei,Y320-U30,HWY320-U,HUAWEI Y320-U30
+Huawei,Y320-U351,HWY320-U,HUAWEI Y320-U351
+Huawei,Y321,HWY321-U,HUAWEI Y321-U051
+Huawei,Y321,hwy321-c00,HUAWEI Y321-C00
+Huawei,Y325-T00,HWY325-T,HUAWEI Y325-T00
+Huawei,Y330,hwY330-U05,Bucare Y330-U05
+Huawei,Y330,hwY330-U05,HUAWEI Y330-U05
+Huawei,Y330,hwY330-U21,HUAWEI Y330-U21
+Huawei,Y330-C00,hwY330-C00,HUAWEI Y330-C00
+Huawei,Y330-U01,hwY330-U01,HUAWEI Y330-U01
+Huawei,Y330-U01,hwY330-U01,Luno
+Huawei,Y330-U07,hwY330-U07,HUAWEI Y330-U07
+Huawei,Y330-U08,hwY330-U08,HUAWEI Y330-U08
+Huawei,Y330-U11,hwY330-U11,HUAWEI Y330-U11
+Huawei,Y330-U11,hwY330-U11,V8510
+Huawei,Y330-U15,hwY330-U15,HUAWEI Y330-U15
+Huawei,Y330-U17,hwY330-U17,HUAWEI Y330-U17
+Huawei,Y336-A1,hwY336-A1,HUAWEI Y336-A1
+Huawei,Y336-U02,HWY336-U,HUAWEI Y336-U02
+Huawei,Y336-U12,HWY336-U,HUAWEI Y336-U12
+Huawei,Y340-U081,hwY340-U081,Y340-U081
+Huawei,Y360-U03,HWY360-U,HUAWEI Y360-U03
+Huawei,Y360-U103,HWY360-U6572,HUAWEI Y360-U103
+Huawei,Y360-U12,HWY360-U,HUAWEI Y360-U12
+Huawei,Y360-U23,HWY360-U,HUAWEI Y360-U23
+Huawei,Y360-U31,HWY360-U,HUAWEI Y360-U31
+Huawei,Y360-U42,HWY360-U,HUAWEI Y360-U42
+Huawei,Y360-U61,HWY360-U,HUAWEI Y360-U61
+Huawei,Y360-U72,HWY360-U6572,HUAWEI Y360-U72
+Huawei,Y360-U82,HWY360-U6572,HUAWEI Y360-U82
+Huawei,Y360-U93,HWY360-U6572,Delta Y360-U93
+Huawei,Y360-U93,HWY360-U6572,HUAWEI Y360-U93
+Huawei,Y3II,HWLUA-L6735,HUAWEI LUA-L01
+Huawei,Y3II,HWLUA-L6735,HUAWEI LUA-L02
+Huawei,Y3II,HWLUA-L6735,HUAWEI LUA-L21
+Huawei,Y3II,HWLUA-U6582,HUAWEI LUA-U02
+Huawei,Y3II,HWLUA-U6582,HUAWEI LUA-U22
+Huawei,Y3III,HWCRO-U6580M,CRO-U00
+Huawei,Y3III,HWCRO-U6580M,CRO-U23
+Huawei,Y3III,HWCRO-U6580M,HUAWEI CRO-U00
+Huawei,Y3III,HWCRO-U6580M,HUAWEI CRO-U23
+Huawei,Y5,HWY560-L,HUAWEI Y560-L02
+Huawei,Y5,HWY560-L,HUAWEI Y560-L23
+Huawei,Y5,HWY560-U,HUAWEI Y560-U03
+Huawei,Y5 2017,HWMYA-L6737,MYA-AL00
+Huawei,Y5 2017,HWMYA-L6737,MYA-L02
+Huawei,Y5 2017,HWMYA-L6737,MYA-L03
+Huawei,Y5 2017,HWMYA-L6737,MYA-L13
+Huawei,Y5 2017,HWMYA-L6737,MYA-L22
+Huawei,Y5 2017,HWMYA-L6737,MYA-L23
+Huawei,Y5 2017,HWMYA-L6737,MYA-TL00
+Huawei,Y5 2017,HWMYA-U6580,MYA-U29
+Huawei,Y500-T00,HWY500-T00,HUAWEI Y500-T00
+Huawei,Y511-T00,HWY511-T,HUAWEI Y511-T00
+Huawei,Y511-T00,HWY511-T,Y511-T00
+Huawei,Y511-U00,HWY511-U,Y511-U00
+Huawei,Y511-U10,HWY511-U,HUAWEI Y511-U10
+Huawei,Y511-U251,HWY511-U,HUAWEI Y511-U251
+Huawei,Y511-U30,HWY511-U,HUAWEI Y511-U30
+Huawei,Y511-U30,HWY511-U,VIETTEL V8506
+Huawei,Y516-,HWY516-T,HUAWEI Y516-T00
+Huawei,Y518-T00,HWY518-T,HUAWEI Y518-T00
+Huawei,Y520-U03,HWY520-U,HUAWEI Y520-U03
+Huawei,Y520-U12,HWY520-U,HUAWEI Y520-U12
+Huawei,Y520-U22,HWY520-U,HUAWEI Y520-U22
+Huawei,Y520-U33,HWY520-U,HUAWEI Y520-U33
+Huawei,Y523-L076,HWY523,HUAWEI Y523-L076
+Huawei,Y523-L176,HWY523,HUAWEI Y523-L176
+Huawei,Y530,hwY530-U00,HUAWEI Y530-U00
+Huawei,Y530-U051,hwY530-U051,HUAWEI Y530
+Huawei,Y530-U051,hwY530-U051,HUAWEI Y530-U051
+Huawei,Y535,HWY535-C00,HUAWEI Y535-C00
+Huawei,Y535D-C00,HWY535D-C00,HUAWEI Y535D-C00
+Huawei,Y536-A1,hwY536A1,HUAWEI Y536A1
+Huawei,Y540-U01,HWY540-U,HUAWEI Y540-U01
+Huawei,Y541-U02,HWY541-U,HUAWEI Y541-U02
+Huawei,Y541-U02,HWY541-U,Y541-U02
+Huawei,Y550-L01,hwY550-L01,HUAWEI Y550-L01
+Huawei,Y550-L02,hwY550-L02,HUAWEI Y550-L02
+Huawei,Y550-L02,hwY550-L02,Y550-L02
+Huawei,Y550-L03,hwY550-L03,HUAWEI Y550
+Huawei,Y550-L03,hwY550-L03,HUAWEI Y550-L03
+Huawei,Y550-L03,hwY550-L03,Personal Huawei Y550
+Huawei,Y550-L03,hwY550-L03,Y550-L03
+Huawei,Y560-CL00,HWY560-CL,HUAWEI Y560-CL00
+Huawei,Y560-L01,HWY560-L,HUAWEI Y560-L01
+Huawei,Y560-L03,HWY560-L,HUAWEI Y560-L03
+Huawei,Y560-U02,HWY560-U,HUAWEI Y560-U02
+Huawei,Y560-U12,HWY560-U,HUAWEI Y560-U12
+Huawei,Y560-U23,HWY560-U,HUAWEI Y560-U23
+Huawei,Y5II,HWCUN-L6735,CUN-L22
+Huawei,Y5II,HWCUN-L6735,HUAWEI CUN-L01
+Huawei,Y5II,HWCUN-L6735,HUAWEI CUN-L02
+Huawei,Y5II,HWCUN-L6735,HUAWEI CUN-L03
+Huawei,Y5II,HWCUN-L6735,HUAWEI CUN-L21
+Huawei,Y5II,HWCUN-L6735,HUAWEI CUN-L22
+Huawei,Y5II,HWCUN-L6735,HUAWEI CUN-L23
+Huawei,Y5II,HWCUN-L6735,HUAWEI CUN-L33
+Huawei,Y5II,HWCUN-U6582,HUAWEI CUN-U29
+Huawei,Y6,hwSCC-Q,HUAWEI SCC-U21
+Huawei,Y6,hwSCC-Q,SCC-U21
+Huawei,Y6,hwSCL-Q,HUAWEI SCL-L01
+Huawei,Y6,hwSCL-Q,HUAWEI SCL-L02
+Huawei,Y6,hwSCL-Q,HUAWEI SCL-L03
+Huawei,Y6,hwSCL-Q,HUAWEI SCL-L04
+Huawei,Y6,hwSCL-Q,HUAWEI SCL-L21
+Huawei,Y6,hwSCL-Q,HW-SCL-L32
+Huawei,Y6,hwSCL-Q,SCL-L01
+Huawei,Y6,hwSCLU-Q,HUAWEI SCL-U23
+Huawei,Y6,hwSCLU-Q,HUAWEI SCL-U31
+Huawei,Y6,hwSCLU-Q,SCL-U23
+Huawei,Y6 2017,HWMYA-L6737,MYA-L41
+Huawei,Y6 Elite,HWLYO-L6735,HUAWEI LYO-L02
+Huawei,Y6 Pro,HWTIT-AL00,HUAWEI TIT-AL00
+Huawei,Y6 Pro,HWTIT-L6735,HUAWEI TIT-AL00
+Huawei,Y6 Pro,HWTIT-L6735,HUAWEI TIT-CL10
+Huawei,Y6 Pro,HWTIT-L6735,HUAWEI TIT-L01
+Huawei,Y6 Pro,HWTIT-L6735,HUAWEI TIT-TL00
+Huawei,Y6 Pro,HWTIT-L6735,TIT-AL00
+Huawei,Y6 Pro,HWTIT-L6735,TIT-L01
+Huawei,Y6 Pro,HWTIT-L8916,HUAWEI TIT-CL00
+Huawei,Y6 Pro,HWTIT-U6582,HUAWEI TIT-U02
+Huawei,Y6 \xe2\x85\xa1 Compact,HWLYO-L6735,HUAWEI LYO-L01
+Huawei,Y600,HWY600-U,HUAWEI Y600-U00
+Huawei,Y600,HWY600-U,HUAWEI Y600-U151
+Huawei,Y600,HWY600-U,HUAWEI Y600-U20
+Huawei,Y600-U351,HWY600-U,HUAWEI Y600-U351
+Huawei,Y600-U40,HWY600-U,HUAWEI Y600-U40
+Huawei,Y600D-C00,HWY600D-C00,HUAWEI Y600D-C00
+Huawei,Y610,HWY610-U,HUAWEI Y610-U00
+Huawei,Y618,HWY618-T,HUAWEI Y618-T00
+Huawei,Y625-U03,KVY625-U,Kavak Y625-U03
+Huawei,Y625-U13,HWY625-U,HUAWEI Y625-U13
+Huawei,Y625-U21,HWY625-U,HUAWEI Y625-U21
+Huawei,Y625-U32,HWY625-U,HUAWEI Y625-U32
+Huawei,Y625-U43,HWY625-U,HUAWEI Y625-U43
+Huawei,Y625-U51,HWY625-U,HUAWEI Y625-U51
+Huawei,Y635-CL00,hwY635,HUAWEI Y635-CL00
+Huawei,Y635-L01,hwY635,Y635-L01
+Huawei,Y635-L02,hwY635,HUAWEI Y635-L02
+Huawei,Y635-L02,hwY635,Y635-L02
+Huawei,Y635-L03,hwY635,HUAWEI Y635-L03
+Huawei,Y635-L03,hwY635,Y635-L03
+Huawei,Y635-L21,hwY635,Y635-L21
+Huawei,Y635-TL00,hwY635,HUAWEI Y635-TL00
+Huawei,Y635-TL00,hwY635,Y635-TL00
+Huawei,Y6II,HWCAM-H,CAM-L03
+Huawei,Y6II,HWCAM-H,CAM-L21
+Huawei,Y6II,HWCAM-H,CAM-L23
+Huawei,Y6II,HWCAM-H,CAM-U22
+Huawei,Y6II,HWCAM-H,HUAWEI CAM-L03
+Huawei,Y6II,HWCAM-H,HUAWEI CAM-L21
+Huawei,Y6II,HWCAM-H,HUAWEI CAM-L23
+Huawei,Y6II,HWCAM-H,HUAWEI CAM-U22
+Huawei,Y6II,HWCAM-Q,CAM-L32
+Huawei,Y6\xe2\x85\xa1Compact,HWLYO-L6735,HUAWEI LYO-L03
+Huawei,Y7,HWTRT-Q,TRT-L21A
+Huawei,Y7,HWTRT-Q,TRT-L53
+Huawei,Y7,HWTRT-Q,TRT-LX1
+Huawei,Y7,HWTRT-Q,TRT-LX2
+Huawei,Y7,HWTRT-Q,TRT-LX3
+Huawei,Youth,hws7701u,Orinoquia Gran Roraima S7-702u
+Huawei,ascend-5w,HWH1621-Q,H1623
+Huawei,d-01G,d-01G,d-01G
+Huawei,d-01H,d-01H,d-01H
+Huawei,d-02H,d-02H,d-02H
+Huawei,eH811,hweH811,eH811
+Huawei,honor 5X,HNKIW-Q,KIW-L22
+Huawei,honor 5X,HNKIW-Q,KIW-L23
+Huawei,honor 5X,HNKIW-Q,KIW-L24
+Huawei,honor 6A Pro,HWDLI-Q,DLI-L42
+Huawei,honor 6C,HWDIG-L8940,DIG-L21HN
+Huawei,honor 6C Pro,HWJMM,JMM-L22
+Huawei,honor 6x,HWBLN-H,BLN-L21
+Huawei,honor 6x,HWBLN-H,BLN-L22
+Huawei,hw204HW,hw204HW,204HW
+Huawei,m881,hwm881,HUAWEI M881
+Huawei,nova,HWCAN,HUAWEI CAN-L01
+Huawei,nova,HWCAN,HUAWEI CAN-L02
+Huawei,nova,HWCAN,HUAWEI CAN-L03
+Huawei,nova,HWCAN,HUAWEI CAN-L11
+Huawei,nova,HWCAN,HUAWEI CAN-L12
+Huawei,nova,HWCAN,HUAWEI CAN-L13
+Huawei,nova,HWCAN,HUAWEI CAZ-AL10
+Huawei,nova,HWCAZ,HUAWEI CAZ-AL00
+Huawei,nova,HWCAZ,HUAWEI CAZ-AL10
+Huawei,nova,HWCAZ,HUAWEI CAZ-TL10
+Huawei,nova,HWCAZ,HUAWEI CAZ-TL20
+Huawei,nova 2,HWPIC,PIC-AL00
+Huawei,nova 2,HWPIC,PIC-TL00
+Huawei,nova 2 Plus,HWBAC,BAC-AL00
+Huawei,nova 2 Plus,HWBAC,BAC-L01
+Huawei,nova 2 Plus,HWBAC,BAC-L03
+Huawei,nova 2 Plus,HWBAC,BAC-L23
+Huawei,nova 2 Plus,HWBAC,BAC-TL00
+Huawei,nova 2i,HWRNE,RNE-L02
+Huawei,nova 2i,HWRNE,RNE-L22
+Huawei,nova 2s,HWHWI,HWI-AL00
+Huawei,nova 2s,HWHWI,HWI-TL00
+Huawei,nova lite,HWPRA-H,PRA-LX2
+Huawei,nova lite,HWPRA-H,PRA-LX3
+Huawei,nova plus,HWMLA,HUAWEI MLA-L01
+Huawei,nova plus,HWMLA,HUAWEI MLA-L02
+Huawei,nova plus,HWMLA,HUAWEI MLA-L03
+Huawei,nova plus,HWMLA,HUAWEI MLA-L11
+Huawei,nova plus,HWMLA,HUAWEI MLA-L12
+Huawei,nova plus,HWMLA,HUAWEI MLA-L13
+Huawei,nova plus,HWMLA,MLA-L01
+Huawei,nova plus,HWMLA,MLA-L02
+Huawei,nova plus,HWMLA,MLA-L03
+Huawei,nova plus,HWMLA,MLA-L11
+Huawei,nova plus,HWMLA,MLA-L12
+Huawei,nova plus,HWMLA,MLA-L13
+Huawei,nova \xe9\x9d\x92\xe6\x98\xa5\xe7\x89\x88\xe6\x9c\xac,HWWAS-H,WAS-AL00
+Huawei,nova \xe9\x9d\x92\xe6\x98\xa5\xe7\x89\x88\xe6\x9c\xac,HWWAS-H,WAS-TL10
+Huawei,t1_8p0,hws8701,MediaPad T1 8.0
+Huawei,t1_8p0,hws8701,S8-701u
+Huawei,t1_8p0,hws8701,S8-701w
+Huawei,t1_8p0lte,hwt1821l,HUAWEI MediaPad T1 8.0 4G
+Huawei,t1_8p0lte,hwt1821l,Honor T1 8.0
+Huawei,t1_8p0lte,hwt1821l,MediaPad T1 8.0 Pro
+Huawei,t1_8p0lte,hwt1821l,S8-821w
+Huawei,t1_8p0lte,hwt1821l,T1-821w
+Huawei,t1_8p0lte,hwt1821l,T1-823L
+Huawei,\xe5\x8d\x8e\xe4\xb8\xbaG9\xe9\x9d\x92\xe6\x98\xa5\xe7\x89\x88,HWVNS-H,HUAWEI VNS-DL00
+Huawei,\xe5\x8d\x8e\xe4\xb8\xbaG9\xe9\x9d\x92\xe6\x98\xa5\xe7\x89\x88,HWVNS-H,HUAWEI VNS-TL00
+Huawei,\xe5\x8d\x8e\xe4\xb8\xba\xe5\xb9\xb3\xe6\x9d\xbfT3 8\xe8\xa1\x8c\xe4\xb8\x9a\xe4\xb8\x93\xe4\xba\xab\xe7\x89\x88,HWBZK-Q,BZK-L00
+Huawei,\xe5\x8d\x8e\xe4\xb8\xba\xe5\xb9\xb3\xe6\x9d\xbfT3 8\xe8\xa1\x8c\xe4\xb8\x9a\xe4\xb8\x93\xe4\xba\xab\xe7\x89\x88,HWBZK-Q,BZK-W00
+Huawei,\xe5\x8d\x8e\xe4\xb8\xba\xe6\x8f\xbd\xe9\x98\x85M2\xe9\x9d\x92\xe6\x98\xa5\xe7\x89\x887.0,hwple703l,PLE-701L
+Huawei,\xe5\x8d\x8e\xe4\xb8\xba\xe6\x8f\xbd\xe9\x98\x85M2\xe9\x9d\x92\xe6\x98\xa5\xe7\x89\x887.0,hwple703l,PLE-703L
+Huawei,\xe5\x8d\x8e\xe4\xb8\xba\xe7\x95\x85\xe4\xba\xab6,HWNCE-L6750,NCE-AL00
+Huawei,\xe5\x8d\x8e\xe4\xb8\xba\xe7\x95\x85\xe4\xba\xab6,HWNCE-L6750,NCE-AL10
+Huawei,\xe5\x8d\x8e\xe4\xb8\xba\xe7\x95\x85\xe4\xba\xab6,HWNCE-L6750,NCE-TL10
+Huawei,\xe5\x8d\x8e\xe4\xb8\xba\xe7\x95\x85\xe4\xba\xab6S,HWDIG-L8940,DIG-AL00
+Huawei,\xe5\x8d\x8e\xe4\xb8\xba\xe7\x95\x85\xe4\xba\xab6S,HWDIG-L8940,DIG-TL10
+Huawei,\xe5\x8d\x8e\xe4\xb8\xba\xe7\x95\x85\xe4\xba\xab7,HWSLA-Q,SLA-AL00
+Huawei,\xe5\x8d\x8e\xe4\xb8\xba\xe7\x95\x85\xe4\xba\xab7,HWSLA-Q,SLA-TL10
+Huawei,\xe5\x8d\x8e\xe4\xb8\xba\xe7\x95\x85\xe4\xba\xab7S,HWFIG-H,FIG-AL00
+Huawei,\xe5\x8d\x8e\xe4\xb8\xba\xe7\x95\x85\xe4\xba\xab7S,HWFIG-H,FIG-AL10
+Huawei,\xe5\x8d\x8e\xe4\xb8\xba\xe7\x95\x85\xe4\xba\xab7S,HWFIG-H,FIG-TL00
+Huawei,\xe5\x8d\x8e\xe4\xb8\xba\xe7\x95\x85\xe4\xba\xab7S,HWFIG-H,FIG-TL10
+Huawei,\xe8\x8d\xa3\xe8\x80\x80 V9 play,HWJMM-Q,JMM-AL00
+Huawei,\xe8\x8d\xa3\xe8\x80\x80 V9 play,HWJMM-Q,JMM-AL10
+Huawei,\xe8\x8d\xa3\xe8\x80\x80 V9 play,HWJMM-Q,JMM-TL00
+Huawei,\xe8\x8d\xa3\xe8\x80\x80 V9 play,HWJMM-Q,JMM-TL10
+Huawei,\xe8\x8d\xa3\xe8\x80\x804A,hwSCL-Q,SCL-AL00
+Huawei,\xe8\x8d\xa3\xe8\x80\x805X,HNKIW-Q,KIW-AL10
+Huawei,\xe8\x8d\xa3\xe8\x80\x805X,HNKIW-Q,KIW-AL20
+Huawei,\xe8\x8d\xa3\xe8\x80\x805X,HNKIW-Q,KIW-CL00
+Huawei,\xe8\x8d\xa3\xe8\x80\x805X,HNKIW-Q,KIW-TL00
+Huawei,\xe8\x8d\xa3\xe8\x80\x805X,HNKIW-Q,KIW-UL00
+Huawei,\xe8\x8d\xa3\xe8\x80\x808\xe9\x9d\x92\xe6\x98\xa5\xe7\x89\x88,HWPRA-H,PRA-AL00
+Huawei,\xe8\x8d\xa3\xe8\x80\x808\xe9\x9d\x92\xe6\x98\xa5\xe7\x89\x88,HWPRA-H,PRA-AL00X
+Huawei,\xe8\x8d\xa3\xe8\x80\x808\xe9\x9d\x92\xe6\x98\xa5\xe7\x89\x88,HWPRA-H,PRA-TL10
+Huawei,\xe8\x8d\xa3\xe8\x80\x809\xe9\x9d\x92\xe6\x98\xa5\xe7\x89\x88,HWLLD-H,LLD-AL00
+Huawei,\xe8\x8d\xa3\xe8\x80\x809\xe9\x9d\x92\xe6\x98\xa5\xe7\x89\x88,HWLLD-H,LLD-AL10
+Huawei,\xe8\x8d\xa3\xe8\x80\x809\xe9\x9d\x92\xe6\x98\xa5\xe7\x89\x88,HWLLD-H,LLD-TL10
+Huawei,\xe8\x8d\xa3\xe8\x80\x80Note8,hwedison,EDI-AL10
+Huawei,\xe8\x8d\xa3\xe8\x80\x80Note8,hwedison,EDI-DL00
+Huawei,\xe8\x8d\xa3\xe8\x80\x80\xe7\x95\x85\xe4\xba\xab7 Plus,HWTRT-Q,TRT-AL00
+Huawei,\xe8\x8d\xa3\xe8\x80\x80\xe7\x95\x85\xe4\xba\xab7 Plus,HWTRT-Q,TRT-AL00A
+Huawei,\xe8\x8d\xa3\xe8\x80\x80\xe7\x95\x85\xe4\xba\xab7 Plus,HWTRT-Q,TRT-TL10
+Huawei,\xe8\x8d\xa3\xe8\x80\x80\xe7\x95\x85\xe4\xba\xab7 Plus,HWTRT-Q,TRT-TL10A
+Huawei,\xe8\x8d\xa3\xe8\x80\x80\xe7\x95\x85\xe7\x8e\xa9 6X,HWBLN-H,BLN-AL10
+Huawei,\xe8\x8d\xa3\xe8\x80\x80\xe7\x95\x85\xe7\x8e\xa9 6X,HWBLN-H,BLN-AL20
+Huawei,\xe8\x8d\xa3\xe8\x80\x80\xe7\x95\x85\xe7\x8e\xa9 6X,HWBLN-H,BLN-AL30
+Huawei,\xe8\x8d\xa3\xe8\x80\x80\xe7\x95\x85\xe7\x8e\xa9 6X,HWBLN-H,BLN-AL40
+Huawei,\xe8\x8d\xa3\xe8\x80\x80\xe7\x95\x85\xe7\x8e\xa9 6X,HWBLN-H,BLN-TL00
+Huawei,\xe8\x8d\xa3\xe8\x80\x80\xe7\x95\x85\xe7\x8e\xa9 6X,HWBLN-H,BLN-TL10
+Huawei,\xe8\x8d\xa3\xe8\x80\x80\xe7\x95\x85\xe7\x8e\xa94C,hwCHM-H,CHM-TL00
+Huawei,\xe8\x8d\xa3\xe8\x80\x80\xe7\x95\x85\xe7\x8e\xa94C,hwCHM-H,CHM-TL00H
+Huawei,\xe8\x8d\xa3\xe8\x80\x80\xe7\x95\x85\xe7\x8e\xa94C,hwCHM-H,CHM-UL00
+Huawei,\xe8\x8d\xa3\xe8\x80\x80\xe7\x95\x85\xe7\x8e\xa94X,hnCHE-H,CHE-TL00
+Huawei,\xe8\x8d\xa3\xe8\x80\x80\xe7\x95\x85\xe7\x8e\xa94X,hnCHE-H,CHE-TL00H
+Huawei,\xe8\x8d\xa3\xe8\x80\x80\xe7\x95\x85\xe7\x8e\xa95A,HNCAM-H,CAM-TL00
+Huawei,\xe8\x8d\xa3\xe8\x80\x80\xe7\x95\x85\xe7\x8e\xa95A,HNCAM-H,CAM-TL00H
+Huawei,\xe8\x8d\xa3\xe8\x80\x80\xe7\x95\x85\xe7\x8e\xa95A,HNCAM-H,CAM-UL00
+Huawei,\xe8\x8d\xa3\xe8\x80\x80\xe7\x95\x85\xe7\x8e\xa95A,HNCAM-Q,CAM-AL00
+Huawei,\xe8\x8d\xa3\xe8\x80\x80\xe7\x95\x85\xe7\x8e\xa95A,HNCAM-Q,CAM-CL00
+Huawei,\xe8\x8d\xa3\xe8\x80\x80\xe7\x95\x85\xe7\x8e\xa95A,HWCAM-H,CAM-TL00
+Huawei,\xe8\x8d\xa3\xe8\x80\x80\xe7\x95\x85\xe7\x8e\xa95A,HWCAM-H,CAM-TL00H
+Huawei,\xe8\x8d\xa3\xe8\x80\x80\xe7\x95\x85\xe7\x8e\xa95A,HWCAM-H,CAM-UL00
+Huawei,\xe8\x8d\xa3\xe8\x80\x80\xe7\x95\x85\xe7\x8e\xa95A,HWCAM-Q,CAM-AL00
+Huawei,\xe8\x8d\xa3\xe8\x80\x80\xe7\x95\x85\xe7\x8e\xa95C,HNNEM-H,NEM-AL10
+Huawei,\xe8\x8d\xa3\xe8\x80\x80\xe7\x95\x85\xe7\x8e\xa95C,HNNEM-H,NEM-TL00
+Huawei,\xe8\x8d\xa3\xe8\x80\x80\xe7\x95\x85\xe7\x8e\xa95C,HNNEM-H,NEM-TL00H
+Huawei,\xe8\x8d\xa3\xe8\x80\x80\xe7\x95\x85\xe7\x8e\xa95C,HNNEM-H,NEM-UL10
+Huawei,\xe8\x8d\xa3\xe8\x80\x80\xe7\x95\x85\xe7\x8e\xa96,HWMYA-L6737,MYA-AL10
+Huawei,\xe8\x8d\xa3\xe8\x80\x80\xe7\x95\x85\xe7\x8e\xa96,HWMYA-L6737,MYA-TL10
+Huawei,\xe8\x8d\xa3\xe8\x80\x80\xe7\x95\x85\xe7\x8e\xa96A,HWDLI-Q,DLI-AL10
+Huawei,\xe8\x8d\xa3\xe8\x80\x80\xe7\x95\x85\xe7\x8e\xa97X,HWBND-H,BND-AL00
+Huawei,\xe8\x8d\xa3\xe8\x80\x80\xe7\x95\x85\xe7\x8e\xa97X,HWBND-H,BND-AL10
+Huawei,\xe8\x8d\xa3\xe8\x80\x80\xe7\x95\x85\xe7\x8e\xa97X,HWBND-H,BND-TL10
+Huawei,\xe8\x8d\xa3\xe8\x80\x80\xe7\x95\x85\xe7\x8e\xa9\xe5\xb9\xb3\xe6\x9d\xbf2 9.6,HWBZA-Q,BZA-L00
+Huawei,\xe8\x8d\xa3\xe8\x80\x80\xe7\x95\x85\xe7\x8e\xa9\xe5\xb9\xb3\xe6\x9d\xbf2 9.6,HWBZA-Q,BZA-W00
+Huawei,\xe9\xba\xa6\xe8\x8a\x924,hwRIO-AL00,HUAWEI RIO-AL00
+Huawei,\xe9\xba\xa6\xe8\x8a\x925,HWMLA,HUAWEI MLA-AL00
+Huawei,\xe9\xba\xa6\xe8\x8a\x925,HWMLA,HUAWEI MLA-AL10
+Huawei,\xe9\xba\xa6\xe8\x8a\x925,HWMLA,MLA-AL00
+Huawei,\xe9\xba\xa6\xe8\x8a\x925,HWMLA,MLA-AL10
+Hurricane,Ace,Ace,Ace
+Hurricane,Air,Air,Air
+Hurricane,Archer,Archer,Archer
+Hurricane,Atlas,Atlas,Atlas
+Hurricane,Beam,Beam,Beam
+Hurricane,Blast,Blast,Blast
+Hurricane,Blaze,Blaze,Blaze
+Hurricane,Bolt,Bolt,Hurricane_Bolt
+Hurricane,Charge,Charge,Charge
+Hurricane,Edge,Edge,Edge
+Hurricane,Epic,Epic,Epic
+Hurricane,Fire,Fire,Fire
+Hurricane,Flame,Flame,Flame
+Hurricane,Flex,Flex,Flex
+Hurricane,Flint,Flint,Flint
+Hurricane,Fuse,Fuse,Fuse
+Hurricane,Galaxy,Galaxy,Galaxy
+Hurricane,Giga,HURRICANE_GIGA,HURRICANE_GIGA
+Hurricane,Icon,Icon,Icon
+Hurricane,Ridge,Ridge,Ridge
+Hurricane,Rush,Hurricane,Rush
+Hurricane,SWIRL,Swirl,Swirl
+Hurricane,Sprint,Sprint,Sprint
+Hurricane,Surge,Surge,Surge
+Hurricane,Vega,Vega,Vega
+Hurricane,Vegas,Vegas,Vegas
+Hurricane,Vibe,Vibe,VIBE
+Hurricane,Volt,Hurricane,Volt
+Hurricane,Vortex,C9,HURRICANE VORTEX
+Hurricane,Vulcan,Vulcan,Vulcan
+Hurricane,Wave,Hurricane,Wave
+Hyundai,A25563L,A25563L,A25563L
+Hyundai,A26062L,A26062L,A26062L
+Hyundai,A26062k,A26062K,A26062K
+Hyundai,CAR AVN SYSTEM,koecn,TCC893X_EVM
+Hyundai,Eternity A24,A25024L,A25024L
+Hyundai,Eternity G22,G25022K,G25022K
+Hyundai,Eternity G23,G25523K,G25523K
+Hyundai,Eternity G24,G25524K,G25524K
+Hyundai,Eternity G27,G24027K,G24027K
+Hyundai,Eternity W42,W25042L,W25042L
+Hyundai,Eternity W44,W25544L,W25544L
+Hyundai,HT0702W08,HT0702W08,HT0702W08
+Hyundai,HY1-5085,HY1_5085,HY1-5085
+Hyundai,Hyundai Koral 10W,HT1002W16,HT1002W16
+Hyundai,Hyundai Koral 10X,HT1003X16,HT1003X16
+Hyundai,Hyundai Koral 7M3X,HT0703K,HT0703K16
+Hyundai,L500U,L500U,L500U
+Hyundai,L501,L501,L501
+Hyundai,L502,Hyundai_L502,L502
+Hyundai,L575,L575,L575
+Hyundai,Seoul_S8,Seoul_S8,Seoul S8
+Hyundai,Ultra Active,Ultra_Active,Ultra Active
+Hyundai,Ultra Charm,Ultra_Charm,Ultra Charm
+Hyundai,Ultra Dream,Ultra_Dream,Ultra Dream
+Hyundai,Ultra Energy Lite,Ultra_Energy_Lite,Ultra Energy Lite
+Hyundai,Ultra Energy Plus,Ultra_Energy_Plus,Ultra Energy Plus
+Hyundai,Ultra Latitude,Ultra_Latitude,Ultra Latitude
+Hyundai,Ultra Live II,HYUNDAI_Ultra_Live_II,Ultra Live II
+Hyundai,Ultra Shadow,Ultra_Shadow,Ultra Shadow
+Hyundai,Ultra Shine,Ultra_Shine,Ultra Shine
+Hyundai,Ultra Storm,Ultra_Storm,Ultra Storm
+Hyundai,Ultra Style,Ultra_Style,Ultra Style
+Hyundai,Ultra Sync,Ultra_Sync,Ultra Sync
+Hyundai,e501,e501,e501
+Hyundai,e502,e502,e502
+Hyundai,e551,e551,e551
+Hyundai,e551 Lite,e551_Lite,e551 Lite
+Hyve,Buzz BU01,buzz_bu01,BU01
+Hyve,Pryme01,pryme01,Pryme 01
+Hyve,Storm ST01,storm_st01,ST01
+ICL-KME CS OJSC,TR10CD1,TR10CD1_7,TR10CD1
+IDEA,i4901,i4901,i4901
+IMO(In My Opinion),IMO Q,IMO_Q,IMO Q
+INQ Mobile,,camden,Camden
+INQ Mobile,,camden,INQ Cloud Touch
+INQ Mobile,,camden,INQ Cloud Touch -parrot
+INQ Mobile,,msm7627_surf,INQ Mayfair (EU)
+IPRODA,T1144,T1144,T1144
+IUNI,N1,IUNI_N1,IUNI N1
+IUSA,TR10CS1,TR10CS1_7,TR10CS1
+IUSA,TR10CS1,TR10CS1_8,TR10CS1
+IView,1070TPC,tulip-d100,1070TPC
+IView,769TPC,tulip-d86v,769TPC
+IView,776TPCIII,776TPCIII,776TPCIII
+IView,778TPC,778TPC,778TPC
+IView,788TPCII,iView_788TPCII,788TPCII
+IView,920TPC,920TPC,920TPC
+IView,Retailer Stores,730TPC,730TPC
+IView,SupraPad i700,g01i,i700
+IView,SupraPad i785Q,anchor,i785Q
+Ice Phone,Mini,ice_phone_mini,Ice-Phone Mini
+Icon,Portal_10i,Portal_10i,NTMC17
+IkuMobile,I3,I3,IKU i3
+IkuMobile,IKU_i1,IKU_i1,i1
+IkuMobile,K2,IKU_K2,K2
+IkuMobile,T1,T1,iKU T1
+Ilike,X3_PRO_SLIM,X3_PRO_SLIM,X3 PRO SLIM
+Ilike,X5_PRO,X5_PRO,X5_PRO
+ImageMobile,Ipanema,C001,C001
+ImageMobile,Rio,Rio,B001
+Impecca,ET7050D,ET7050D,ET7050D
+Inet-Tablet,D711HC_PG,D711HC_PG,D711HC_PG
+Inet-Tablet,D7911L3BC_OGS,D7911L3BC_OGS,D7911L3BC_OGS
+Infinity,10.1-v2,Infinity-101-v2,Infinity-10.1-v2
+Infinity,10.1-v3,Infinity_101_v3,Infinity-10.1-v3
+Infinix,HOT 2,Infinix_X510,Infinix X510
+Infinix,HOT 3,INFINIX-X554,Infinix HOT 3 Pro
+Infinix,HOT 3,INFINIX-X554,Infinix-X554
+Infinix,HOT 3 LTE,INFINIX-X553,Infinix HOT 3 LTE
+Infinix,HOT 3 LTE,INFINIX-X553-A1,Infinix HOT 3 LTE
+Infinix,HOT 4,Infinix-X5511,Infinix HOT 4
+Infinix,HOT 4,Infinix-X5511,Infinix HOT4 LTE
+Infinix,HOT 4,X557,Infinix HOT 4
+Infinix,HOT 4,X557,Infinix X557
+Infinix,HOT 4,X557-Lite,Infinix HOT 4
+Infinix,HOT 4 Lite,X557-Lite,Infinix HOT 4 Lite
+Infinix,HOT 4 PRO,X556,Infinix HOT 4 Pro
+Infinix,HOT 4 PRO,X556,Infinix_X556_LTE
+Infinix,HOT 4 Pro,Infinix-X5511-13M,Infinix HOT 4 Pro
+Infinix,HOT 4 Pro,X556,Infinix HOT 4 Pro
+Infinix,HOT NOTE,Infinix-X551,Infinix-X551
+Infinix,HOT S3,Infinix-X573,Infinix X573
+Infinix,HOT5,Infinix-X559C,Infinix X559C
+Infinix,HOT5 Lite,Infinix-X559,Infinix X559
+Infinix,HOT5 Lite,X557,Infinix HOT 4
+Infinix,Infinix,Infinix_X510_sprout,Infinix X510
+Infinix,Infinix X5010,Infinix-X5010,Infinix X5010
+Infinix,Infinix X559,Infinix-X559,Infinix X559
+Infinix,Infinix X571,Infinix-X571,Infinix X571
+Infinix,Infinix X572,Infinix-X572,Infinix X572
+Infinix,NOTE 3,X601,Infinix NOTE 3
+Infinix,NOTE 3 Pro,X601-3G,Infinix NOTE 3 Pro
+Infinix,NOTE 3 Pro,X601-LTE,Infinix NOTE 3 Pro
+Infinix,NOTE 3 Pro,X601-LTE,Infinix_X601_LTE
+Infinix,NOTE 4,Infinix-X572,Infinix X572
+Infinix,NOTE 4,Infinix-X572,Infinix X572-LTE
+Infinix,NOTE 4 Pro,Infinix-X571,Infinix X571
+Infinix,RACE Blot2,Infinix_X454,Infinix X454
+Infinix,RACE Bolt 3,X455,Infinix X455
+Infinix,S2,Infinix-X522,Infinix S2
+Infinix,S2,Infinix-X522,Infinix S2 Pro
+Infinix,SURF 2,INFINIX_X511,Infinix X511
+Infinix,X405,up09_infinix_x405_gms,Infinix X405
+Infinix,X505,X505,Infinix X505
+Infinix,X521,Infinix-X521,Infinix HOT S
+Infinix,X521,Infinix-X521,Infinix-X521
+Infinix,X521,Infinix-X521,Infinix-X521-LTE
+Infinix,X521,Infinix-X521,Infinix_X521
+Infinix,X521,Infinix-X521-3G,Infinix-X521
+Infinix,X521,Infinix-X521-Pro,Infinix-X521
+Infinix,X521,Infinix-X521-Pro,Infinix_X521
+Infinix,X521,Infinix-X521-Pro,Infinix_X521_LTE
+Infinix,X521-H1,Infinix-X521-Pro,Infinix-X521
+Infinix,X521-H1,Infinix-X521-Pro,Infinix_X521
+Infinix,X521-I1,Infinix-X521,Infinix_X521
+Infinix,X521E1,Infinix-X521,Infinix HOT S
+Infinix,X521E1,Infinix-X521,Infinix-X521
+Infinix,X521E1,Infinix-X521,Infinix_X521
+Infinix,X521G1,Infinix-X521-Pro,Infinix-X521
+Infinix,X521G1,Infinix-X521-Pro,Infinix-X521_LTE
+Infinix,X521G1,Infinix-X521-Pro,Infinix_X521
+Infinix,X521S,Infinix-X521,Infinix-X521S
+Infinix,X521S,Infinix-X521,Infinix_X521S
+Infinix,X551,INFINIX-X551,INFINIX-X551
+Infinix,X552,INFINIX-X552,Infinix Zero 3
+Infinix,X552,INFINIX-X552,Infinix-X552
+Infinix,X552-C1,INFINIX-X552,Infinix-X552
+Infinix,X552-E1,INFINIX-X552-95M,Infinix Zero 3
+Infinix,X552-E1,INFINIX-X552-95M,Infinix-X552
+Infinix,X552-F1,INFINIX-X552-95M,Infinix Zero 3
+Infinix,X552-F1,INFINIX-X552-95M,Infinix-X552
+Infinix,X555,X555,Infinix Zero 4
+Infinix,X557F1,X557-Lite,Infinix HOT 4
+Infinix,X572,Infinix-X572,Infinix X572
+Infinix,X572,Infinix-X572,Infinix X572-LTE
+Infinix,X600,INFINIX-X600,INFINIX-X600
+Infinix,X600,INFINIX-X600-5M,INFINIX-X600
+Infinix,X600,INFINIX-X600-5M,Infinix-X600
+Infinix,X600,INFINIX-X600-H533-5M,Infinix-X600-LTE
+Infinix,Zero 2,Infinix_X509,Infinix X509
+Infinix,Zero 4,X555,Infinix Zero 4
+Infinix,Zero 4 Plus,X602,Infinix Zero 4 Plus
+Infinix,Zero 5,Infinix-X603,Infinix X603
+Infinix,Zero 5 Pro,Infinix-X603,Infinix X603
+Infinix,Zero 5 Pro,Infinix-X603,Infinix X603-LTE
+Infocus,A1S,AE2,InFocus M505
+Infocus,Amazing A8,D78,Amazing A8
+Infocus,Big Tab,IF195a,IF195a
+Infocus,Big Tab,IF236a,IF236a
+Infocus,C7,C2107,C2107
+Infocus,CS1 8.0,cs180,CS180
+Infocus,Epic 1,JGZ,TSP
+Infocus,FP-U320-INF-WLTW,U320-WF,FP-U320-INF-WLTW
+Infocus,IF9001,AA2,IF9001
+Infocus,IF9002,AB2,IF9002
+Infocus,IF9007,AG2,IF9007
+Infocus,IF9007,AG5,IF9007
+Infocus,IF9021,AU8,IF9021
+Infocus,IF9035_IN,A62,IF9035
+Infocus,IN260,IN260,IN260
+Infocus,IN335,IVM,IN335
+Infocus,IN610,MG2,IN610
+Infocus,IN810,VKY,IN810
+Infocus,IN815,VK3,IN815
+Infocus,InFocus M6S,AH2,IF9003
+Infocus,InFocus M7 Lite,A02,IF9031
+Infocus,InFocus M7S,A08,IF9031
+Infocus,M2,LSO,InFocus M2
+Infocus,M2+,LSC,InFocus M2PLUS
+Infocus,M210,M210,M210
+Infocus,M260,ZL2,InFocus M260
+Infocus,M2_3G,G10,InFocus M2_3G
+Infocus,M310,H1W,InFocus M310
+Infocus,M320,M320,InFocus M320
+Infocus,M320e,M320e,InFocus M320e
+Infocus,M320m,M320m,InFocus M320m
+Infocus,M320u,M320,InFocus M320u
+Infocus,M330,D77,InFocus M330
+Infocus,M350,G30,InFocus M350
+Infocus,M350,G3E,InFocus M350
+Infocus,M370,FOT,M370
+Infocus,M370i,FAT,M370i
+Infocus,M372,FOT,M372
+Infocus,M377,FO7,M377
+Infocus,M415,ZL3,InFocus M415
+Infocus,M425,HGO,InFocus M425
+Infocus,M430,HGO,InFocus M430
+Infocus,M460,G3T,InFocus M460
+Infocus,M500,InFocus_M500,InFocus M500
+Infocus,M510,TID_CHT,M510
+Infocus,M510t,TID,InFocus M510t
+Infocus,M511,TID_CHT,M510
+Infocus,M511,TID_TWN,M511
+Infocus,M512,MC2_CN,InFocus M512
+Infocus,M512,MC2_CN,M512
+Infocus,M518,MC2_APT,M518
+Infocus,M530,G20,InFocus M530
+Infocus,M535,G40,InFocus M535
+Infocus,M535_00WW,G40,InFocus M535
+Infocus,M550,ZZ1,InFocus M550
+Infocus,M550 3D,ZD1,InFocus M550 3D
+Infocus,M560,ZM1,InFocus M560
+Infocus,M5s,AB5,IF9002
+Infocus,M680,G42,InFocus M680
+Infocus,M808,ZM1,InFocus M808
+Infocus,M808i,ZM1,InFocus M808i
+Infocus,M810,VNA,InFocus M810
+Infocus,M810t,VNA,InFocus M810t
+Infocus,M812,VN2,InFocus M812
+Infocus,M812A,VN2,InFocus M812A
+Infocus,M812i,V2I,InFocus M812i
+Infocus,NewTab F1,f1,NewTab F1
+Infocus,Smart503,MC2,Smart503
+Infocus,T3000,P7M,T3000
+Infocus,VZH,VZH,VZH
+Infocus,VZU,VZH,VZU
+Infocus,Vision 3 Pro,AY2,IF9029
+Infocus,XT-50IP600,XT_50IP600,XT_50IP600
+Inhon,L35,L35,L35
+Inhon,L50,INHON_L50,L50
+Inhon,L55,L55,L55
+Inhon,V6,V6,Inhon_V6
+Innjoo,3,InnJoo_3,InnJoo_3
+Innjoo,Fire 4 Pro,Fire_4_Pro,Fire 4 Pro
+Innjoo,Halo 4 LTE,Halo_4_LTE,Halo 4 LTE
+Innjoo,Halo2 3G,Halo2_3G,Halo2 3G
+Innjoo,Halo2 LTE,Halo2_LTE,Halo2 LTE
+Innjoo,Halo4 mini LTE,Halo_4_mini_LTE,Halo_4_mini_LTE
+Innjoo,Max 4 Pro,Max_4_Pro,Max 4 Pro
+Innjoo,Max3 LTE,Max3_LTE,Max3_LTE
+Innjoo,VISION LTE,VISION_LTE,VISION LTE
+Insignia,FLEX 8\xe2\x80\x99\xe2\x80\x99 LTE Android Tablet,ns_15t8lte,NS-15T8LTE
+Insignia,Flex 10.1,ns_14t004,NS-14T004
+Insignia,"Flex 8""",ns_15at08,NS-15AT08
+Insignia,MID7802RA,MID7802RA,NS-P16AT785HD
+Insignia,NS-14T002,ns_14t002,NS-14T002
+Insignia,NS-15AT07,NS-15AT07,NS-15AT07
+Insignia,NS-15AT10,TA120,NS-15AT10
+Insignia,NS-P08A7100,NS-P08A7100,NS-P08A7100
+Insignia,NS-P10A6100,NS-P10A6100,NS-P10A6100
+Insignia,NS-P10A7100,NS-P10A7100,NS-P10A7100
+Insignia,NS-P10A8100,mid1023_ma,NS-P10A8100
+Insignia,NS-P10A8100K,mid1028_ma,NS-P10A8100K
+Insignia,NS-P11A8100,NS-P11A8100,NS-P11A8100
+Insignia,NS-P16AT08,mid8005,NS-P16AT08
+Insignia,NS-P16AT10,NS-P16AT10,NS-P16AT10
+Intel,,SP-A20i,SP-A20i
+Intel,,blackbay,Xolo_X900
+Intel,,noonhill,AZ210A
+Intel,,noonhill,AZ210B
+Intel,,noonhill,SP-A20i
+Intel,AQ710A,Salitpa,AQ710A
+Intel,Etisalat E-20,zeeyabeach,BT230
+Intel,INTEX\xc2\xa0AQUA\xc2\xa0LIONS\xc2\xa0N1,INTEX_AQUA_LIONS_N1,INTEX AQUA LIONS N1
+Intel,Orange San Diego,AZ210A,AZ210A
+Intel,Orange avec Intel Inside,AZ210B,AZ210B
+Intel,TR10CD1(PVT2),TR10CD1_4,TR10CD1
+Intel,TR10CD1(PVT2),TR10CD1_6,TR10CD1
+Intel,TR10CS1 (PVT2),TR10CS1_4,TR10CS1
+Intel,Xolo X500,zeeyabeach,Xolo_X500
+Intel,Yolo,zeeyabeach,BT210
+Intenso,Tab734,Tab734,Tab734
+Intenso,Tab814S,Tab814S,Tab814S
+Intermec,CN51,CN51_NC0,CN51 NC0
+Intermec,CN51,CN51_NCF,CN51 NCF
+Intermec,CN51,CN51_NCU,CN51 NCU
+Intermec,CN51,CN51_NN0,CN51 NN0
+Intermec,CN51,CN51_QC0,CN51 QC0
+Intermec,CN51,CN51_QCF,CN51 QCF
+Intermec,CN51,CN51_QCU,CN51 QCU
+Intermec,CN51,CN51_QN0,CN51 QN0
+Intex,AQUA 4G MINI,INTEX_AQUA_4G_MINI,INTEX AQUA 4G MINI
+Intex,AQUA CRYSTAL,INTEX_AQUA_CRYSTAL,INTEX AQUA CRYSTAL
+Intex,AQUA CRYSTAL+,AQUA_CRYSTAL_PLUS,INTEX AQUA CRYSTAL+
+Intex,AQUA LIONS 2,INTEX_AQUA_LIONS_2,INTEX AQUA LIONS 2
+Intex,AQUA LIONS T1 LITE,AQUA_LIONS_T1_LITE,INTEX AQUA LIONS T1 LITE
+Intex,AQUA TREND LITE,INTEX_AQUA_TREND_LITE,INTEX AQUA TREND LITE
+Intex,AQUA YOUNG 4G,INTEX_AQUA_YOUNG_4G,INTEX AQUA YOUNG 4G
+Intex,AQUA ZENITH,INTEX_AQUA_ZENITH,INTEX AQUA ZENITH
+Intex,AQUA_4.0_4G,INTEX_AQUA_4_4G,INTEX_AQUA_4.0_4G
+Intex,AQUA_S3,INTEX_AQUA_S3,INTEX AQUA S3
+Intex,Aqua 4.0 3G,INTEX_AQUA_4_3G,INTEX AQUA 4.0 3G
+Intex,Aqua 4G mini,INTEX_AQUA_4G_MINI,INTEX AQUA 4G MINI
+Intex,Aqua 5.5 VR,Aqua_5_5_VR,Aqua 5.5 VR
+Intex,Aqua 5.5 VR+,AQUA_5_5_VR_PLUS,INTEX AQUA 5.5 VR+
+Intex,Aqua A4,INTEX_AQUA_A4,INTEX AQUA A4
+Intex,Aqua A4+,INTEX_AQUA_A4_PLUS,INTEX AQUA A4 PLUS
+Intex,Aqua Aura 2GB,Aqua_Aura_2GB,Aqua Aura 2GB
+Intex,Aqua Jewel 2,INTEX_AQUA_JEWEL_2,INTEX AQUA JEWEL 2
+Intex,Aqua Lions 2,INTEX_AQUA_LIONS_2,INTEX AQUA LIONS 2
+Intex,Aqua Lions 3,INTEX_AQUA_LIONS_3,INTEX AQUA LIONS 3
+Intex,Aqua Power 4G,Intex_Aqua_Power_4G,Aqua Power 4G
+Intex,Aqua Power IV,INTEX_AQUA_POWER_IV,INTEX AQUA POWER IV
+Intex,Aqua Pride,AquaPride,Aqua Pride
+Intex,Aqua Ring,Aqua_Ring,Aqua_Ring
+Intex,Aqua Strong 5.1+,Aqua_Strong_5_1_Plus,Intex Aqua Strong 5.1+
+Intex,Aqua Supreme+,Aqua_Supreme_Plus,Intex Aqua Supreme+
+Intex,Aqua View,AquaView,Aqua View
+Intex,Aqua_Lions_4G,INTEX_AQUA_LIONS_4G,INTEX AQUA LIONS 4G
+Intex,Aqua_Q8,Aqua_Q8,Aqua Q8
+Intex,Cloud AX1,INTEX_CLOUD_AX1,INTEX CLOUD AX1
+Intex,Cloud style 4G,Intex_Cloud_Style_4G,Intex_Cloud_Style_4G
+Intex,Cloud_Q11_4G,Cloud_Q11_4G,Cloud Q11 4G
+Intex,Cloud_Q11_4G,Cloud_Q11_4G,Cloud_Q11_4G
+Intex,ELYT DUAL,INTEX_ELYT_DUAL,INTEX ELYT DUAL
+Intex,ELYT E1,INTEX_ELYT_E1,INTEX ELYT E1
+Intex,ELYT E6,INTEX_ELYT_E6,INTEX ELYT E6
+Intex,ELYT E7,INTEX_ELYT_E7,INTEX ELYT E7
+Intex,Elite E1,Intex_Elite_E1,Intex Elite E1
+Intex,INTEX  AQUA Lions T1,AQUA_LIONS_T1,INTEX AQUA LIONS T1
+Intex,INTEX AQUA AMAZE+,INTEX_AQUA_AMAZE_PLUS,INTEX AQUA AMAZE+
+Intex,INTEX AQUA LIONS X1,AQUA_LIONS_X1,INTEX AQUA LIONS X1
+Intex,INTEX AQUA LIONS X1+,AQUA_LIONS_X1_PLUS,INTEX AQUA LIONS X1+
+Intex,INTEX AQUA NOTE 5.5,AQUA_NOTE_5_5,INTEX AQUA NOTE 5.5
+Intex,INTEX AQUA S1,INTEX_AQUA_S1,INTEX AQUA S1
+Intex,INTEX AQUA STYLE 3,INTEX_AQUA_STYLE_3,INTEX AQUA STYLE 3
+Intex,INTEX Aqua Selfie,INTEX_AQUA_SELFIE,INTEX AQUA SELFIE
+Intex,i1,INTEX_i1,INTEX i1
+Inverse Net,EP172PR,EP172PR,EP172PR
+Irbis,IRBIS TZ175,TZ175,TZ175
+Irbis,IRBIS TZ176,TZ176,TZ176
+Irbis,IRBIS TZ178,TZ178,TZ178
+Irbis,IRBIS TZ198,TZ198,TZ198
+Irbis,IRBIS TZ737,TZ737,TZ737
+Irbis,IRBIS TZ747,TZ747,TZ747
+Irbis,IRBIS TZ752,TZ752,TZ752
+Irbis,IRBIS TZ753,TZ753,TZ753
+Irbis,SP454,SP454,SP454
+Irbis,SP455,SP455,SP455
+Irbis,SP510,SP510,SP510
+Irbis,SP511,SP511,SP511
+Irbis,SP550,SP550,SP550
+Irbis,SP551,SP551,SP551
+Irbis,TZ177,TZ177,TZ177
+Irbis,TZ184,TZ184,TZ184
+Irbis,TZ55,TZ55,TZ55
+Irbis,TZ716,TZ716,TZ716
+Irbis,TZ720,TZ720,TZ720
+Irbis,TZ721,TZ721,TZ721
+Irbis,TZ725,TZ725,TZ725
+Irbis,TZ726,TZ726,TZ726
+Irbis,TZ762,TZ762,TZ762
+Irbis,TZ771,TZ771,TZ771
+Irbis,TZ777,TZ777,TZ777
+Irbis,TZ794,TZ794,TZ794
+Irbis,TZ831,TZ831,TZ831
+Irbis,TZ841,TZ841,TZ841
+Irbis,TZ872,TZ872,TZ872
+Irbis,TZ874,TZ874,TZ874
+Irbis,TZ877,TZ877,TZ877
+Irbis,TZ885,TZ885,TZ885
+Irbis,TZ890,TZ890,TZ890
+Irbis,TZ892,TZ892,TZ892
+Irbis,TZ960,TZ960,TZ960
+Irbis,TZ961,TZ961,TZ961
+Irbis,TZ962,TZ962,TZ962
+Irbis,TZ965,TZ965,TZ965
+Irbis,TZ969,TZ969,TZ969
+Iris,IS2_Plus,IS2_Plus,IS2_Plus
+Itel,A11,itel_A11,itel A11
+Itel,A12,itel_A12,itel A12
+Itel,A13,itel_A13,itel A13
+Itel,A13 Plus,itel-A13Plus,itel A13Plus
+Itel,A21,itel_A21,itel A21
+Itel,A31,itel_A31,itel A31
+Itel,A31 Plus,itel-A31Plus,itel A31Plus
+Itel,A41,itel_A41,itel A41
+Itel,A41 Plus,itel_A41Plus,itel A41 Plus
+Itel,A42 Plus,itel-A42Plus,itel A42 Plus
+Itel,A43,itel-A43,itel A43
+Itel,A51,itel_A51,itel A51
+Itel,P11,itel_P11,itel P11
+Itel,P12,itel_P12,itel P12
+Itel,P31,itel-P31,itel P31
+Itel,P41,itel_P41,itel P41
+Itel,P51,P51,itel P51
+Itel,Prime 4,itel_Prime4,itel Prime 4
+Itel,S11,S11,itel S11
+Itel,S11 Plus,S11Plus,itel S11 Plus
+Itel,S11 Plus,S11Plus,itel S11Plus
+Itel,S12,itel-S12,itel S12
+Itel,S21,itel-S21,itel S21
+Itel,S31,S31,itel S31
+Itel,S32,itel-S32,itel S32
+Itel,S41,itel_S41,itel S41
+Itel,S42,itel-S42,itel S42
+Itel,it1355,itel_it1355,itel it1355
+Itel,it1355M,itel_it1355M,itel it1355M
+Itel,it1407,itel_it1407,itel it1407
+Itel,it1408,itel_it1408,itel it1408
+Itel,it1408,itel_it1408C,itel it1408
+Itel,it1409,itel_it1409,itel it1409
+Itel,it1460,itel-it1460-Pro,itel it1460
+Itel,it1460,itel-it1460-Pro,itel it1460 Pro
+Itel,it1505,itel_it1505,itel_it1505
+Itel,it1506,itel_it1506,itel it1506
+Itel,it1507,itel_it1507,itel it1507
+Itel,it1507,itel_it1507C,itel it1507
+Itel,it1508,itel_it1508,itel it1508
+Itel,it1508,itel_it1508C,itel it1508
+Itel,it1508 Plus,itel_it1508Plus,itel it1508
+Itel,it1508 Plus,itel_it1508Plus,itel it1508 Plus
+Itel,it1512,it1512,it1512
+Itel,it1513,itel_it1513,itel it1513
+Itel,it1516 Plus,itel_it1516Plus,itel it1516 Plus
+Itel,it1518,itel_it1518,itel it1518
+Itel,it1520,itel-it1520,itel-it1520
+Itel,it1550,itel_it1550,itel_it1550
+Itel,it1551,itel_it1551,itel it1551
+Itel,it1551,itel_it1551C,itel it1551
+Itel,it1553,itel-it1553,itel-it1553
+Itel,it1556,itel_it1556,itel it1556
+Itel,it1556 Plus,itel_it1556Plus,itel it1556 Plus
+Itel,it1556 Plus,itel_it1556Plus,itel it1556 plus
+Itel,it1655,itel_it1655,itel it1655
+Itel,it1655S,itel_it1655S,itel it1655S
+Itel,it1702,itel_it1702,itel it1702
+Itel,it1703,itel_it1703,itel it1703
+Itel,itel A20,itel-A20,itel A20
+Itel,itel A31,itel_A31,itel A31
+Itel,itel A40,itel-A40,itel A40
+Itel,itel A41,itel_A41,itel A41
+Itel,itel A42 Plus,itel-A42Plus,itel A42 Plus
+Itel,itel P41,itel_P41,itel P41
+Itel,itel Prime 4,itel_Prime4,itel Prime 4
+Itel,itel S12,itel-S12,itel S12
+Itel,itel S32LTE,itel-S32LTE,itel S32LTE
+Itworks,TM705,TM705,NID_7010
+JLab,PRO-7,polaris-p1gms,JLab PRO-7
+JP Sacouto,Flag Mill v2,MG101A2T_BT,Flag Mill v2
+JP Sacouto,Flag Mill v2,MG101A2T_BT_A50,Flag Mill v2
+JP Sacouto,Flag Mill v2,MG101A2T_BT_W32,Flag Mill v2
+JP Sacouto,MOVE_S201,move_S201_2_32_Z8350,MOVE_S201
+JP Sacouto,Mini Mill v2,MG070A2T_BT,Mini Mill v2
+JP Sacouto,TF10EA2,TF10EA2_Medical_2,CASEBOOK_3
+JP Sacouto,mymaga CLASS Plus 2,MG101A4T,mymaga CLASS Plus 2
+JVC,,gener,RY-AP1
+JVC,DM65UXR\\DM65USR\\DM85UXR,mstarnapoli_atsc,DM65UXR
+JabrBox,H460,H460,H460
+JabrBox,H460B01,H460,H460
+JabrBox,S502,S502,S502
+Janam,XM75,XM75,XM75
+Janam,XT100,XT100,XT100
+Janam,XT2,XT2,XT2
+Jide,Remix Mini,rm1g,Remix Mini
+Jinga,Touch 4G,Touch4G,Touch4G
+Jivi,Energy E12,Energy_E12,Energy E12
+Jivi,Prime P30,Prime_P30,Prime P30
+Jivi,Prime P444,Prime_P444,Prime P444
+Jivi,Prime P4442,Prime_P4442,Prime P4442
+Just5,CF8,CF8,CF8
+Just5,COSMO L707,COSMO_L707,COSMO_L707
+Just5,COSMO_L808,COSMO_L808,COSMO L808
+Just5,FREEDOM C100,FREEDOM_C100,FREEDOM C100
+Just5,FREEDOM C100,FREEDOM_C105,FREEDOM C105
+Just5,FREEDOM X1,FREEDOM_X1,FREEDOM X1
+Just5,Freedom M303,FREEDOM_M303,FREEDOM_M303
+Just5,GINI Tab V7,GINI_Tab_V7,GINI_Tab_V7
+Just5,Konrow,Konrow,Just5
+Just5,M503,M503,M503
+Just5,Mode1 MD-02P,MD-02P,MD-02P
+"K-Lite,",K-LITE NEXT M1,K-LITE_NEXT_M1,K-LITE_NEXT_M1
+K-Touch,,whistler,W808
+K-Touch,K-Touch920,KTOUCH920,K-Touch 920
+K-Touch,K3,K3,K-Touch K3
+K-Touch,L5,L5,L5
+K-Touch,L930i,L930i,K-Touch L930i
+K-Touch,M2s,M2s,K-Touch M2s
+K-Touch,Touch 2C,Touch2c,K-Touch Tou ch 2c
+KAAN,A1,KAAN_A1,KAAN_A1
+KAZAM,TROOPER X3.5,KAZAM,Trooper_X35
+KAZAM,TROOPER X4.0,KAZAM,Trooper_X40
+KAZAM,TROOPER X5.5,KAZAM,Trooper_X55
+KAZAM,TV 4.5,KOT49H,KAZAM TV 45
+KAZAM,TV 4.5,TV_45,KAZAM TV 45
+KAZAM,Thunder 345,Thunder_345,KAZAM Thunder 345
+KAZAM,Thunder 345 LTE,Thunder_345_LTE,KAZAM Thunder 345 LTE
+KAZAM,Thunder 345 LTE,Thunder_345_LTE,Thunder3 45 LTE
+KAZAM,Thunder 345L,Thunder_345L,KAZAM Thunder 345L
+KAZAM,Thunder 347,Thunder_347,Thunder 347
+KAZAM,Thunder 350L,Thunder_350L,KAZAM Thunder 350L
+KAZAM,Thunder 550,TH55025,KAZAM Thunder 550
+KAZAM,Thunder 550L,TH5L5025,KAZAM Thunder 550L
+KAZAM,Thunder2 45L,Thunder2_45,KAZAM THUNDER2 45L
+KAZAM,Thunder2 50,Thunder2_50,KAZAM Thunder2 50
+KAZAM,Tornado 348,Tornado_348,Tornado 348
+KAZAM,Tornado 350,KAZAM_Tornado_350,KAZAM Tornado 350
+KAZAM,Tornado 455L,KAZAM_Tornado_455L,KAZAM Tornado 455L
+KAZAM,Tornado2 50,Tornado2_50,KAZAM Tornado2 50
+KAZAM,Trooper 440L,Trooper_440L,KAZAM Trooper 440L
+KAZAM,Trooper 445L,TR4L4544,KAZAM Trooper 445L
+KAZAM,Trooper 450,KAZAM_Trooper_450,KAZAM Trooper 450
+KAZAM,Trooper 450L,KAZAM_Trooper_450L,KAZAM_Trooper_450L
+KAZAM,Trooper 451,Trooper_451,KAZAM Trooper 451
+KAZAM,Trooper 455,TR45544,KAZAM Trooper 455
+KAZAM,Trooper 540,TR54015,KAZAM Trooper 540
+KAZAM,Trooper 550L,TR5L5025,KAZAM Trooper 550L
+KAZAM,Trooper 551,TR550115,KAZAM Trooper 551
+KAZAM,Trooper 555,TR55515,KAZAM Trooper 555
+KAZAM,Trooper 650,TR65035,KAZAM Trooper 650
+KAZAM,Trooper 650 4G,TR6L5035,KAZAM Trooper 650 4G
+KAZAM,Trooper2 40,Trooper2_40,KAZAM Trooper2 40
+KAZAM,Trooper2 45,Trooper2_45,Trooper2 45
+KAZAM,Trooper2 50,Trooper2_50,KAZAM Trooper2 50
+KAZAM,Trooper2 60,Trooper2_60,Kazam Trooper2 60
+KD Interactive,C15100i,C15100i,C15100i
+KD Interactive,C15100m,Pixi3-7_KD,C15100m
+KD Interactive,C15150m,Pixi3-7_KD,C15150m
+KD Interactive,Kurio Phone,C14500,KurioPhone
+KD Interactive,Kurio Tab - Extrem,g03k,C14100
+KD Interactive,Kurio10S,C13300A,Kurio10S
+KD Interactive,Kurio4S,C13200A,Kurio4S
+KD Interactive,Kurio7S,C13000A,Kurio7S
+KD Interactive,TAB3-Premium-XTREME3,Pixi4-7_WIFI_KD,01016
+KD Interactive,TAB3-Premium-XTREME3,Pixi4-7_WIFI_KD,01516
+KDDI,CablePlus STB,C02AS,C02AS
+KDDI,Power Up Unit,C02BB1,C02BB1
+KDDI,STW2000,H02ST1,STW2000
+KDDI,SmartTV Box,C01AS,SMARTTVBOX
+KOOOK,C600,GBC_bravo,C600
+KT Tech,,s120,KM-S120
+KT Tech,,s200,KM-S200
+KT Tech,,s220,KM-S220
+KT Tech,,s220H,KM-S220H
+KT Tech,,s300,KM-S300
+KT Tech,,s330,KM-S330
+KT Tech,EV-S100,s100,EV-S100
+KT Tech,TAKE SUIT,e100,KM-E100
+Kalley,Klic,SA,K4-02 4G
+Kapsys,SmartVision2,r889,KAP11000
+Karbonn,A1 Indian,A1_Indian,A1 Indian
+Karbonn,A40 Indian,A40_Indian,A40 Indian
+Karbonn,A40 Indian Plus,A40_Indian_Plus,A40 Indian Plus
+Karbonn,A41 Power,A41_Power,A41 Power
+Karbonn,A45 Indian,A45_Indian,A45 Indian
+Karbonn,A9_Indian,A9_Indian,A9 Indian
+Karbonn,Aura  4G,Aura_4G,Aura 4G
+Karbonn,Aura Note 2,Aura_Note_2,Aura Note 2
+Karbonn,Aura Note 4G,AuraNote4G,Aura Note 4G
+Karbonn,Aura Note Play,Aura_Note_Play,Aura Note Play
+Karbonn,Aura Power,Aura_Power,Aura_Power
+Karbonn,Aura Power 4G,AuraPower4G,Aura Power 4G
+Karbonn,Aura Power 4G,Aura_Power_4G_Plus,Aura Power 4G Plus
+Karbonn,Aura Power 4G Plus,Aura_Power_4G_Plus,Aura Power 4G Plus
+Karbonn,Aura Sleek 4G,AuraSleek4G,Aura Sleek 4G
+Karbonn,K9 Kavach 4G,K9_Kavach,K9 Kavach 4G
+Karbonn,K9 Smart 4G,K9Smart4G,K9 Smart 4G
+Karbonn,K9 Smart Eco,K9_Smart_Eco,K9 Smart Eco
+Karbonn,K9 Smart Eco Plus,K9_Smart_Eco_Plus,K9 Smart Eco Plus
+Karbonn,K9 Smart Grand,K9_Smart_Grand,K9 Smart Grand
+Karbonn,K9 Smart Selfie,K9_Smart_Selfie,K9 Smart Selfie
+Karbonn,K9 Smart Yuva,K9_Smart_Yuva,K9 Smart Yuva
+Karbonn,K9 Viraat 4G,K9_VIRAAT_4G,K9 VIRAAT 4G
+Karbonn,Karbonn K9 Music 4G,K9Music4G,K9 Music 4G
+Karbonn,Karbonn Yuva2,Karbonn_Yuva_2,Karbonn Yuva 2
+Karbonn,Sparkle V,Sparkle_V_sprout,Sparkle V
+Karbonn,Titanium Frames S7,Titanium_Frames_S7,Titanium Frames S7
+Karbonn,Titanium Jumbo,Titanium_Jumbo,Titanium Jumbo
+Karbonn,Titanium Jumbo 2,Titanium_Jumbo_2,Titanium Jumbo 2
+Karbonn,Titanium Vista 4G,TitaniumVista4G,Titanium Vista 4G
+Kempler Strauss,Alumini 3 Plus,Alumini_3_Plus,Alumini_3_Plus
+Kenbo,O51,O51,O51
+Kennex,MD7053G,MD7053G,MD7053G
+Ketablet,Ketablet,TR10CS1_6,TR10CS1
+Kiano,Elegance 5.1,Elegance_5_1,Elegance_5_1
+Kiano,Elegance 5.1 Pro,ELEGANCE_5_1_PRO,ELEGANCE_5_1_PRO
+Kiano,Elegance 5.5,Elegance_5_5,Elegance_5_5
+Kiano,Elegance 5.5 Pro,Elegance_5_5_Pro,Elegance_5_5_Pro
+Kiano,Slim_Tab_8,Slim_Tab_8,Slim_Tab_8
+Klipad,7588AN,tulip-d9003,7588AN
+Klipad,7588AN,tulip-d9003,KL3838
+Klipad,KL450,KL450,KL450
+Klipad,KL600,KLIPAD_KL600,KLIPAD_KL600
+Klipad,KLIPAD_SMART_D71,KLIPAD_SMART_D71,KLIPAD_SMART_D71
+Klipad,PRO_I746,KLIPAD_PRO_I746,KLIPAD_PRO_I746
+Klipad,SMART_D791,KLIPAD_SMART_D791,KLIPAD_SMART_D791
+Klipad,SMART_I745,KLIPAD_SMART_I745,KLIPAD_SMART_I745
+Klipad,V355,V355,KLIPAD_V355
+Klipad,V355B,V355B,KLIPAD_V355B
+Kobo,Arc,zeus,Arc
+Kobo,Arc 10HD,macallan,arc 10HD
+Kobo,Arc 7,lbp8,arc 7
+Kobo,Arc 7HD,cardhu,arc 7HD
+Kobo,Vox,pegasus,Vox
+Kodak,Ektra,KodakEktra,Ektra
+Kodak,IM5,IM5,IM5
+Kodak,SP4,SP4,SP4
+Kogan,Agora 6 Plus,Kogan_Agora_6Plus,Kogan Agora 6Plus
+Kogan,Kogan Agora 8 Plus,Agora_8_Plus,Agora 8 Plus
+Konrow,LINK55,LINK55,LINK55
+Konrow,Primo,PRIMO,PRIMO
+Konrow,Smartfive,KONROW_Smartfive,Smartfive
+Krono,SKY,SKY,SKY
+Kruger&Matz,DRIVE 5,Drive_5,Kruger&Matz Drive 5
+Kruger&Matz,EAGLE 701,EAGLE_KM0701_1,KM0701_1
+Kruger&Matz,EAGLE 804,EAGLE_KM0804_1,KM0804_1
+Kruger&Matz,EAGLE 805,EAGLE_KM0805_1,KM0805_1
+Kruger&Matz,FLOW,Kruger_Matz_FLOW,FLOW
+Kruger&Matz,FLOW 5,FLOW_5,FLOW_5
+Kruger&Matz,FLOW 5+,FLOW5PLUS,FLOW5PLUS
+Kruger&Matz,KM1066,EAGLE_1066,KM1066
+Kruger&Matz,KM1067,EAGLE_1067,KM1067
+Kruger&Matz,LIVE 5,LIVE_5,Kr\xc3\xbcger&Matz _LIVE5_KM0450
+Kruger&Matz,LIVE 5 PLUS,LIVE_5_PLUS,LIVE 5 PLUS
+Kruger&Matz,MOVE 7,MOVE_7,MOVE_7
+Kubo,K5,K5,K5
+Kult,Gladiator,Gladiator,Gladiator
+Kult,Kult Ambition,Ambition,Ambition
+Kult,Kult Beyond,Beyond,Beyond
+Kyocera,,SCP-8600,Zio
+Kyocera,,WX06K,WX06K
+Kyocera,404KC,404KC,404KC
+Kyocera,503KC,503KC,503KC
+Kyocera,602KC,602KC,602KC
+Kyocera,Android One S2,S2_sprout,S2
+Kyocera,BASIO,KYV32,KYV32
+Kyocera,Brigadier,E6782,E6782
+Kyocera,DIGNO,KYI11,ISW11K
+Kyocera,DIGNO,KYL22,KYL22
+Kyocera,DIGNO Dual,WX04K,WX04K
+Kyocera,DIGNO L,KYV36,KYV36
+Kyocera,DIGNO R,202K,202K
+Kyocera,DIGNO S,KYL21,KYL21
+Kyocera,DIGNO T,302KC,302KC
+Kyocera,DIGNO V,KYV42,KYV42_u
+Kyocera,DIGNO W,KYV40,KYV40U
+Kyocera,DIGNO rafre,KYV36,KYV36
+Kyocera,DM015K,DM015K,DM015K
+Kyocera,DuraForce,E6560,KYOCERA-E6560
+Kyocera,DuraForce,E6560C,E6560C
+Kyocera,DuraForce,E6560L,E6560L
+Kyocera,DuraForce,E6560T,E6560T
+Kyocera,DuraForce,E6762,USCC-E6762
+Kyocera,DuraForce PRO,E6820,KYOCERA-E6820
+Kyocera,DuraForce PRO,E6820TM_3GB,E6820TM
+Kyocera,DuraForce PRO,E6820_3GB,KYOCERA-E6820
+Kyocera,DuraForce PRO,E6830,E6830
+Kyocera,DuraForce PRO,E6833,E6833
+Kyocera,DuraForce PRO with Sapphire Shield,E6810,E6810
+Kyocera,DuraForce PRO with Sapphire Shield,E6810_3GB,E6810
+Kyocera,DuraForce XD,E6790,KYOCERA-E6790
+Kyocera,DuraForce XD,E6790TM,E6790TM
+Kyocera,DuraScout,E6782L,E6782L
+Kyocera,Echo,KSP8000,KSP8000
+Kyocera,Echo,M9300,M9300
+Kyocera,Event,C5133,Event
+Kyocera,HONEY BEE,101K,101K
+Kyocera,Honeybee Touch,201K,201K
+Kyocera,Hydro,C5170,C5170
+Kyocera,Hydro,C5171,Hydro
+Kyocera,Hydro AIR,C6745,KYOCERA-C6745
+Kyocera,Hydro EDGE,C5215,C5215
+Kyocera,Hydro Elite,C6750,C6750
+Kyocera,Hydro ICON,C6730,C6730
+Kyocera,Hydro LIFE,C6530,C6530
+Kyocera,Hydro LIFE,C6530N,C6530N
+Kyocera,Hydro PLUS,C5171R,Hydro
+Kyocera,Hydro PLUS,C5171R,Hydro_PLUS
+Kyocera,Hydro REACH,C6743,C6743
+Kyocera,Hydro SHORE,C6742A,KYOCERA-C6742A
+Kyocera,Hydro VIBE,C6725,C6725
+Kyocera,Hydro VIEW,C6742,C6742
+Kyocera,Hydro VIEW,C6742,KYOCERA-C6742
+Kyocera,Hydro WAVE,C6740,C6740
+Kyocera,Hydro WAVE,C6740N,C6740N
+Kyocera,Hydro XTRM,C6522,C6522
+Kyocera,Hydro XTRM,C6522N,C6522N
+Kyocera,Hydro XTRM,C6721,USCC-C6721
+Kyocera,INFOBAR A03,KYV33,KYV33
+Kyocera,KC-01,KC-01,KC-01
+Kyocera,LUCE,KCP01K,KCP01K
+Kyocera,LifeWatch Universal Gateway,CD8100,CD8100
+Kyocera,Milano,C5120,C5120
+Kyocera,Milano,C5121,C5121
+Kyocera,Qua phone,KYV42,KYV42
+Kyocera,Qua phone (KYV37),KYV37,KYV37
+Kyocera,Rise,C5155,C5155
+Kyocera,Rise,C5156,Rise
+Kyocera,S301,KC-S301AE,KC-S301AE
+Kyocera,SZJ201,SZJ201,SZJ-JS201
+Kyocera,TORQUE,KC-100S,KC-100S
+Kyocera,TORQUE,SKT01,SKT01
+Kyocera,TORQUE G01,KYY24,KYY24
+Kyocera,TORQUE G02,KYV35,KYV35
+Kyocera,TORQUE G03,KYV41,KYV41
+Kyocera,TORQUE(KC-S701),KC-S701,KC-S701
+Kyocera,Torque,E6710,Torque
+Kyocera,TorqueXT,E6715,E6715
+Kyocera,URBANO L01,KYY21,KYY21
+Kyocera,URBANO L02,KYY22,KYY22
+Kyocera,URBANO L03,KYY23,KYY23
+Kyocera,URBANO PROGRESSO,KYY04,URBANO PROGRESSO
+Kyocera,URBANO V01,KYV31,KYV31
+Kyocera,URBANO V02,KYV34,KYV34
+Kyocera,URBANO V03,KYV38,KYV38
+Kyocera,WX10K,WX10K,WX10K
+Kyocera,Zio,SCP-8600,Zio
+Kyocera,miraie,KYL23,KYL23
+Kyocera,miraie f,KYV39,KYV39
+Kyocera,rafre,KYV40,KYV40
+Kyocera,zio,msm7627_kb60,Zio
+Kyocera,zio,msm7627_surf,Zio
+Kyocera,zio,pls8600,Zio
+Kyowon,All&G PAD,mypad2,KA-E410W
+LGE,,AS855,LG-AS855
+LGE,,LGP970,LG-P970
+LGE,,US855,USCC-US855
+LGE,,alessi,LG-E720
+LGE,,alessi,LG-E720b
+LGE,,alohag_302-220,LG-C710h
+LGE,,black,LG-KU5900
+LGE,,bproj_214-07,LG-P970
+LGE,,bproj_222-88,LG-P970
+LGE,,bproj_226-10,LG-P970
+LGE,,bproj_228-03,LG-P970
+LGE,,bproj_231-01,LG-P970
+LGE,,bproj_232-05,LG-P970
+LGE,,bproj_234-33,LG-P970
+LGE,,bproj_260-03,LG-P970
+LGE,,bproj_454-xxx,LG-P970
+LGE,,bproj_530-XXX,LG-P970
+LGE,,bproj_BAL-xxx,LG-P970
+LGE,,bproj_OPEN-CN,LG-P970
+LGE,,bproj_VDF-XXX,LG-P970
+LGE,,cosmo_268-06,LG-P920
+LGE,,cosmo_302-720,LG-P925g
+LGE,,cosmo_454-XXX,LG-P920
+LGE,,cosmo_466-92,LG-P920
+LGE,,cosmo_505-XXX,LG-P920
+LGE,,cosmo_515-XXX,LG-P920
+LGE,,cosmo_525-01,LG-P920
+LGE,,cosmo_525-05,LG-P920
+LGE,,cosmo_724-02,LG-P920h
+LGE,,cosmo_724-05,LG-P920h
+LGE,,cosmo_724-xxx,LG-P920h
+LGE,,cosmo_BAL-XXX,LG-P920
+LGE,,cosmo_CIS-XXX,LG-P920
+LGE,,cosmo_ESA-XXX,LG-P920
+LGE,,cosmo_H3G-XXX,LG-P920
+LGE,,cosmo_MOR-XXX,LG-P920
+LGE,,cosmo_OPEN-CN,LG-P920
+LGE,,cosmo_OPT-XXX,LG-P920
+LGE,,cosmo_TMO-XXX,LG-P920
+LGE,,cosmo_VDF-XXX,LG-P920
+LGE,,cosmo_tcl-mx,LG-P920h
+LGE,,cosmo_viv-br,LG-P920h
+LGE,,e510_724-XX,LG-E510f
+LGE,,envt2,USCC-US760
+LGE,,envt2,VS761
+LGE,,envt2,enV Pro
+LGE,,envt2,enV Touch2
+LGE,,gelato_262-xx,LG-P690
+LGE,,gelato_425-02,LG-P690f
+LGE,,gelato_460-xx,LG-P690
+LGE,,gelato_460-xx,LG-P693
+LGE,,gelato_are-xx,LG-P690
+LGE,,gelato_bal-xx,LG-P690
+LGE,,gelato_hkg-xx,LG-P690
+LGE,,gelato_mor-xx,LG-P690
+LGE,,gelato_nfc_234-10,LG-P692
+LGE,,gelato_nfc_530-24,LG-P692
+LGE,,gelato_nfc_tim-it,LG-P692
+LGE,,gelato_ngr-xx,LG-P690
+LGE,,gelato_sgp-xx,LG-P690
+LGE,,gelato_tmb-sk,LG-P690
+LGE,,gelato_tur-xx,LG-P690
+LGE,,gelato_win-it,LG-P690
+LGE,,gelatods_bal-xxx,LG-P698
+LGE,,gelatods_ngr-xxx,LG-P698
+LGE,,gelatods_open-xx,LG-P698
+LGE,,gelatods_tha-xxx,LG-P698f
+LGE,,hub,LG-LU3000
+LGE,,ku9500,KU9500
+LGE,,l95g,LG-L95G
+LGE,,ls700,LG-LS700
+LGE,,lu2300,LU2300
+LGE,,lu3100,LG-LU3100
+LGE,,msm8660_surf,LG-LU6200
+LGE,,p2,LG-P940h
+LGE,,p925g,LG-P925g
+LGE,,p940,LG-P940
+LGE,,p990_208-10,LG-P990
+LGE,,p990_214-01,LG-P990
+LGE,,p990_219-10,LG-P990
+LGE,,p990_226-01,LG-P990
+LGE,,p990_228-01,LG-P990
+LGE,,p990_234-xx,LG-P990
+LGE,,p990_262-02,LG-P990
+LGE,,p990_454-xxx,LG-P990
+LGE,,p990_466-92,LG-P990
+LGE,,p990_466-xxx,LG-P990
+LGE,,p990_505-xxx,LG-P990
+LGE,,p990_525-01,LG-P990
+LGE,,p990_525-05,LG-P990
+LGE,,p990_BAL-xxx,LG-P990
+LGE,,p990_esa-xxx,LG-P990
+LGE,,p990h,LG-P990h
+LGE,,p990h_334-020,LG-P990h
+LGE,,p990h_716-10,LG-P990h
+LGE,,p990h_722-34,LG-P990h
+LGE,,p990h_724-05,LG-P990h
+LGE,,p990h_730-01,LG-P990h
+LGE,,p990h_730-03,LG-P990h
+LGE,,p990h_CTM-xxx,LG-P990h
+LGE,,p990h_SSV-xxx,LG-P990h
+LGE,,p993,LG-P993
+LGE,,star,LG-P990hN
+LGE,,univa_228-01,LG-E510
+LGE,,univa_454-xx,LG-E510
+LGE,,univa_525-01,LG-E510
+LGE,,univa_525-05,LG-E510
+LGE,,univa_722-34,LG-E510g
+LGE,,univa_bal-xxx,LG-E510
+LGE,,univa_neu-xx,LG-E510
+LGE,,univa_open_cn,LG-E510
+LGE,,univa_tha-xx,LG-E510f
+LGE,,univa_tmo-gr,LG-E510
+LGE,,univa_vdf-es,LG-E510
+LGE,,v900aus,LG-V900
+LGE,,v901twn,LG-V901
+LGE,,x2_450-08,LG-KU8800
+LGE,,x3,LG-P880
+LGE,070 touch,w3voip,LG-FL40L
+LGE,10SM3TB,lg_10sm3tb,10sm3tb
+LGE,AKA,aka,LG-F520L
+LGE,AKA,aka,LG-F520S
+LGE,AKA,aka,LG-H788
+LGE,Ally,aloha,AS740
+LGE,Ally,aloha,Ally
+LGE,Ally,aloha,Aloha
+LGE,Ally,aloha,US740
+LGE,Android TV,cosmo,LG Google TV
+LGE,Android TV,eden,LG Android TV V4
+LGE,Android TV,eden,LG Google TV G3
+LGE,Android TV,eden,LG Google TV G3 KR
+LGE,Android TV G3,eden,LG Google TV G3
+LGE,B6,b6,LGT02
+LGE,DM-01G,DM-01G,DM-01G
+LGE,DM-02H,DM-02H,DM-02H
+LGE,Enact,fx3q,VS890 4G
+LGE,Escape,l1a,LG-P870
+LGE,Eve,EVE,GW620
+LGE,Eve,EVE,LG GW620
+LGE,Eve,EVE,LG GW620F
+LGE,Eve,EVE,LG GW620R
+LGE,Eve,EVE,LG GW620g
+LGE,Eve,EVE,LG KH5200
+LGE,Eve,EVE,LG-GW620
+LGE,Eve,EVE,LG-KH5200
+LGE,F60,e2,LG-D390
+LGE,F60,e2,LG-D390AR
+LGE,F60,e2ds,LG-D392
+LGE,F60,e2n,LG-D390n
+LGE,F60,e2nac,LG-D393
+LGE,F60,e2nam,LGMS395
+LGE,F60,e2nas,LGLS660
+LGE,F60,e2nav,VS810PP
+LGE,F70,f70,LGL31L
+LGE,Fortune,lv1,LG-M153
+LGE,Fortune,lv1,LG-M154
+LGE,G PAD\xe2\x85\xa2 10.1,th10,LG-X760
+LGE,G PAD\xe2\x85\xa2 10.1,th10,LG-X760E
+LGE,G PAD\xe2\x85\xa2 10.1,th10,LG-X760W
+LGE,G Pad 10.1,e9wifi,LG-V700
+LGE,G Pad 10.1,e9wifin,LG-V700WJ
+LGE,G Pad 10.1,e9wifin,LG-V700n
+LGE,G Pad 10.1 LTE,e9lte,LG-VK700
+LGE,G Pad 10.1 LTE,e9lte,VK700
+LGE,G Pad 7.0,e7wifi,LG-V400
+LGE,G Pad 7.0,e7wifi,LG-V400S1
+LGE,G Pad 7.0,e7wifi,LG-V400Y1
+LGE,G Pad 7.0,e7wifi,LG-V400Y7
+LGE,G Pad 7.0 LTE,e7lte,LG-V410
+LGE,G Pad 7.0 LTE,e7lte,LG-V411
+LGE,G Pad 7.0 LTE,e7lte,LGUK410
+LGE,G Pad 8+,altev2,AK815
+LGE,G Pad 8.0,e8wifi,LG-V480
+LGE,G Pad II 8.0,t8wifi,LG-V498
+LGE,G Pad II 8.0,t8wifi,LG-V498S1
+LGE,G Pad II 8.0,t8wifi,LG-V498S2
+LGE,G Pad III 8.0 Homeboy,b6,LG-P451L
+LGE,G Pad \xe2\x85\xa1 10.1,t1lte,LGUK932
+LGE,G Pad \xe2\x85\xa1 10.1 FHD 4G LTE,t1lte,LG-V935
+LGE,G Pad \xe2\x85\xa1 10.1 FHD 4G LTE,t1lte,LG-V935T
+LGE,G Pro Lite,luv90ds,LG-D685
+LGE,G Pro Lite,luv90ds,LG-D686
+LGE,G Pro Lite,luv90nfc,LG-D683
+LGE,G Pro Lite,luv90nfc,LG-D684
+LGE,G Pro Lite,luv90ss,LG-D680
+LGE,G Pro Lite,luv90ss,LG-D681
+LGE,G Pro Lite,luv90ss,LG-D682
+LGE,G Pro Lite,luv90ss,LG-D682TR
+LGE,G Pro2,b1,LG-F350K
+LGE,G Pro2,b1,LG-F350L
+LGE,G Pro2,b1,LG-F350S
+LGE,G Pro2,b1w,LG-D838
+LGE,G Stylo,g4stylusw,LG-F560K
+LGE,G Vista,b2lds,LG-D690
+LGE,G Vista,x10,VS880
+LGE,G Vista,x10,VS880PP
+LGE,G Watch,dory,G Watch
+LGE,G Watch R,lenok,G Watch R
+LGE,G pad 8.0,e8wifi,LG-V480
+LGE,G pad 8.0 LTE,e8lte,LG-V490
+LGE,G2 MINI,g2m,LG-D620
+LGE,G2 MINI,g2mds,LG-D618
+LGE,G2 MINI,g2mss,LG-D610
+LGE,G2 MINI,g2mss,LG-D610AR
+LGE,G2 MINI,g2mss,LG-D610TR
+LGE,G2 MINI,g2mv,LG-D625
+LGE,G2 mini 4G LTE,g2mv,LG-D625
+LGE,G3 Beat,jagdsnm,LG-D726
+LGE,G3 Beat,jagdsnm,LG-D728
+LGE,G3 Beat,jagdsnm,LG-D729
+LGE,G3 Beat,jagn,LG-F470K
+LGE,G3 Beat,jagn,LG-F470L
+LGE,G3 Beat,jagn,LG-F470S
+LGE,G3 Beat,jagnm,LG-D722J
+LGE,G3 Beat,jagnm,LG-D727
+LGE,G3 S,jag3gds,LG-D724
+LGE,G3 S,jag3gss,LG-D723
+LGE,G3 S,jagnm,LG-D722
+LGE,G3 S,jagnm,LG-D722AR
+LGE,G3 S,jagnm,LG-D725PR
+LGE,G3 Screen,liger,LG-F490L
+LGE,G3 Stylus,b2ldsn,LG-D690n
+LGE,G3 Stylus,b2lss,LG-D693
+LGE,G3 Stylus,b2lss,LG-D693AR
+LGE,G3 Stylus,b2lss,LG-D693TR
+LGE,G3 Stylus,b2lssn,LG-D693n
+LGE,G3 Vigor,jagc,LGLS885
+LGE,G3 Vigor,jagnm,LG-D725
+LGE,GA7800,eden,LG Android TV V4
+LGE,GPAD 7.0 LTE,e7lte,VK410
+LGE,Gentle,cf,LG-F580L
+LGE,Gpad 7.0,e7wifi,LG-V400
+LGE,Gx2,b2ln,LG-F430L
+LGE,Homeboy2,t8wi7u,LG-V607L
+LGE,Ice cream Smart,vfpv,LG-F440L
+LGE,Intuition,batman_vzw,VS950 4G
+LGE,K20,lv517,RS501
+LGE,K3 2017,lv0,LG-AS110
+LGE,K3 2017,lv0,LGUS110
+LGE,K4,lv1,LG-M151
+LGE,K4 (2017),lv1,LGL157BL
+LGE,K4 (2017),lv1,LGL57BL
+LGE,L Bello,luv80ds,LG-D335
+LGE,L Bello,luv80ds,LG-D335E
+LGE,L Bello,luv80ds,LG-D337
+LGE,L Fino,l70p,LG-D290
+LGE,L Fino,l70p,LG-D290AR
+LGE,L Fino,l70pds,LG-D295
+LGE,L Fino,l70pn,LG-D290
+LGE,L-01F,g2,L-01F
+LGE,L20,luv20ds,LG-D105
+LGE,L20,luv20ss,LG-D100
+LGE,L20,luv20ss,LG-D100AR
+LGE,L20,luv20ts,LG-D107
+LGE,L30 Sporty,luv30ds,LG-D125
+LGE,L30 Sporty,luv30ss,LG-D120
+LGE,L30 Sporty,luv30ss,LG-D120AR
+LGE,L45,lo_2,LG-X130g
+LGE,L45,lo_2_ds,LG-X132
+LGE,L50 Sporty,luv50ds,LG-D221
+LGE,L50 Sporty,luv50ds,LG-D227
+LGE,L50 Sporty,luv50ss,LG-D213
+LGE,L50 Sporty,luv50ss,LG-D213AR
+LGE,L50 Sporty,luv50ssn,LG-D213
+LGE,L5000,l5000,LG-F590
+LGE,L60,lo_1,LG-X135
+LGE,L60,lo_1,LG-X137
+LGE,L60,lo_1,LG-X140
+LGE,L60,lo_1,LG-X145
+LGE,L60,lo_1,LG-X147
+LGE,L65,w55,LG-D280
+LGE,L65,w55ds,LG-D285
+LGE,L65,w55n,LG-D280
+LGE,L7 II,vee7e,LG-P712
+LGE,L7 II,vee7e,LG-P714
+LGE,L7 II Dual,vee7ds,LG-P716
+LGE,L70,w5,LG-D320
+LGE,L70,w5,LG-D320AR
+LGE,L70,w5,LG-D321
+LGE,L70,w5,LGAS323
+LGE,L70,w5,LGMS323
+LGE,L70,w5c,LGLS620
+LGE,L70,w5ds,LG-D325
+LGE,L70,w5n,LG-D320
+LGE,L70,w5n,LG-D329
+LGE,L70,w5ts,LG-D340f8
+LGE,L70 CDMA,w5c,LGL41C
+LGE,L80 Dual,w6ds,LG-D380
+LGE,L80 Dual,w6ds,LG-D385
+LGE,L80 Single,w6,LG-D370
+LGE,L80 Single,w6,LG-D373
+LGE,L80 Single,w6,LG-D375
+LGE,L80 Single,w6,LG-D375AR
+LGE,L90,w7,LG-D400
+LGE,L90,w7,LG-D405
+LGE,L90,w7,LG-D415
+LGE,L90,w7ds,LG-D410
+LGE,L90,w7n,LG-D400
+LGE,L90,w7n,LG-D405
+LGE,L90 Dual,w7dsn,LG-D410
+LGE,LBello,luv80ss,LG-D331
+LGE,LBello,luv80ss,LG-D331AR
+LGE,LG AKA,aka,LG-H778
+LGE,LG AKA,aka,LG-H779
+LGE,LG AKA,aka,LG-H788
+LGE,LG AKA,aka,LG-H788SG
+LGE,LG AKA,aka,LG-H788TR
+LGE,LG AKA,aka,LG-H788n
+LGE,LG Aristo,lv3,LGMS210
+LGE,LG Bello II,v10,LG-X150
+LGE,LG Bello II,v10,LG-X155
+LGE,LG Bello II,v10,LG-X165g
+LGE,LG Bello II,v10,LG-X170g
+LGE,LG Class,c100n,LG-F620K
+LGE,LG Class,c100n,LG-F620L
+LGE,LG Class,c100n,LG-F620S
+LGE,LG Classic,y30t,LGL17AG
+LGE,LG Classic,y30tc,LGL18VC
+LGE,LG Connect 4G,cayman,LG-MS840
+LGE,LG DOUBLEPLAY,lgc729,LG-C729
+LGE,LG Destiny,y50,LGL21G
+LGE,LG Enlighten,VS700,LG-VS700
+LGE,LG Enlighten,VS700,LG-VS700PP
+LGE,LG Escape 3,m1v,LG-K373
+LGE,LG Escape2,c70n,LG-H443
+LGE,LG Escape2,c70n,LG-H445
+LGE,LG Esteem,MS910,LG-MS910
+LGE,LG F570S,yg,LG-F570S
+LGE,LG F70,f70n,LG-D315
+LGE,LG F70,f70n,LG-D315l
+LGE,LG F70,f70n,LG-F370K
+LGE,LG F70,f70n,LG-F370L
+LGE,LG F70,f70n,LG-F370S
+LGE,LG Fiesta 2 LTE,lv7,LGL163BL
+LGE,LG Fiesta 2 LTE,lv7,LGL164VL
+LGE,LG Fiesta LTE,lv7,LGL63BL
+LGE,LG Fiesta LTE,lv7,LGL64VL
+LGE,LG G Flex,zee,LG-D950
+LGE,LG G Flex,zee,LG-D950G
+LGE,LG G Flex,zee,LG-D951
+LGE,LG G Flex,zee,LG-D955
+LGE,LG G Flex,zee,LG-D956
+LGE,LG G Flex,zee,LG-D958
+LGE,LG G Flex,zee,LG-D959
+LGE,LG G Flex,zee,LG-F340K
+LGE,LG G Flex,zee,LG-F340L
+LGE,LG G Flex,zee,LG-F340S
+LGE,LG G Flex,zee,LG-LS995
+LGE,LG G Flex,zee,LGL23
+LGE,LG G Flex2,z2,LG-F510K
+LGE,LG G Flex2,z2,LG-F510L
+LGE,LG G Flex2,z2,LG-F510S
+LGE,LG G Flex2,z2,LG-H950
+LGE,LG G Flex2,z2,LG-H955
+LGE,LG G Flex2,z2,LG-H959
+LGE,LG G Flex2,z2,LGAS995
+LGE,LG G Flex2,z2,LGLS996
+LGE,LG G Flex2,z2,LGUS995
+LGE,LG G Pad 8.0 L Edition,e8lte,LGT01
+LGE,LG G Pad 8.0 LTE,e8lte,LG-P490L
+LGE,LG G Pad 8.3,awifi,LG-V500
+LGE,LG G Pad 8.3 Google Play Edition,palman,LG-V510
+LGE,LG G Pad 8.3 LTE,altev,VK810 4G
+LGE,LG G Pad 8.3 homeBoy,awifi070u,LG-V507L
+LGE,LG G Pad F 8.0,t8lte,LG-AK495
+LGE,LG G Pad F 8.0,t8lte,LG-UK495
+LGE,LG G Pad F 8.0,t8lte,LG-V495
+LGE,LG G Pad F 8.0,t8lte,LG-V496
+LGE,LG G Pad F 8.0,t8lte,LG-V499
+LGE,LG G Pad F2 8.0,mth8,LG-LK460
+LGE,LG G Pad F7.0,e7iilte,LGLK430
+LGE,LG G Pad F\xe2\x84\xa2 8.0 2nd Gen,t8lte,LG-AK495
+LGE,LG G Pad F\xe2\x84\xa2 8.0 2nd Gen,t8lte,LG-UK495
+LGE,LG G Pad II 10.1 FHD,t1wifi,LG-V940
+LGE,LG G Pad II 10.1 FHD,t1wifin,LG-V940n
+LGE,LG G Pad II 8.0LTE,t8lte,LG-V497
+LGE,LG G Pad II 8.3,altev2,LG-P815L
+LGE,LG G Pad III 10.1 FHD LTE,b5,LG-P755L
+LGE,LG G Pad III 10.1 FHD LTE,b5,LG-V755
+LGE,LG G Pad III 8.0,b3,LG-V522
+LGE,LG G Pad III 8.0 FHD,b3,LG-V525
+LGE,LG G Pad III 8.0 FHD,b3,LG-V525S1
+LGE,LG G Pad III 8.0 FHD,b3,LG-V525S3
+LGE,LG G Pad IV 8.0,tf840,LG-V533
+LGE,LG G Pad IV 8.0 FHD LTE,tf840,LG-P530L
+LGE,LG G Pad X 8.0,b3,LG-V521
+LGE,LG G Pad X 8.3,altev2,VK815
+LGE,LG G Pad X2 8.0 PLUS,tf840,LG-V530
+LGE,LG G Pad X\xc2\xae II 10.1,b5,LGUK750
+LGE,LG G Pad\xe2\x84\xa2 X 8.0,b3,LG-V520
+LGE,LG G Stylo,g4stylus,LG-H634
+LGE,LG G Stylo,g4stylusc,LGLS770
+LGE,LG G Stylo,g4stylusds,LG-H630D
+LGE,LG G Stylo,g4stylusdsn,LG-H630
+LGE,LG G Stylo,g4stylusn,LG-H631
+LGE,LG G Stylo,g4stylusn,LG-H631MX
+LGE,LG G Stylo,g4stylusn,LG-H635
+LGE,LG G Stylo,g4stylusn,LG-H635A
+LGE,LG G Stylo,g4stylusn,LG-H636
+LGE,LG G Stylo,g4stylusn,LGMS631
+LGE,LG G Vista,b2l,LG-D631
+LGE,LG G Vista 2,p1v,LG-H740
+LGE,LG G2,g2,LG-D800
+LGE,LG G2,g2,LG-D801
+LGE,LG G2,g2,LG-D802
+LGE,LG G2,g2,LG-D802T
+LGE,LG G2,g2,LG-D802TR
+LGE,LG G2,g2,LG-D803
+LGE,LG G2,g2,LG-D805
+LGE,LG G2,g2,LG-D806
+LGE,LG G2,g2,LG-F320K
+LGE,LG G2,g2,LG-F320L
+LGE,LG G2,g2,LG-F320S
+LGE,LG G2,g2,LG-LS980
+LGE,LG G2,g2,VS980 4G
+LGE,LG G3,g3,AS985
+LGE,LG G3,g3,LG-AS990
+LGE,LG G3,g3,LG-D850
+LGE,LG G3,g3,LG-D851
+LGE,LG G3,g3,LG-D852
+LGE,LG G3,g3,LG-D852G
+LGE,LG G3,g3,LG-D855
+LGE,LG G3,g3,LG-D856
+LGE,LG G3,g3,LG-D857
+LGE,LG G3,g3,LG-D858
+LGE,LG G3,g3,LG-D858HK
+LGE,LG G3,g3,LG-D859
+LGE,LG G3,g3,LG-F400K
+LGE,LG G3,g3,LG-F400L
+LGE,LG G3,g3,LG-F400S
+LGE,LG G3,g3,LGL24
+LGE,LG G3,g3,LGLS990
+LGE,LG G3,g3,LGUS990
+LGE,LG G3,g3,LGV31
+LGE,LG G3,g3,VS985 4G
+LGE,LG G3 A,tigers,LG-F410S
+LGE,LG G3 Cat.6,tiger6,LG-F460K
+LGE,LG G3 Cat.6,tiger6,LG-F460L
+LGE,LG G3 Cat.6,tiger6,LG-F460S
+LGE,LG G4,p1,AS986
+LGE,LG G4,p1,LG-AS811
+LGE,LG G4,p1,LG-AS991
+LGE,LG G4,p1,LG-F500K
+LGE,LG G4,p1,LG-F500L
+LGE,LG G4,p1,LG-F500S
+LGE,LG G4,p1,LG-H810
+LGE,LG G4,p1,LG-H811
+LGE,LG G4,p1,LG-H812
+LGE,LG G4,p1,LG-H815
+LGE,LG G4,p1,LG-H818
+LGE,LG G4,p1,LG-H819
+LGE,LG G4,p1,LGLS991
+LGE,LG G4,p1,LGUS991
+LGE,LG G4,p1,LGV32
+LGE,LG G4,p1,VS986
+LGE,LG G4 Beat,p1bdsn,LG-H736
+LGE,LG G4 Beat,p1bssn,LG-H735
+LGE,LG G4 Stylus,mp1s3gds,LG-H540
+LGE,LG G4 Stylus,mp1s3gss,LG-H542
+LGE,LG G4 vigor,p1bssn,LG-H731
+LGE,LG G4c,c90,LG-H525
+LGE,LG G4c,c90n,LG-H525n
+LGE,LG G4s,p1bds3g,LG-H734
+LGE,LG G5,h1,LG-F700K
+LGE,LG G5,h1,LG-F700L
+LGE,LG G5,h1,LG-F700S
+LGE,LG G5,h1,LG-H820
+LGE,LG G5,h1,LG-H820PR
+LGE,LG G5,h1,LG-H830
+LGE,LG G5,h1,LG-H831
+LGE,LG G5,h1,LG-H850
+LGE,LG G5,h1,LG-H858
+LGE,LG G5,h1,LG-H860
+LGE,LG G5,h1,LG-H868
+LGE,LG G5,h1,LGAS992
+LGE,LG G5,h1,LGLS992
+LGE,LG G5,h1,LGUS992
+LGE,LG G5,h1,RS988
+LGE,LG G5,h1,VS987
+LGE,LG G5 SE,alicee,LG-H840
+LGE,LG G5 SE,alicee,LG-H845
+LGE,LG G5 SE,alicee,LG-H848
+LGE,LG G6,lucye,LG-AS993
+LGE,LG G6,lucye,LG-H870
+LGE,LG G6,lucye,LG-H870AR
+LGE,LG G6,lucye,LG-H870DS
+LGE,LG G6,lucye,LG-H870I
+LGE,LG G6,lucye,LG-H870S
+LGE,LG G6,lucye,LG-H871
+LGE,LG G6,lucye,LG-H872
+LGE,LG G6,lucye,LG-H872PR
+LGE,LG G6,lucye,LG-H873
+LGE,LG G6,lucye,LG-LS993
+LGE,LG G6,lucye,LGM-G600K
+LGE,LG G6,lucye,LGM-G600L
+LGE,LG G6,lucye,LGM-G600S
+LGE,LG G6,lucye,LGUS997
+LGE,LG G6,lucye,VS988
+LGE,LG GRACE\xe2\x84\xa2 LTE,lv517,LGL59BL
+LGE,LG Gentle,cfm,LG-F660L
+LGE,LG Gpad X 10.1,t1lte,LG-V930
+LGE,LG Gx,omega,LG-F310L
+LGE,LG Gx,omegar,LG-F310LR
+LGE,LG Harmony,lv517,LG-M257
+LGE,LG Joy,y30,LG-H220
+LGE,LG Joy,y30dsf,LG-H222
+LGE,LG Joy,y30f,LG-H221
+LGE,LG Joy,y30f,LG-H221AR
+LGE,LG K10,m209n,LG-K425
+LGE,LG K10,m209n,LG-K428
+LGE,LG K10,m209n,LGMS428
+LGE,LG K10,m216,LG-K420
+LGE,LG K10,m216n,LG-F670K
+LGE,LG K10,m216n,LG-F670L
+LGE,LG K10,m216n,LG-F670S
+LGE,LG K10,m216n,LG-K420
+LGE,LG K10,m23g,LG-K410
+LGE,LG K10 (2017),lv517,LG-M257PR
+LGE,LG K10 (2017),mlv5,LG-M250
+LGE,LG K10 (2017),mlv5n,LG-M250
+LGE,LG K10 LTE,m209,LG-K420PR
+LGE,LG K10 LTE,m253,LG-K430
+LGE,LG K10 LTE,m253n,LG-K430
+LGE,LG K10 Power,mlv7,LG-M320
+LGE,LG K20,lv517n,LG-M255
+LGE,LG K20 Plus,lv517,LG-TP260
+LGE,LG K20 Plus,lv517,LGMP260
+LGE,LG K20 V,lv517,VS501
+LGE,LG K3,lv0,LGL48VL
+LGE,LG K3,me0,LGLS450
+LGE,LG K3 LTE,mme0,LG-K100
+LGE,LG K3 LTE,mme0n,LG-K100
+LGE,LG K4,e1q,LG-K120GT
+LGE,LG K4,e1q,LG-K121
+LGE,LG K4,e1q,VS425
+LGE,LG K4,lv1,LG-M160
+LGE,LG K4 LTE,me1,LG-K120
+LGE,LG K4 LTE,me1ds,LG-K130
+LGE,LG K4/K7 (2017),mlv1,LG-X230
+LGE,LG K4/K7 (2017),mlv1,LG-X230YK
+LGE,LG K5,d3,LG-X220
+LGE,LG K7,m1,LG-AS330
+LGE,LG K7,m1,LG-K330
+LGE,LG K7,m1,LGMS330
+LGE,LG K7,m13g,LG-X210
+LGE,LG K8,lv3,LG-M210
+LGE,LG K8,m1v,LGAS375
+LGE,LG K8,m1v,LGUS375
+LGE,LG K8,m1v,RS500
+LGE,LG K8,mm1v,LG-K350
+LGE,LG K8 (2017),lv3,LGUS215
+LGE,LG K8 (2017),lv3n,LG-M200
+LGE,LG K8 (2017),mlv3,LG-X240
+LGE,LG K8 (2017) Dual,lv3,LG-M200
+LGE,LG K8 LTE,mm1vn,LG-K350
+LGE,LG K8 V,m1v,VS500
+LGE,LG K8 V,m1v,VS500PP
+LGE,LG K8(2018),cv1,LM-X21(G)
+LGE,LG K8(2018),cv1,LM-X210(G)
+LGE,LG L39C,l4ii_cdma,LGL39C
+LGE,LG LEON\xe2\x84\xa2 LTE,c50,LG-H345
+LGE,LG Lancet,c50,VS820
+LGE,LG Leon,my50,LG-H320
+LGE,LG Leon,my50ds,LG-H324
+LGE,LG Leon,my50ds,LG-H326
+LGE,LG Leon 4G LTE,c50,LG-H340
+LGE,LG Leon 4G LTE,c50,LG-H340AR
+LGE,LG Leon 4G LTE,c50,LG-H340GT
+LGE,LG Leon 4G LTE,c50,LG-H343
+LGE,LG Leon 4G LTE,c50,LGMS345
+LGE,LG Leon 4G LTE,c50ds,LG-H342
+LGE,LG Leon 4G LTE,c50n,LG-H340n
+LGE,LG Leon TV,my50ds,LG-H326
+LGE,LG Logos,c70,LGUS550
+LGE,LG Lucid,cayman,VS840 4G
+LGE,LG Lucid,cayman,VS840PP
+LGE,LG Lucid 2,l1v,VS870 4G
+LGE,LG Lucid 3,x5,VS876
+LGE,LG M1,m1ds,LG-K332
+LGE,LG Mach\xe2\x84\xa2,l2s,LG-LS860
+LGE,LG Magna,my90,LG-H500
+LGE,LG Magna,my90,LG-T540
+LGE,LG Magna,my90ds,LG-H502
+LGE,LG Magna LTE,mc90,LG-H520
+LGE,LG Max,v10,LG-X155
+LGE,LG Max,v10,LG-X160
+LGE,LG Max,v10,LG-X165g
+LGE,LG Motion 4G,l0,LG-MS770
+LGE,LG OPTIMUS M+,m3_mpcs_us,LG-MS695
+LGE,LG OPTIMUS ZIP,lgl75c,LGL75C
+LGE,LG Optimus 3D,cosmopolitan,LG-P920
+LGE,LG Optimus 3D,cosmopolitan,LG-P925g
+LGE,LG Optimus 3D,cosmopolitan,LG-SU760
+LGE,LG Optimus ELITE\xe2\x84\xa2,m3s,LG-VM696
+LGE,LG Optimus Elite,m3s,LG Optimus Elite
+LGE,LG Optimus Elite,m3s,LG-LS696
+LGE,LG Optimus F3Q,fx3q,LG-D520
+LGE,LG Optimus F7,fx1,LG-AS780
+LGE,LG Optimus F7,fx1,LG-LG870
+LGE,LG Optimus F7,fx1,LG-US780
+LGE,LG Optimus G,geeb,LG-E970
+LGE,LG Optimus G,geeb,LG-E971
+LGE,LG Optimus G,geeb,LG-E973
+LGE,LG Optimus G,geehdc,L-01E
+LGE,LG Optimus G,geehdc,LGL21
+LGE,LG Optimus G,geehrc,LG-E975
+LGE,LG Optimus G,geehrc,LG-E975K
+LGE,LG Optimus G,geehrc,LG-E975T
+LGE,LG Optimus G,geehrc,LG-E976
+LGE,LG Optimus G,geehrc,LG-E977
+LGE,LG Optimus G,geehrc,LG-E987
+LGE,LG Optimus G,geehrc,LG-F180K
+LGE,LG Optimus G,geehrc,LG-F180S
+LGE,LG Optimus G,geehrc4g,LG-F180L
+LGE,LG Optimus G,geehrc4g,LG-LS970
+LGE,LG Optimus G Pro,geefhd,LG-E980
+LGE,LG Optimus G Pro,geefhd,LG-E980h
+LGE,LG Optimus G Pro,geefhd,LG-E981h
+LGE,LG Optimus G Pro,geefhd,LG-E986
+LGE,LG Optimus G Pro,geefhd,LG-E988
+LGE,LG Optimus G Pro,geefhd,LG-E989
+LGE,LG Optimus G Pro,geefhd,LG-F240K
+LGE,LG Optimus G Pro,geefhd,LG-F240S
+LGE,LG Optimus G Pro,geefhd4g,LG-F240L
+LGE,LG Optimus HUB,univa_222-01,LG-E510
+LGE,LG Optimus HUB,univa_arb-xx,LG-E510
+LGE,LG Optimus HUB,univa_cis-xxx,LG-E510
+LGE,LG Optimus HUB,univa_esa-xx,LG-E510
+LGE,LG Optimus HUB,univa_eur-xx,LG-E510
+LGE,LG Optimus HUB,univa_open-eu,LG-E510
+LGE,LG Optimus HUB,univa_tur-xx,LG-E510
+LGE,LG Optimus L1II,v1,LG-E410
+LGE,LG Optimus L1II,v1,LG-E410B
+LGE,LG Optimus L1II,v1,LG-E410c
+LGE,LG Optimus L1II,v1,LG-E410f
+LGE,LG Optimus L1II,v1,LG-E410g
+LGE,LG Optimus L1II,v1,LG-E410i
+LGE,LG Optimus L1II,v1,LG-E411f
+LGE,LG Optimus L1II,v1,LG-E411g
+LGE,LG Optimus L1II,v1ds,LG-E415f
+LGE,LG Optimus L1II,v1ds,LG-E415g
+LGE,LG Optimus L1II,v1ds,LG-E420
+LGE,LG Optimus L1II,v1ds,LG-E420f
+LGE,LG Optimus L1II,v1ts,LG-E475f
+LGE,LG Optimus L3,e0,LG-E400
+LGE,LG Optimus L3,e0,LG-E400R
+LGE,LG Optimus L3,e0,LG-E400b
+LGE,LG Optimus L3,e0,LG-E400f
+LGE,LG Optimus L3,e0,LG-E400g
+LGE,LG Optimus L3,e0,LG-L38C
+LGE,LG Optimus L3,e0,LGL35G
+LGE,LG Optimus L3,e0_open_eur,LG-E400
+LGE,LG Optimus L3 Dual,e1,LG-E405
+LGE,LG Optimus L3 Dual,e1,LG-E405f
+LGE,LG Optimus L3 II,vee3ds,LG-E435
+LGE,LG Optimus L3 II,vee3ds,LG-E435f
+LGE,LG Optimus L3 II,vee3ds,LG-E435g
+LGE,LG Optimus L3 II,vee3ds,LG-E435k
+LGE,LG Optimus L3 II,vee3e,LG-E425
+LGE,LG Optimus L3 II,vee3e,LG-E425c
+LGE,LG Optimus L3 II,vee3e,LG-E425f
+LGE,LG Optimus L3 II,vee3e,LG-E425g
+LGE,LG Optimus L3 II,vee3e,LG-E425j
+LGE,LG Optimus L3 II,vee3e,LG-E430
+LGE,LG Optimus L3 II,vee3e,LG-E431g
+LGE,LG Optimus L4 II,vee4ss,LG-E440
+LGE,LG Optimus L4 II,vee4ss,LG-E440f
+LGE,LG Optimus L4 II,vee4ss,LG-E440g
+LGE,LG Optimus L4 II,vee4ss,LG-E465f
+LGE,LG Optimus L4 II,vee4ss,LG-E465g
+LGE,LG Optimus L4 II Dual,vee4ds,LG-E445
+LGE,LG Optimus L4 II Dual,vee4ds,LG-E467f
+LGE,LG Optimus L4 II Tri,vee4ts,LG-E470f
+LGE,LG Optimus L5 Dual,m4ds,LG-E615
+LGE,LG Optimus L5 Dual,m4ds,LG-E615f
+LGE,LG Optimus L5 II,vee5ds,LG-E455
+LGE,LG Optimus L5 II,vee5ds,LG-E455f
+LGE,LG Optimus L5 II,vee5ds,LG-E455g
+LGE,LG Optimus L5 II,vee5nfc,LG-E460
+LGE,LG Optimus L5 II,vee5nfc,LG-E460f
+LGE,LG Optimus L5 II,vee5ss,LG-E450
+LGE,LG Optimus L5 II,vee5ss,LG-E450B
+LGE,LG Optimus L5 II,vee5ss,LG-E450f
+LGE,LG Optimus L5 II,vee5ss,LG-E450g
+LGE,LG Optimus L5 II,vee5ss,LG-E450j
+LGE,LG Optimus L5 II,vee5ss,LG-E451g
+LGE,LG Optimus L5 II,vee5ss,LG-E460
+LGE,LG Optimus L7,u0,LG-P700
+LGE,LG Optimus L7,u0,LG-P705
+LGE,LG Optimus L7,u0,LG-P705f
+LGE,LG Optimus L7,u0,LG-P705g
+LGE,LG Optimus L7,u0,LG-P708g
+LGE,LG Optimus L7,u0,LG-T280
+LGE,LG Optimus L7,u0,LGL96G
+LGE,LG Optimus L7,vee7ds,LG-P715
+LGE,LG Optimus L7 II,vee7e,LG-P710
+LGE,LG Optimus L7 II,vee7e,LG-P712
+LGE,LG Optimus L7 II,vee7e,LG-P713
+LGE,LG Optimus L7 II,vee7e,LG-P713GO
+LGE,LG Optimus L7 II,vee7e,LG-P713TR
+LGE,LG Optimus L7 II,vee7e,LG-P714
+LGE,LG Optimus L7II,vee7ds,LG-P715
+LGE,LG Optimus L7II,vee7ds,LG-P716
+LGE,LG Optimus L9,u2,LG-D700
+LGE,LG Optimus L9,u2,LG-P760
+LGE,LG Optimus L9,u2,LG-P765
+LGE,LG Optimus L9,u2,LG-P768
+LGE,LG Optimus L9,u2,LG-P769
+LGE,LG Optimus L9,u2,LG-P778
+LGE,LG Optimus L9,u2,LGMS769
+LGE,LG Optimus L9 (NFC),u2,LG-P760
+LGE,LG Optimus L9 II,l9ii,LG-D605
+LGE,LG Optimus LTE Tag,cayman,LG-AS840
+LGE,LG Optimus LTE Tag,cayman,LG-F120K
+LGE,LG Optimus LTE Tag,cayman,LG-F120L
+LGE,LG Optimus LTE Tag,cayman,LG-F120S
+LGE,LG Optimus LTE Tag,lge_120_kt,LG-F120K
+LGE,LG Optimus LTE Tag,lge_120_skt,LG-F120S
+LGE,LG Optimus LTE2,d1lkt,LG-F160K
+LGE,LG Optimus LTE2,d1lsk,LG-F160S
+LGE,LG Optimus LTE2,d1lu,LG-F160L
+LGE,LG Optimus LTE2,d1lu,LG-F160LV
+LGE,LG Optimus LTE3,fx1sk,LG-F260S
+LGE,LG Optimus One,thunderg,LG-P500
+LGE,LG Optimus One,thunderg,LG-P500h
+LGE,LG Optimus One,thunderg,LG-P503
+LGE,LG Optimus One,thunderg,LG-P504
+LGE,LG Optimus One,thunderg,LG-P505
+LGE,LG Optimus One,thunderg,LG-P505CH
+LGE,LG Optimus One,thunderg,LG-P505R
+LGE,LG Optimus One,thunderg,LG-P506
+LGE,LG Optimus One,thunderg,LG-P509
+LGE,LG Optimus Regard,l0,LG-LW770
+LGE,LG Optimus Select,u0_cdma,LG-AS730
+LGE,LG Optimus Zone 2,w3c,VS415PP
+LGE,LG Pecan,pecan,LG-P350
+LGE,LG Pecan,pecan,LG-P350f
+LGE,LG Pecan,pecan,LG-P350g
+LGE,LG Phoenix 2,m1v,LG-K371
+LGE,LG Power,y50c,LGL22C
+LGE,LG Prime II,v10,LG-X170fTV
+LGE,LG Prime II,v10,LG-X170g
+LGE,LG Prime Plus 4G,mc90ds,LG-H522
+LGE,LG Q6,mh,LG-M700
+LGE,LG Q6,mhn,LG-M700
+LGE,LG Q6,mhn,LG-M703
+LGE,LG Q6,mhn,LG-US700
+LGE,LG Q6,mhn,LGM-X600K
+LGE,LG Q6,mhn,LGM-X600L
+LGE,LG Q6,mhn,LGM-X600S
+LGE,LG RAY,d2,LG-X190
+LGE,LG Rebel,e1q,LGL43AL
+LGE,LG Rebel,e1q,LGL44VL
+LGE,LG Revolution,bryce,VS910 4G
+LGE,LG SUNSET,c50,LGL33L
+LGE,LG Smart Folder,cf2,LGM-X100L
+LGE,LG Smart Folder,cf2,LGM-X100S
+LGE,LG Spectrum,VS920,VS920 4G
+LGE,LG Spirit,my70,LG-H420
+LGE,LG Spirit 4G LTE,c70n,LG-H440n
+LGE,LG Spirit LTE,c70,LG-H440
+LGE,LG Spirit LTE,c70,LG-H440AR
+LGE,LG Stylo 2,ph1,LG-K540
+LGE,LG Stylo 2,ph1,LGL81AL
+LGE,LG Stylo 2,ph1,LGL82VL
+LGE,LG Stylo 2,ph1,LGLS775
+LGE,LG Stylo 2 Plus,ph2n,LG-K550
+LGE,LG Stylo 2 Plus,ph2n,LG-K557
+LGE,LG Stylo 2 Plus,ph2n,LGMS550
+LGE,LG Stylo 3 Plus,sf340n,LG-M470
+LGE,LG Stylo 3 Plus,sf340n,LG-M470F
+LGE,LG Stylo 3 Plus,sf340n,LG-TP450
+LGE,LG Stylo 3 Plus,sf340n,LGMP450
+LGE,LG Stylo3,sf317,LG-M430
+LGE,LG Stylo3,sf317,LGL83BL
+LGE,LG Stylo3,sf317,LGL84VL
+LGE,LG Stylo3,sf340,LG-LS777
+LGE,LG Stylus 2,ph1,LG-F720K
+LGE,LG Stylus 2,ph1,LG-F720L
+LGE,LG Stylus 2,ph1,LG-F720S
+LGE,LG Stylus 2,ph1,LG-K520
+LGE,LG Stylus2,ph1n,LG-K520
+LGE,LG Stylus2 4G,ph2,LG-K530
+LGE,LG Stylus2 4G,ph2,LG-K535
+LGE,LG Stylus2 Plus,ph2n,LG-K535
+LGE,LG Stylus2 Plus,ph2n,LG-K535n
+LGE,LG Stylus3,msf3,LG-M400
+LGE,LG Stylus3,msf3n,LG-M400
+LGE,LG Thrill 4G,cosmopolitan,LG-P925
+LGE,LG Treasure,m1,LGL51AL
+LGE,LG Treasure,m1,LGL52VL
+LGE,LG Tribute 2\xe2\x84\xa2,c50,LGLS665
+LGE,LG Tribute 5,m1,LGLS675
+LGE,LG Tribute Dynasty,mcv150,LG-SP200
+LGE,LG U,bbg,LG-F820L
+LGE,LG Venice,u0_cdma,LG-LG730
+LGE,LG Viper 4G LTE,cayman,LG-LS840
+LGE,LG Volt,my70ds,LG-H422
+LGE,LG Volt,x5,LGLS740
+LGE,LG Volt 4G,c70ds,LG-H442
+LGE,LG Volt II,c90nas,LGLS751
+LGE,LG Volt LTE,c70w,LG-F540K
+LGE,LG Volt LTE,c70w,LG-F540L
+LGE,LG Volt LTE,c70w,LG-F540S
+LGE,LG Volt S,c90,LG-F640S
+LGE,LG Watch Sport,swordfish,LG Watch Sport
+LGE,LG Watch Style,angelfish,LG Watch Style
+LGE,LG Watch Urbane,bass,LG Watch Urbane
+LGE,LG Watch Urbane 2nd Edition LTE,nemo,LG Watch Urbane
+LGE,LG Wine Smart,cf,LG-H410
+LGE,LG Wine Smart Jazz,cf,LG-F610K
+LGE,LG Wine Smart Jazz,cf,LG-F610S
+LGE,LG X Screen,k5,LGK500J
+LGE,LG X Skin,k6b,LG-F740L
+LGE,LG X Style,k6b,LG-K200
+LGE,LG X Style,k6b,LGL53BL
+LGE,LG X Style,k6b,LGL56VL
+LGE,LG X Style,k6b,LGLS676
+LGE,LG X Venture,lv9,LG-US701
+LGE,LG X Venture,lv9n,LG-H700
+LGE,LG X Venture,lv9n,LG-M710
+LGE,LG X Venture,lv9n,LG-M710ds
+LGE,LG X cam,k7,LG-F690L
+LGE,LG X cam,k7,LG-F690S
+LGE,LG X cam,k7,LG-K580
+LGE,LG X cam,k7n,LG-K580
+LGE,LG X cam,k7n,LG-K580Y
+LGE,LG X charge,lv7,LG-M322
+LGE,LG X charge,lv7,LG-M327
+LGE,LG X max,mk6m,LG-K240
+LGE,LG X power,k6p,LG-K210
+LGE,LG X power,k6p,LG-K212
+LGE,LG X power,k6p,LG-K450
+LGE,LG X power,k6p,LGUS610
+LGE,LG X power,mk6p,LG-F750K
+LGE,LG X power,mk6p,LG-K220
+LGE,LG X power,mk6p55,LGLS755
+LGE,LG X power,mk6pn,LG-K220
+LGE,LG X power2,lv7,LG-M320G
+LGE,LG X screen,k5,LG-F650K
+LGE,LG X screen,k5,LG-F650L
+LGE,LG X screen,k5,LG-F650S
+LGE,LG X screen,k5,LG-K500
+LGE,LG X screen,k5,LGS02
+LGE,LG X screen,k5n,LG-K500
+LGE,LG X screen,k5n,LG-K500n
+LGE,LG X300,lv3n,LGM-K120K
+LGE,LG X300,lv3n,LGM-K120L
+LGE,LG X300,lv3n,LGM-K120S
+LGE,LG X400,mlv5n,LGM-K121K
+LGE,LG X400,mlv5n,LGM-K121L
+LGE,LG X400,mlv5n,LGM-K121S
+LGE,LG X400,mlv5n,LGM-X301K
+LGE,LG X400,mlv5n,LGM-X301L
+LGE,LG X400,mlv5n,LGM-X301S
+LGE,LG X400,mlv5n,LGM-X401L
+LGE,LG X400,mlv5n,LGM-X401S
+LGE,LG X5,mk6m,LG-F770S
+LGE,LG X500,mlv7n,LG-M320
+LGE,LG X500,mlv7n,LGM-X320K
+LGE,LG X500,mlv7n,LGM-X320L
+LGE,LG X500,mlv7n,LGM-X320S
+LGE,LG ZONE,d2,LG-X180g
+LGE,LG Zero,c100,LG-H650
+LGE,LG optimus it L-05D,l_dcm,L-05D
+LGE,LG optimus it L-05E,L05E,L-05E
+LGE,LG-AS876,x5,AS876
+LGE,LG-D150,w35,LG-D150
+LGE,LG-D157f,w35ds,LG-D157f
+LGE,LG-E985T,gvarfhd,LG-E985
+LGE,LG-E985T,gvarfhd,LG-E985T
+LGE,LGL22,g2,LGL22
+LGE,Marquee,L-07C,L-07C
+LGE,Marquee,LG855,LG-LG855
+LGE,Marquee,LS855,LG-LS855
+LGE,Marquee,bproj_CIS-xxx,LG-P970
+LGE,My touch 4G,e739,LG-E739
+LGE,Nexus 4,mako,Nexus 4
+LGE,Nexus 5,hammerhead,Nexus 5
+LGE,Nexus 5X,bullhead,Nexus 5X
+LGE,Optiimus Black,bproj_208-01,LG-P970
+LGE,Optimus  EX,x2,LG-SU880
+LGE,Optimus  LTE,l1a,LG-P870
+LGE,Optimus 2,as680,LG-AS680
+LGE,Optimus 2X,p990,LG-P990
+LGE,Optimus 2X,p990,LG-P990H
+LGE,Optimus 2X,p990,LG-P990h
+LGE,Optimus 2X,p990_262-xx,LG-P990
+LGE,Optimus 2X,p990_CIS-xxx,LG-P990
+LGE,Optimus 2X,p990_EUR-xx,LG-P990
+LGE,Optimus 2X,p990hN,LG-P990hN
+LGE,Optimus 2X,p999,LG-P999
+LGE,Optimus 2X,star,LG-P990
+LGE,Optimus 2X,star,LG-SU660
+LGE,Optimus 2X,star_450-05,LG-SU660
+LGE,Optimus 2X,su660,LG-SU660
+LGE,Optimus 3D,cosmo_450-05,LG-SU760
+LGE,Optimus 3D,cosmo_EUR-XXX,LG-P920
+LGE,Optimus 3D,cosmo_MEA-XXX,LG-P920
+LGE,Optimus 3D,p920,LG-P920
+LGE,Optimus 3D,p920,LG-P920h
+LGE,Optimus 3D,su760,LG-SU760
+LGE,Optimus 3D Cube,cx2,LG-SU870
+LGE,Optimus 3D MAX,cx2,LG-P720
+LGE,Optimus 3D MAX,cx2,LG-P720h
+LGE,Optimus 3D MAX,cx2,LG-P725
+LGE,Optimus 3D MAX,cx2,LG-SU870
+LGE,Optimus 4X HD,x3,LG-P880
+LGE,Optimus 4X HD,x3,LG-P880g
+LGE,Optimus Big,justin,LG-LU6800
+LGE,Optimus Big,lu6800,LG-LU6800
+LGE,Optimus Black,LGL85C,LGL85C
+LGE,Optimus Black,black,LG-KU5900
+LGE,Optimus Black,blackg,LG-P970
+LGE,Optimus Black,blackg,LG-P970h
+LGE,Optimus Black,bproj_214-03,LG-P970
+LGE,Optimus Black,bproj_262-XXX,LG-P970
+LGE,Optimus Black,bproj_302-220,LG-P970g
+LGE,Optimus Black,bproj_334-020,LG-P970h
+LGE,Optimus Black,bproj_724-xxx,LG-P970h
+LGE,Optimus Black,bproj_ARE-XXX,LG-P970
+LGE,Optimus Black,bproj_EUR-XXX,LG-P970
+LGE,Optimus Black,bproj_sea-xxx,LG-P970
+LGE,Optimus Black,ku5900,LG-KU5900
+LGE,Optimus Black,lgp970,LG-P970
+LGE,Optimus Black,lgp970,LG-P970g
+LGE,Optimus Black,lgp970,LG-P970h
+LGE,Optimus Chat,hazel,LG-C550
+LGE,Optimus Chat,hazel,LG-C555
+LGE,Optimus Core,u0_cdma,LGL86C
+LGE,Optimus EX,x2,IS11LG
+LGE,Optimus EX,x2_450-05,LG-SU880
+LGE,Optimus Exceed 2,w5c,LG-VS450PP
+LGE,Optimus F3,fx3,LG-LS720
+LGE,Optimus F3,fx3,LG-P655H
+LGE,Optimus F3,fx3,LG-P655K
+LGE,Optimus F3,fx3,LG-P659
+LGE,Optimus F3,fx3,LG-P659H
+LGE,Optimus F3,fx3,LGL25L
+LGE,Optimus F3,fx3,LGMS659
+LGE,Optimus F5,l1e,LG-P870h
+LGE,Optimus F5,l1e,LG-P875
+LGE,Optimus F5,l1e,LG-P875h
+LGE,Optimus F5,l1v,AS870 4G
+LGE,Optimus F6,f6,LG-D500
+LGE,Optimus F6,f6,LG-D505
+LGE,Optimus F6,f6,LGMS500
+LGE,Optimus Fuel,w3c,LGL34C
+LGE,Optimus G Pro,geevl04e,L-04E
+LGE,Optimus GJ,geehdc,LG-E975w
+LGE,Optimus GK,gvfhd,LG-F220K
+LGE,Optimus Hub,lgc800,LG-C800
+LGE,Optimus Hub,lgc800g,LG-C800G
+LGE,Optimus Hub,univa_214-04,LG-E510
+LGE,Optimus Hub,univa_724-05,LG-E510f
+LGE,Optimus Hub,univa_730-01,LG-E510g
+LGE,Optimus Hub,univa_730-03,LG-E510g
+LGE,Optimus Hub,univa_740-01,LG-E510g
+LGE,Optimus Hub,univa_clr-br,LG-E510f
+LGE,Optimus Hub,univa_ctm-xxx,LG-E510g
+LGE,Optimus Hub,univa_ent-cl,LG-E510g
+LGE,Optimus Hub,univa_open-br,LG-E510f
+LGE,Optimus Hub,univa_open-de,LG-E510
+LGE,Optimus Hub,univa_ssv-xxx,LG-E510g
+LGE,Optimus Hub,univa_tcl-mx,LG-E510f
+LGE,Optimus Hub,univa_tlf-es,LG-E510
+LGE,Optimus Hub,univa_ufn-mx,LG-E510g
+LGE,Optimus Hub,univa_usc-mx,LG-E510g
+LGE,Optimus Hub,univa_viv-br,LG-E510f
+LGE,Optimus L40,w3,LG-D160
+LGE,Optimus L40,w3,LG-D165
+LGE,Optimus L40,w3,LG-D165AR
+LGE,Optimus L40,w3ds,LG-D170
+LGE,Optimus L40,w3ds,LG-D175f
+LGE,Optimus L40,w3ts,LG-D180f
+LGE,Optimus L5,m4,LG-E610
+LGE,Optimus L5,m4,LG-E610v
+LGE,Optimus L5,m4,LG-E612
+LGE,Optimus L5,m4,LG-E612f
+LGE,Optimus L5,m4,LG-E612g
+LGE,Optimus L5,m4,LG-E617G
+LGE,Optimus L5,m4,LG-L40G
+LGE,Optimus L7II,vee7ds,LG-P716
+LGE,Optimus LIFE,l1_dcm,L-02E
+LGE,Optimus LTE,i_dcm,L-01D
+LGE,Optimus LTE,i_skt,LG-SU640
+LGE,Optimus LTE,i_u,LG-LU6200
+LGE,Optimus LTE,iproj,LG-P936
+LGE,Optimus LTE,lgp930,LG-P930
+LGE,Optimus LTE,lgp935,LG-P935
+LGE,Optimus Mach,LU3000,LG-LU3000
+LGE,Optimus Mach,hub,LG-LU3000
+LGE,Optimus Mach,lu3000,LG-LU3000
+LGE,Optimus Net,gelato_302-610,LG-P690b
+LGE,Optimus Net,gelato_cis-xx,LG-P690
+LGE,Optimus Net,gelato_sea-xx,LG-P690
+LGE,Optimus Net,lgl45c,LGL45C
+LGE,Optimus Net Dual,gelatods_are-xxx,LG-P698
+LGE,Optimus Net Dual,gelatods_cis-xxx,LG-P698
+LGE,Optimus Net Dual,gelatods_ind-xxx,LG-P698
+LGE,Optimus Net Dual,gelatods_open-br,LG-P698f
+LGE,Optimus Net Dual,gelatods_sea-xxx,LG-P698
+LGE,Optimus One,ku3700,LG-KU3700
+LGE,Optimus One,lu3700,LG-LU3700
+LGE,Optimus One,su370,LG-SU370
+LGE,Optimus One,thunder_kor-05,LG-SU370
+LGE,Optimus One,thunder_kor-08,LG-KU3700
+LGE,Optimus One,thunder_kor-08,LG-LU3700
+LGE,Optimus One,thunderc,LG-CX670
+LGE,Optimus One,thunderc,LG-LW690
+LGE,Optimus One,thunderc,LG-MS690
+LGE,Optimus One,thunderc,LG-US670
+LGE,Optimus One,thunderc,LS670
+LGE,Optimus One,thunderc,VM670
+LGE,Optimus One,thunderc,Vortex
+LGE,Optimus One,thunderc,thunderc
+LGE,Optimus PAD LTE,express,LG-LU8300
+LGE,Optimus Pad,l06c,L-06C
+LGE,Optimus Pad,v900,LG-V900
+LGE,Optimus Pad,v900asia,LG-V900
+LGE,Optimus Pad,v901ar,LG-V901
+LGE,Optimus Pad,v901kr,LG-V901
+LGE,Optimus Pad,v901tr,LG-V901
+LGE,Optimus Pad,v905r,LG-V905R
+LGE,Optimus Pad,v909,LG-V909
+LGE,Optimus Pad,v909mkt,LG-V909
+LGE,Optimus Plus,m3_acg_us,LG-AS695
+LGE,Optimus Pro,muscat,LG-C660
+LGE,Optimus Pro,muscat,LG-C660R
+LGE,Optimus Pro,muscat,LG-C660h
+LGE,Optimus Q,lgl55c,LGL55C
+LGE,Optimus Q2,bssq,LG-LU6500
+LGE,Optimus Q2,bssq_450-06,LG-LU6500
+LGE,Optimus Slider,VM701,LG-VM701
+LGE,Optimus Sol,victor,LG-E730
+LGE,Optimus Sol,victor,LG-E730f
+LGE,Optimus Spirit,gelato_505-01,LG-P690f
+LGE,Optimus Spirit,gelato_eur-xx,LG-P690
+LGE,Optimus Vu,325,LG-F100L
+LGE,Optimus Vu,batman,LG-F100L
+LGE,Optimus Vu,batman,LG-F100S
+LGE,Optimus Vu,batman_dcm,L-06DJOJO
+LGE,Optimus Vu,batman_lgu,LG-F100L
+LGE,Optimus Vu,batman_skt,LG-F100S
+LGE,Optimus Vu,lge_325_skt,LG-F100S
+LGE,Optimus Vu,vu10,LG-P895
+LGE,Optimus Vu,vu10,LG-P895qb
+LGE,Optimus Vu2,vu2kt,LG-F200K
+LGE,Optimus Vu2,vu2sk,LG-F200S
+LGE,Optimus Vu2,vu2u,LG-F200L
+LGE,Optimus Vu2,vu2u,LG-F200LS
+LGE,Optimus Vu:,batman_dcm,L-06D
+LGE,Optimus Z,su950,SU950
+LGE,Optimus Zone,e0v,LG-VS410PP
+LGE,Optimus chat,elini,L-04C
+LGE,PRADA 3.0,p2,L-02D
+LGE,PRADA 3.0,p2,LG-KU5400
+LGE,PRADA 3.0,p2,LG-LU5400
+LGE,PRADA 3.0,p2,LG-P940
+LGE,PRADA 3.0,p2,LG-P940h
+LGE,PRADA 3.0,p2,LG-SU540
+LGE,PecanV,pecanV,LG-P355
+LGE,Phoenix 3,lv1,LG-M150
+LGE,Premier,m209,LGL61AL
+LGE,Premier,m209,LGL62VL
+LGE,Q8,anna,LG-H970
+LGE,Q8,anna,LGM-X800K
+LGE,Q8,anna,LGM-X800L
+LGE,Qua phone PX,JSG,LGV33
+LGE,Qua tab PX,b3,LGT31
+LGE,Qua tab PZ,b5,LGT32
+LGE,Rebel 3,lv1,LGL158VL
+LGE,Rebel 3,lv1,LGL58VL
+LGE,Shine Plus with Google,alohag,LG-C710h
+LGE,Smart Dios V8700,SE_TF,ref_SCTF
+LGE,Spectrum,i_vzw,VS920 4G
+LGE,Spectrum 2,d1lv,VS930 4G
+LGE,Spirit 4G,l1m,LG-MS870
+LGE,Splendor,u0_cdma,LG-US730
+LGE,Spray,e2jps,402LG
+LGE,Spree,e1q,LG-K120
+LGE,Stylo 2 V,mph1,VS835
+LGE,Swift,swift,GT540
+LGE,Swift,swift,GT540GO
+LGE,Swift,swift,GT540R
+LGE,Swift,swift,GT540f
+LGE,TBD,aka,LG-F520K
+LGE,Thrill 4G,cosmo_310-410,LG-P925
+LGE,Thrill 4G,p925,LG-P925
+LGE,V10,pplus,LG-F600K
+LGE,V10,pplus,LG-F600L
+LGE,V10,pplus,LG-F600S
+LGE,V10,pplus,LG-H900
+LGE,V10,pplus,LG-H900PR
+LGE,V10,pplus,LG-H901
+LGE,V10,pplus,LG-H960
+LGE,V10,pplus,LG-H961AN
+LGE,V10,pplus,LG-H961N
+LGE,V10,pplus,LG-H961S
+LGE,V10,pplus,LG-H962
+LGE,V10,pplus,LG-H968
+LGE,V10,pplus,RS987
+LGE,V10,pplus,VS990
+LGE,V20,elsa,LG-F800K
+LGE,V20,elsa,LG-F800L
+LGE,V20,elsa,LG-F800S
+LGE,V20,elsa,LG-H910
+LGE,V20,elsa,LG-H910PR
+LGE,V20,elsa,LG-H915
+LGE,V20,elsa,LG-H918
+LGE,V20,elsa,LG-H990
+LGE,V20,elsa,LG-LS997
+LGE,V20,elsa,LG-US996
+LGE,V20,elsa,LGV34
+LGE,V20,elsa,VS995
+LGE,V20 PRO,L-01J,L-01J
+LGE,V30,joan,LG-AS998
+LGE,V30,joan,LG-H930
+LGE,V30,joan,LG-H931
+LGE,V30,joan,LG-H932
+LGE,V30,joan,LG-H932PR
+LGE,V30,joan,LG-H933
+LGE,V30,joan,LG-LS998
+LGE,V30,joan,LG-US998
+LGE,V30,joan,LGM-V300K
+LGE,V30,joan,LGM-V300L
+LGE,V30,joan,LGM-V300S
+LGE,V30,joan,VS996
+LGE,V30+,joan,LGV35
+LGE,VU3,vu3,LG-F300K
+LGE,VU3,vu3,LG-F300L
+LGE,VU3,vu3,LG-F300S
+LGE,WM-LG8200,b6,LG-V425
+LGE,WM-LG8200,b6,WM-LG8200
+LGE,Wine Smart,cf,LGS01
+LGE,Wine Smart,vfp,LG-D486
+LGE,Wine Smart,vfp,LG-F480K
+LGE,Wine Smart,vfp,LG-F480L
+LGE,Wine Smart,vfp,LG-F480S
+LGE,Wine Smart 3G,vfp3g,LG-T480K
+LGE,Wine Smart 3G,vfp3g,LG-T480S
+LGE,X Mach,sjr,LG-K600
+LGE,X charge,mlv7,LG-SP320
+LGE,Y25,y25,LGL15G
+LGE,Y25,y25c,LGL16C
+LGE,Zone3,e1q,VS425PP
+LGE,Zone4,cv1,LM-X210VPP
+LGU+,TV G,smartbox,TI320-DU
+LGU+,U+ tv UHD,tvg2,ST940I-UP
+LGU+,U+ tv woofer,hg2,LAP250U
+LGU+,U+ tv woofer 1.5,hg2_iot,LAP255U
+LGU+,U+tv UHD2,tvg2a,S60UPI
+LGU+,U+tv soundbar,woofer2,S60UPA
+LGU+,WA-U420D,WA-U420D,WA-U420D
+LIAONING YIYATONG,DISNEY_Tablet_PC,DISNEY_Tablet_PC,DS2310-70LP
+LIAONING YIYATONG,IRULU_MID,IRULU_MID,X10
+LINSAY,F-7HD2CORE / F-7HD4CORE / F-10HD2CORE /F-10XHD4CORE,F-7HD2CORE,LINSAY F-7HD2CORE/F-7HD4CORE/F-10HD2CORE/F-10XHD4CORE
+LT Electronics,LT_C2100,LT_C2100,LT_C2100
+LT Electronics,LT_S9_NOTE,LT_S9_NOTE,LT_S9_NOTE
+LUVO,001,luvo_001,Luvo 001
+LUVO,001L,LUVO-001L,LUVO 001L
+LUXYA,MID704DC Tablet / Bitmore Tab770,MY7317P,MID704DC
+Laiq,GLAM,LAIQ_Glam,LAIQ Glam
+Laiq,Glow,Glow,Glow
+Laiq,STARTRAIL 8,STARTRAIL,STARTRAIL 8
+Lanix,Alpha_950,Alpha_950,Alpha 950
+Lanix,Alpha_950XL,Alpha_950XL,Alpha 950XL
+Lanix,ILIUM L1000,Ilium_L1000,ILIUM L1000
+Lanix,ILIUM L1000,Ilium_L1000,Ilium_L1000
+Lanix,ILIUM L200,ILIUM_L200,ILIUM L200
+Lanix,ILIUM L820,Ilium_L820,Ilium L820
+Lanix,ILIUM L900,Ilium_L900,ILIUM L900
+Lanix,ILIUM L950,Ilium_L950,ILIUM L950
+Lanix,ILIUM L950,Ilium_L950,Ilium_L950
+Lanix,ILIUM PAD E10Si,iLium_Pad_E10Si_1,ILIUM PAD E10Si
+Lanix,ILIUM PAD E8 V6,IliumPAD_E8v6,ILIUM PAD E8 V6
+Lanix,ILIUM PAD I8,Ilium_Padi8v3,ilium PAD i8 v3
+Lanix,ILIUM S670,Ilium_S670,ILIUM S670
+Lanix,ILIUM X110,ILIUM_X110,ILIUM X110
+Lanix,Ilium L1050,Ilium_L1050,Ilium L1050
+Lanix,Ilium L1100,ILIUM_L1100,ILIUM L1100
+Lanix,Ilium L1120,Ilium_L1120,Ilium L1120
+Lanix,Ilium L1200,Ilium_L1200,Ilium L1200
+Lanix,Ilium L1300,Ilium_L1300,Ilium L1300
+Lanix,Ilium L1400,Ilium_L1400,Ilium L1400
+Lanix,Ilium L420,Ilium_L420,Ilium L420
+Lanix,Ilium L420,Ilium_L420,Lanix Ilium L420
+Lanix,Ilium L610,Ilium_L610,Ilium L610
+Lanix,Ilium L620,Ilium_L620,Ilium L620
+Lanix,Ilium L920,Ilium_L920,Ilium L920
+Lanix,Ilium LT500,Ilium_LT500,Ilium LT500
+Lanix,Ilium LT510,Ilium_LT510,Ilium LT510
+Lanix,Ilium LT520,Ilium_LT520,Ilium LT520
+Lanix,Ilium PAD i7,ILIUM_PADi7,Ilium PAD i7
+Lanix,Ilium PAD i7 v2,ILIUM_PADi7V2,Ilium PAD i7 v2
+Lanix,Ilium Pad L8X,Ilium_Pad_L8X,Ilium Pad L8X
+Lanix,Ilium Pad T7X,Ilium_Pad_T7X,Ilium Pad T7X
+Lanix,Ilium X120,Ilium_X120,Ilium X120
+Lanix,Ilium X120B,Ilium_X120B,Ilium X120B
+Lanix,Ilium X200,Ilium_X200,Ilium X200
+Lanix,Ilium X210,Ilium_X210,Ilium X210
+Lanix,Ilium X220,Ilium_X220,Ilium X220
+Lanix,Ilium X260,Ilium_X260,Ilium X260
+Lanix,Ilium X500B,Ilium_X500B,Ilium X500B
+Lanix,Ilium X510,Ilium_X510,Ilium X510
+Lanix,Ilium X520,Ilium_X520,Ilium X520
+Lanix,Ilium X710,Ilium_X710,Ilium X710
+Lanix,Ilium_L1100,Ilium_L1100,ILIUM L1100
+Lanix,Ilium_S130,Ilium_S130,Ilium S130
+Lanix,Ilium_S130,Ilium_S130,Ilium_S130
+Lanix,Ilium_S520,Ilium_S520,ILIUM S520
+Lanix,Llium L910,Ilium_L910,Ilium L910
+Lanix,X100,ILIUM_X100,ILIUM_X100
+Lanix,X400,Ilium_X400,ILIUM X400
+Lanix,ilium  PAD  E9,ILium_PADE9,ilium PAD E9
+Lanix,ilium PAD E7,ILIUM_PADE7,ilium PAD E7
+Lanix,ilium PAD E8,ILIUM_PADE8,ilium PAD E8
+Lanix,ilium PAD E9,ilium_PAD_E9,ilium Pad E9
+Lanix,ilium PAD i7,Ilium_PAD_i7,Ilium_PAD_i7
+Lanix,ilium Pad E7,ilium_Pad_E7,ilium_Pad_E7
+Lanix,ilium_S106,Ilium_S106,Ilium S106
+Lanix,llium Pad L8,llium_Pad_L8,llium Pad L8
+Lark,Cumulus 5 HD,Cumulus_5_HD,Cumulus_5_HD
+Lark,Cumulus 5.5 HD,Cumulus_55_HD,Cumulus_5.5_HD
+Lark,Cumulus 6 HD,Cumulus_6_HD,Cumulus_6_HD
+Lark,Impress_Noda,Impress_Noda,Impress_Noda
+Lark,PHABLET 7,PHABLET7,PHABLET 7
+Lark,Ultimate X4 10.1 3G IPS,UltimateX41013GIPS,Ultimate X4 10.1 3G IPS
+Lark,Ultimate X4 8s 3G,UltimateX48s3G,Ultimate X4 8s 3G
+Lava,A1,LAVAA1,LAVAA1
+Lava,A3,LAVA_A3,LAVA_A3
+Lava,A3_mini,A3_mini,A3_mini
+Lava,A44,LAVA_A44,LAVA_A44
+Lava,A50,A50,A50
+Lava,A52,A52,A52
+Lava,A55,A55,A55
+Lava,A67,A67,A67
+Lava,A68,A68,A68
+Lava,A71,A71,A71
+Lava,A72,A72,A72
+Lava,A73,A73,A73
+Lava,A76Plus,A76Plus,A76Plus
+Lava,A76plus,A76Plus,A76Plus
+Lava,A77,A77,A77
+Lava,A79,LA79,A79
+Lava,A82,LA82,A82
+Lava,A89,A89,Lava A89
+Lava,A97,A97,A97
+Lava,A97,A97,A97 IPS
+Lava,A97 2GB,A97_2GB,A97 2GB
+Lava,A97 2GB Plus,A97_2GB_PLUS,A97 2GB PLUS
+Lava,ERA 1X,era1X,era1X
+Lava,ERA 1X,era1X,era1Xpro
+Lava,Era 2X 3GB,XE2X3GB,Era 2X 3GB
+Lava,Era 4G,era_4G,era_4G
+Lava,Flair P3,P3,P3
+Lava,Flair S1,S1,S1
+Lava,Iris 505,iris505,iris505
+Lava,Iris820,iris820,iris820
+Lava,P7,P7,P7
+Lava,P7 Plus,P7plus,P7plus
+Lava,P7plus,P7plus,P7plus
+Lava,Pixel V1,PixelV1G_sprout,PixelV1
+Lava,Pixel V1,PixelV1_sprout,PixelV1
+Lava,R1,LAVA_R1,LAVA_R1
+Lava,R1LITE,R1_Lite,R1_Lite
+Lava,R2,R2,R2
+Lava,V2 3GB,V23GB,V23GB
+Lava,V2s,V2s,V2s
+Lava,V2s,V2s,V2s M
+Lava,V5,V5,LAVA V5
+Lava,V5,V5,V5
+Lava,X10,X10,LavaX10
+Lava,X10,X10,X10
+Lava,X11,X11,X11
+Lava,X12,X12,X12
+Lava,X17,X17,X17
+Lava,X19,X19,X19
+Lava,X28,X28,X28
+Lava,X28 Plus,X28_plus,X28 Plus
+Lava,X28plus,X28_plus,X28 Plus
+Lava,X3,X3,X3
+Lava,X38,X38,X38
+Lava,X38 2GB,X382GB,X38 2GB
+Lava,X41,X41,X41
+Lava,X41Plus,X41_Plus,X41 Plus
+Lava,X46,LX46,X46
+Lava,X50,X50,X50
+Lava,X50 Plus,X50_Plus,X50 Plus
+Lava,X81,X81,X81
+Lava,XOLO LT900,LT900,LT900
+Lava,XOLO One HD,XOLO_One_HD,XOLO One HD
+Lava,XOLO era 4K,XOLO_era_4K,era 4K
+Lava,Xolo Era 2X,XE2X,Era 2X
+Lava,Xolo Era X,era_X,era_X
+Lava,Xolo era 2,era_2,era 2
+Lava,Z10,LAVA_Z10,Z10
+Lava,Z25,Z25,Z25
+Lava,Z60,Z60,Z60
+Lava,Z70,Z70,Z70
+Lava,Z80,Z80,Z80
+Lava,Z90,Z90,Z90
+Lava,iris 821,iris821,iris821
+Lava,iris 880,iris880,iris880
+Lava,iris Fuel F2,IFF2,Fuel F2
+Lava,iris atom,A1,A1
+Lava,iris atom 3,A3,A3
+Lava,iris30,iris30,iris30
+Lava,iris40,iris40,iris40
+Lava,iris50,iris50,iris50
+Lava,iris512,iris512,iris512
+Lava,iris515,iris515,iris515
+Lava,iris53,iris53,iris53
+Lava,iris560,iris560,iris560
+Lava,iris565,iris565,iris565
+Lava,iris60,iris60,iris60
+Lava,iris605,iris605,iris605
+Lava,iris702,iris702,iris702
+Lava,iris80,iris80,iris80
+Lava,iris870,iris870,iris870
+Lazer,MD1005 Tablet,MD1005,MD1005
+Lazer,MID9526CM,MID9526CM,S952
+Lazer,MW-7615P,MW-7615P,MW-7615P
+Lazer,MW6617,MW6617,MW6617
+Lazer,MY1306P,MY1306P,MY1306P
+Lazer,X4508,X4508,X4508
+Le,LeTV X40,X4_40,X4-40
+Le Pan,TC1010,FG6A-LP,Le Pan TC1010
+Le Pan,TC1020,FG6Q,Le Pan TC1020
+Le Pan,TC802A,UY8,Le Pan TC802A
+LeTV,Le 2,le_s2,Le X520
+LeTV,Le 2,le_s2_ww,Le X526
+LeTV,Le 2,le_s2_ww,Le X527
+LeTV,Le Max,max1_in,Le Max
+LeTV,Le X507,X3_HK,Le X507
+LeTV,Le X507,X3_HK,Le X509
+LeTV,Le X509,X3_HK,Le X509
+LeTV,Le1,Le1,x600
+LeTV,Max3-65,L653AN_US,Max3-65
+LeTV,Super TV X3-55 Pro,L553AN_US,X3-55 Pro
+LeTV,uMax85,DemeterDV,uMax85
+LeTV,x600,x600,X600
+Lechpol,LIVE 4 KM0438,LIVE4_KM0438,LIVE4_KM0438
+Lechpol,LIVE 4 KM0439,LIVE4_KM0439,KrugerMatz_LIVE4
+Lechpol,LIVE 4 KM0439,LIVE4_KM0439,LIVE4_KM0439
+Lechpol,MOVE 6 mini,MOVE_6_mini,MOVE_6_mini
+Leeco,Le Max2,le_x2,Le X820
+Leeco,Le Max2,le_x2,Le X821
+Leeco,Le Max2,le_x2_na,Le X829
+Leeco,Le Pro3,le_zl1,LEX725
+Leeco,Le Pro3,le_zl1,LEX727
+Leeco,Le S3,le_s2_na,Le X522
+Leeco,Le s2,le_s2,Le X520
+Leeco,LePro3,le_zl1,LEX725
+Leeco,LePro3,le_zl1,LEX727
+Leeco,LeoPro3,le_zl1,LEX725
+Leeco,"X Serials(X43 Pro, X55, X65)",DemeterUHD,X4-55
+Lenovo,,18382AU,ThinkPad Tablet
+Lenovo,,A1_07,A1_07
+Lenovo,,A2109A,IdeaTabA2109A
+Lenovo,,A2207A-H,IdeaTabA2207A-H
+Lenovo,,A278t,Lenovo A278t
+Lenovo,,A288t,Lenovo A288t
+Lenovo,,A298t,Lenovo A298t
+Lenovo,,A30t,A30t
+Lenovo,,A530_msm7627a_alps,Lenovo A530
+Lenovo,,A560e_msm7627a,LNV-Lenovo_A560e
+Lenovo,,A580,Lenovo A580
+Lenovo,,A600e_msm8625,LNV-Lenovo A600e
+Lenovo,,A60plus,Lenovo A60+
+Lenovo,,A630,Lenovo A630
+Lenovo,,A660,Lenovo A660
+Lenovo,,A668t,Lenovo A668t
+Lenovo,,A690,Lenovo A690
+Lenovo,,A700e,Lenovo A700e
+Lenovo,,A710e_msm7627a,Lenovo A710e
+Lenovo,,A780_msm7627a,Lenovo A780
+Lenovo,,A789,Lenovo A789
+Lenovo,,A798t,Lenovo A798t
+Lenovo,,A800,Lenovo A800
+Lenovo,,Android,Lenovo A60+
+Lenovo,,K1,K1
+Lenovo,,K2110A-F,IdeaTab K2110A-F
+Lenovo,,LIFETAB_S9512,LIFETAB_S9512
+Lenovo,,Lenovo_S2,Lenovo S2-38AH0
+Lenovo,,MD_LIFETAB_P9516,MD_LIFETAB_P9516
+Lenovo,,P700i,Lenovo P700i
+Lenovo,,P770,Lenovo P770
+Lenovo,,S2005A-H,S2005A-H
+Lenovo,,S2109A,IdeaTabS2109A-F
+Lenovo,,S560,Lenovo S560
+Lenovo,,S880i,Lenovo S880i
+Lenovo,,S890,Lenovo S890
+Lenovo,,S899t,Lenovo S899t
+Lenovo,,S920_ROW,Lenovo S920
+Lenovo,,S920_ROW,Lenovo S920_ROW
+Lenovo,,SmartTabII7,SmartTabII7
+Lenovo,,T702T,A66t
+Lenovo,,a2_3g_data,IdeaTab A2107A-H
+Lenovo,,a2_wifi,IdeaTab A2107A-F
+Lenovo,,a2_wifi_row,IdeaTab A2107A-F
+Lenovo,,a326,Lenovo A326
+Lenovo,,a360,Lenovo A360
+Lenovo,,a370,Lenovo A370
+Lenovo,,a500plus,Lenovo A500+
+Lenovo,,a520_gray,Lenovo A520GRAY
+Lenovo,,a59wg,Lenovo A500
+Lenovo,,a59wg,Lenovo A500+
+Lenovo,,a60_campus,Lenovo A60
+Lenovo,,a60id_tel,Lenovo A60
+Lenovo,,a60os,Lenovo A60
+Lenovo,,a60tw,Lenovo A60
+Lenovo,,a65,Lenovo A65
+Lenovo,,a65_ph_id_vn,Lenovo A65
+Lenovo,,a65cu,Lenovo A65
+Lenovo,,amazon_w,Lenovo A1-32AB0
+Lenovo,,apollo_td,Lenovo S2-38AT0
+Lenovo,,apollo_wg,Lenovo S2-38AH0
+Lenovo,,apollohd_w,Lenovo K2
+Lenovo,,apollozero_w,Lenovo S760
+Lenovo,,aruba,Lenovo A765e
+Lenovo,,austin,Lenovo A300
+Lenovo,,ideatv_S31,ideatv S31
+Lenovo,,lenovo13_td,Lenovo A366t
+Lenovo,,lenovo15_td_ics,Lenovo A698t
+Lenovo,,lenovo73_cu,Lenovo A60
+Lenovo,,lenovo73_gb,Lenovo A520
+Lenovo,,lenovo73_gb,Lenovo P70
+Lenovo,,lenovo75_a2_att_ics,A2107A-H
+Lenovo,,lenovo75_a2_ics,IdeaTab A2107A-H
+Lenovo,,lenovo75_cu_gb,Lenovo A750
+Lenovo,,lenovo75_cu_ics,Lenovo A750
+Lenovo,,mfld_pr2,Lenovo K800
+Lenovo,,mi_350,Spice Mi-350
+Lenovo,,msm7627_ea95,Lenovo A390e
+Lenovo,,msm7627_surf,A68e
+Lenovo,,msm7627_surf,Lenovo A68e
+Lenovo,,msm7627a,LNV-Lenovo A790e
+Lenovo,,msm7627a_ha99,Lenovo A780
+Lenovo,,msm8660_surf,IdeaTab S2007A-F
+Lenovo,,msm8660_surf,IdeaTab S2007A-H
+Lenovo,,msm8660_surf,IdeaTab S2010A-D
+Lenovo,,msm8660_surf,IdeaTab S2010A-F
+Lenovo,,msm8660_surf,IdeaTab S2010A-H
+Lenovo,,msm8960,IdeaTabS2110AF
+Lenovo,,msm8960,IdeaTabS2110AH
+Lenovo,,msm8960,SmartTabII10
+Lenovo,,p700,Lenovo P700
+Lenovo,,p700_ph,Lenovo P700
+Lenovo,,s880,Lenovo S880
+Lenovo,,s880_row,Lenovo S880
+Lenovo,,sanpaolo,IdeaTabV2007A
+Lenovo,,santiago,IdeaTabV2010A
+Lenovo,,santiago,IdeaTabV2010A-W
+Lenovo,,sicily,Lenovo S696
+Lenovo,,stuttgart_row,Lenovo K860
+Lenovo,,ventana,K1
+Lenovo,\t Lenovo YOGA Laptop with Android,YOGABOOK12,Lenovo YB-Q501F
+Lenovo,32A3   40A3   43A3   49A3,uzi,LenovoTV 32A3
+Lenovo,"55E82,49E82,50U3A,58U3A,70UD30A,60UD30A,80UD30A,65UR30A",sun,AQUOS 50U3A
+Lenovo,"55E82,49E82,50U3A,58U3A,70UD30A,60UD30A,80UD30A,65UR30A",sun,AQUOS 65UR30A
+Lenovo,"55E82,49E82,50U3A,58U3A,70UD30A,60UD30A,80UD30A,65UR30A",sun,AQUOS 70UD30A
+Lenovo,"55E82,49E82,50U3A,58U3A,70UD30A,60UD30A,80UD30A,65UR30A",sun,AQUOS 70UG30A
+Lenovo,"55E82,49E82,50U3A,58U3A,70UD30A,60UD30A,80UD30A,65UR30A",sun,AQUOS 70XU30A
+Lenovo,"55E82,49E82,50U3A,58U3A,70UD30A,60UD30A,80UD30A,65UR30A",sun,LenovoTV 49E82
+Lenovo,"55E82,49E82,50U3A,58U3A,70UD30A,60UD30A,80UD30A,65UR30A",sun,LenovoTV 55E82
+Lenovo,60K72,ideatv_K72,ideatv K72
+Lenovo,A10,A10,IdeaPadA10
+Lenovo,A10-70LC,A10-70LC,Lenovo TAB 2 A10-70LC
+Lenovo,A1000,A1000,Lenovo A1000
+Lenovo,A1000,A1000F,IdeaTabA1000-F
+Lenovo,A1000-G,A1000G,IdeaTabA1000-G
+Lenovo,A1000L,A1000LF,IdeaTabA1000L-F
+Lenovo,A1000m,scx35_sp7731gea_taichi,Lenovo A1000m
+Lenovo,A1010,A1010a20,Lenovo A1010a20
+Lenovo,A1900,A1900,Lenovo A1900
+Lenovo,A2010-a,A2010-a,Lenovo A2010-a
+Lenovo,A2010l36,A2010l36,Lenovo A2010l36
+Lenovo,A2016a40,A2016a40,Lenovo A2016a40
+Lenovo,A2016b30,A2016b30,Lenovo A2016b30
+Lenovo,A2016b31,A2016b31,Lenovo A2016b31
+Lenovo,A2020a40,angus3A4,Lenovo A2020a40
+Lenovo,A2020a40,angus3A41,Lenovo A2020a40
+Lenovo,A208t,A208t,Lenovo A208t
+Lenovo,A2105,Lenovo_A2105,Lenovo_A2105
+Lenovo,A2107A,A2107A-H,A2107A-H
+Lenovo,A218t,A218t,Lenovo A218t
+Lenovo,A228t,A228t,Lenovo A228t
+Lenovo,A238t,A238t,Lenovo A238t
+Lenovo,A2580,A2580,Lenovo A2580
+Lenovo,A269,A269,Lenovo A269
+Lenovo,A269i,A269i,Lenovo A269i
+Lenovo,A278t,A278t,Lenovo A278t
+Lenovo,A2800,A2800-d,Lenovo A2800-d
+Lenovo,A2860,A2860,Lenovo A2860
+Lenovo,A3000,A3000,Lenovo A3000-H
+Lenovo,A300t,A300t,Lenovo A300t
+Lenovo,A305E,A305e,LNV-Lenovo A305e
+Lenovo,A305E,A305e,Lenovo A305e
+Lenovo,A308t,A308t,Lenovo A308t
+Lenovo,A316,A316,Lenovo A316
+Lenovo,A316i,A316i,Lenovo A316i
+Lenovo,A318t,A318t,Lenovo A318t
+Lenovo,A319,A319,Lenovo A319
+Lenovo,A31910t30,angus3T3,Lenovo A3910t30
+Lenovo,A320t,A320t,Lenovo A320t
+Lenovo,A328,A328,Lenovo A328
+Lenovo,A328t,A328t,Lenovo A328t
+Lenovo,A3300,A3300-H,LenovoA3300-H
+Lenovo,A3300,A3300-T,Lenovo A3300-T
+Lenovo,A3300-GV,A3300-GV,LenovoA3300-GV
+Lenovo,A3300-HV,A3300-HV,Lenovo A3300-HV
+Lenovo,A330e,A330e,Lenovo A330e
+Lenovo,A338t,A338t,Lenovo A338t
+Lenovo,A3500,A3500,Lenovo A3500
+Lenovo,A3500,A3500HV,Lenovo A3500-HV
+Lenovo,A3500-F,A3500F,EveryPad2
+Lenovo,A3500-F,A3500F,Lenovo A3500-F
+Lenovo,A3500-FL,A3500FL,Lenovo A3500-FL
+Lenovo,A3500-H,A3500H,Lenovo A3500-H
+Lenovo,A355e,A355e,Lenovo A355e
+Lenovo,A358t,A358t,Lenovo A358t
+Lenovo,A3600-D,A3600-d,Lenovo A3600-d
+Lenovo,A3600u,A3600u,Lenovo A3600u
+Lenovo,A360e,A360e,Lenovo A360e
+Lenovo,A360t,A360t,Lenovo A360t
+Lenovo,A368t,A368t,Lenovo A368t
+Lenovo,A369,A369,Lenovo A369
+Lenovo,A369i,A369i,Lenovo A369i
+Lenovo,A370e,A370e,LNV-Lenovo A370e
+Lenovo,A375e,A375e,LNV-Lenovo A375e
+Lenovo,A376,A376,Lenovo A376
+Lenovo,A378t,A378t,Lenovo A378t
+Lenovo,A3800-D,A3800-d,Lenovo A3800-d
+Lenovo,A380e,A380e,LNV-Lenovo A380e
+Lenovo,A380t,A380t,Lenovo A380t
+Lenovo,A385e,A385e,LNV-Lenovo A385e
+Lenovo,A3860,A3580,Lenovo A3580
+Lenovo,A3860,A3860,Lenovo A3860
+Lenovo,A388t,A388t,Lenovo A388t
+Lenovo,A390,A390,Lenovo A390
+Lenovo,A390,A390,Lenovo A390_ROW
+Lenovo,A3900,pxa1L88H2,Lenovo A3900
+Lenovo,A390t,A390t,Lenovo A390t
+Lenovo,A395e,A395e,LNV-Lenovo A395e
+Lenovo,A396,A396,Lenovo A396
+Lenovo,A396,A396_TY,Lenovo A396_TY
+Lenovo,A398t,A398t,Lenovo A398t
+Lenovo,A398t+,A398tp,Lenovo A398t+
+Lenovo,A399,Aiken,Lenovo A399
+Lenovo,A5000,A5000,Lenovo A5000
+Lenovo,A505e,A505e,LNV-Lenovo A505e
+Lenovo,A516,A516,Lenovo A516
+Lenovo,A516,A516_ROW,Lenovo A516
+Lenovo,A526,A526,Lenovo A526
+Lenovo,A529,A529,Lenovo A529
+Lenovo,A536,A536,Lenovo A536
+Lenovo,A5500,A5500,Lenovo A5500
+Lenovo,A5500-F,A5500-F,Lenovo A5500-F
+Lenovo,A5500-H,A5500-H,Lenovo A5500-H
+Lenovo,A5500-HV,A5500-HV,Lenovo A5500-HV
+Lenovo,A560,A560_msm8212,Lenovo A560
+Lenovo,A560,A560_msm8610,LNV-Lenovo A560
+Lenovo,A5800-D,A5800-D,Lenovo A5800-D
+Lenovo,A588t,LenovoA588t,LenovoA588t
+Lenovo,A6000,Kraft-A6000,Lenovo A6000
+Lenovo,A6000-l,Kraft-A6000-l,Lenovo A6000-l
+Lenovo,A6010,A6010,Lenovo A6010
+Lenovo,A606,A606,Lenovo A606
+Lenovo,A616,A616,Lenovo A616
+Lenovo,A628t,A628t,Lenovo A628t
+Lenovo,A630,A630e,LNV-Lenovo A630e
+Lenovo,A656,A656,Lenovo A656
+Lenovo,A658T,A658t,Lenovo A658t
+Lenovo,A6600,A6600d40,Lenovo A6600d40
+Lenovo,A6600 Plus,A6600a40,Lenovo A6600a40
+Lenovo,A670t,A670t,Lenovo A670t
+Lenovo,A678t,A678t,Lenovo A678t
+Lenovo,A680,A680,Lenovo A680
+Lenovo,A680,A680,Lenovo A680_ROW
+Lenovo,A6800,A6800,Lenovo A6800
+Lenovo,A688t,A688t,Lenovo A688t
+Lenovo,A690e,A690e,LNV-Lenovo A690e
+Lenovo,A7-30GC,A7-30GC,Lenovo TAB 2 A7-30GC
+Lenovo,A7-30H,A7-30H,Lenovo TAB 2 A7-30D
+Lenovo,A7-30H,A7-30H,Lenovo TAB 2 A7-30H
+Lenovo,A7-60HC,A760HC,Lenovo A7-60HC
+Lenovo,A7000,A7000-a,Lenovo A7000-a
+Lenovo,A7000 Plus,A7000plus,Lenovo A7000-a
+Lenovo,A706,armani,Lenovo A706
+Lenovo,A706_ROW,armani_row,Lenovo A706_ROW
+Lenovo,A720e,andorrap,Lenovo A720e
+Lenovo,A750e,athenae,Lenovo A750e
+Lenovo,A760,audi,Lenovo A760
+Lenovo,A7600,A7600,Lenovo A7600
+Lenovo,A7600,aiocmcc_ttp,Lenovo A7600-m
+Lenovo,A7600,aiocu_wtfp,Lenovo A7600
+Lenovo,A7600-F,A7600-F,Lenovo A7600-F
+Lenovo,A7600-H,A7600-H,Lenovo A7600-H
+Lenovo,A7600-HV,A7600-HV,Lenovo A7600-HV
+Lenovo,A766,A766,Lenovo A766
+Lenovo,A768t,airplayt,Lenovo A768t
+Lenovo,A7700,A7700,A7700
+Lenovo,A7700,A7700,Lenovo A7700
+Lenovo,A770e,athenaep,Lenovo A770e
+Lenovo,A780e,A780e,LNV-Lenovo A780e
+Lenovo,A785e,A785e,LNV-Lenovo A785e
+Lenovo,A788t,A788t,Lenovo A788t
+Lenovo,A8-50,A8-50L,Lenovo TAB 2 A8-50L
+Lenovo,A8-50,A8-50LC,Lenovo 2 A8-50LC
+Lenovo,A8-50,A8-50LC,Lenovo TAB 2 A8-50LC
+Lenovo,A805e,airplayep,Lenovo A805e
+Lenovo,A806,A806,Lenovo A806
+Lenovo,A808t,A808t,Lenovo A808t
+Lenovo,A808t-i,A808t-i,Lenovo A808t-i
+Lenovo,A816,airplayw,Lenovo A5100
+Lenovo,A816,airplayw,Lenovo A816
+Lenovo,A820,A820,Lenovo A820
+Lenovo,A820e,andorra,Lenovo A820e
+Lenovo,A820t,A820t,Lenovo A820t
+Lenovo,A828,A858,Lenovo A858
+Lenovo,A828t,A828t,Lenovo A828t
+Lenovo,A830,A830,Lenovo A830
+Lenovo,A850,A850,Lenovo A850
+Lenovo,A850,A850_ROW,Lenovo A850
+Lenovo,A850+,A850p,Lenovo A850+
+Lenovo,A858t,A858t,Lenovo A858t
+Lenovo,A859,A859_ROW,Lenovo A859
+Lenovo,A860e,artini,Lenovo A860e
+Lenovo,A889,A889,Lenovo A889
+Lenovo,A890e,airbuse,Lenovo A890e
+Lenovo,A916,A916,Lenovo A916
+Lenovo,A936,A936,Lenovo A936
+Lenovo,A938t,A938t,Lenovo A938t
+Lenovo,B6000-F,B6000,Lenovo B6000-F
+Lenovo,B6000-H,B6000,Lenovo B6000-H
+Lenovo,B6000-HV,B6000,Lenovo B6000-HV
+Lenovo,B8000-F,B8000,Lenovo B8000-F
+Lenovo,B8000-H,B8000,Lenovo B8000-H
+Lenovo,B8080,B8080,Lenovo B8080-F
+Lenovo,B8080-H,B8080,Lenovo B8080-H
+Lenovo,B8080-HV,B8080,Lenovo B8080-HV
+Lenovo,E4002,E4002,MEDION E4002
+Lenovo,EveryPad,A3000,EveryPad
+Lenovo,EveryPad,A3000,IdeaTab A3000-F
+Lenovo,EveryPad2,A3500F,EveryPad2
+Lenovo,IdeaTV,msm8660_surf,ideatv K91
+Lenovo,IdeaTab A1000,A1000LF,LenovoA1000L-F
+Lenovo,IdeaTab A1010,A1010T,IdeaTabA1010-T
+Lenovo,IdeaTab A1020,A1020T,IdeaTabA1020-T
+Lenovo,IdeaTab A3000,A3000,IdeaTab A3000-H
+Lenovo,IdeaTab A3000,A3000,Vodafone Smart Tab III 7
+Lenovo,IdeaTab A5000,A5000E,IdeaTabA5000-E
+Lenovo,IdeaTab S6000,S6000,IdeaTab S6000-F
+Lenovo,IdeaTab S6000,S6000,IdeaTab S6000-H
+Lenovo,IdeaTab S6000,S6000,Vodafone Smart Tab III 10
+Lenovo,Indigo,Indigo,ThinkPad Tablet
+Lenovo,K1,K1,K1
+Lenovo,K10e70,K10e70,Lenovo K10e70
+Lenovo,K3 Note,K50a40,Lenovo K50a40
+Lenovo,K3 Note,aio_3m_otfp_m,Lenovo K50-t3s
+Lenovo,K3 Note,aio_otfp,Lenovo K50-T5
+Lenovo,K3 Note,aio_otfp,Lenovo K50-t5
+Lenovo,K30-E,Kraft-E,Lenovo K30-E
+Lenovo,K30-T,Kraft-T,Lenovo K30-T
+Lenovo,K30-TM,Kraft-TM,Lenovo K30-TM
+Lenovo,K30-W,Kraft-W,Lenovo K30-W
+Lenovo,K32,K32c36,Lenovo K32c36
+Lenovo,K32c30,K32c30,Lenovo K32c30
+Lenovo,K5,A6020a40,Lenovo A6020a40
+Lenovo,K5,A6020a41,Lenovo A6020a41
+Lenovo,K5,A6020l36,Lenovo A6020l36
+Lenovo,K5,A6020l37,Lenovo A6020l37
+Lenovo,K5 Note,A7020a40,Lenovo A7020a40
+Lenovo,K5 Note,A7020a48,Lenovo A7020a48
+Lenovo,K5 Note,k52_e78,Lenovo K52e78
+Lenovo,K5 Note,k52_t58,Lenovo K52t58
+Lenovo,K5 Plus,A6020a46,Lenovo A6020a46
+Lenovo,K50,K50-t5,Lenovo K50-t5
+Lenovo,K50,aio_3m_otfp,Lenovo K50-t3s
+Lenovo,K50-T5,aio_otfp_m,Lenovo K50-t5
+Lenovo,K52t38,k52_t38,Lenovo K52t38
+Lenovo,K52t38,k52_t38,Lenovo k52t38
+Lenovo,K800,K800,Lenovo K800
+Lenovo,K80M,K80M,Lenovo K80M
+Lenovo,K860,stuttgart,Lenovo K860
+Lenovo,K860i,K860i,Lenovo K860i
+Lenovo,K900,K900,Lenovo K900
+Lenovo,K900,K900_ROW,Lenovo K900_ROW
+Lenovo,K910,kiton,Lenovo K910
+Lenovo,K910L,K910L,Lenovo K910L
+Lenovo,K910e,kitone,LNV-Lenovo K910e
+Lenovo,K910e,kitone,Lenovo K910e
+Lenovo,K920/VIBE Z2,kingdom_row,Lenovo K920
+Lenovo,K920/VIBE Z2 Pro,kingdomt,Lenovo K920
+Lenovo,LIFETAB E10310,LIFETAB_E10310,LIFETAB_E10310
+Lenovo,LIFETAB E7310,LIFETAB_E7310,LIFETAB_E7310
+Lenovo,LIFETAB E7310,LIFETAB_E7310,LIFETAB_E7312
+Lenovo,Lenovo,A708t,Lenovo A708t
+Lenovo,Lenovo,A880,Lenovo A880
+Lenovo,Lenovo,PB1-770P,Lenovo PB1-770P
+Lenovo,Lenovo A3300,A3300-GV,LenovoA3300-GV
+Lenovo,Lenovo A3300,A3300-HV,LenovoA3300-HV
+Lenovo,Lenovo K8,brady_f,Lenovo K
+Lenovo,Lenovo K8,brady_f,Lenovo K8
+Lenovo,Lenovo K8 Note,manning,Lenovo K8 Note
+Lenovo,Lenovo K8 Note,manning,XT1902-3
+Lenovo,Lenovo K8 Plus,marino_f,Lenovo K
+Lenovo,Lenovo K8 Plus,marino_f,Lenovo K8 Plus
+Lenovo,Lenovo N Series Chromebook,reks_cheets,Braswell Chrome OS Device
+Lenovo,Lenovo N300,Lindos2,Lenovo N300
+Lenovo,Lenovo S820,S820,Lenovo S820
+Lenovo,Lenovo TAB,TB-8803F,Lenovo TB-8803F
+Lenovo,Lenovo TAB 7,TB-7504F,Lenovo TB-7504F
+Lenovo,Lenovo TAB 7,TB-7504N,Lenovo TB-7504N
+Lenovo,Lenovo TAB 7,TB-7504X,Lenovo TB-7504X
+Lenovo,Lenovo TAB4,701LV,701LV
+Lenovo,Lenovo TAB4,702LV,702LV
+Lenovo,Lenovo Tab 7 Essential,7304I,Lenovo TB-7304I
+Lenovo,Lenovo Tab 7 Essential,TB-7304I,Lenovo TB-7304I
+Lenovo,Lenovo Tab 7 Essential,TB-7304N,Lenovo TB-7304N
+Lenovo,Lenovo Tab 7 Essential,TB-7304X,Lenovo TB-7304X
+Lenovo,Lenovo Tab4 10 Plus,X704A,TB-X704A
+Lenovo,Lenovo X2-CU/VIBE X2,X2-CU,Lenovo X2-CU
+Lenovo,Lenovo YOGA A12,YOGA-A12,Lenovo YB-Q501L
+Lenovo,LenovoTAB2 A7-30DC,A7-30HC,Lenovo TAB 2 A7-30DC
+Lenovo,LenovoTB-8304F,TB-8304F,Lenovo TB-8304F
+Lenovo,LenovoTB-8704V,TB-8704V,TB-8704V
+Lenovo,LenovoTB-X304F/Lenovo TAB4,X304F,Lenovo TB-X304F
+Lenovo,LenovoTB-X304F/Lenovo TAB4,X304F,TB-X304F
+Lenovo,LenovoTB-X704F/Lenovo TAB4 10 Plus,X704F,Lenovo TB-X704F
+Lenovo,LenovoTV 40S9;LenovoTV 50S9;AQUOS 40U1;AQUOS 50U1\xef\xbc\x9bAQUOS 58U1; AQUOS 60LX765A,jazz,AQUOS 58U1
+Lenovo,LenovoTV 40S9;LenovoTV 50S9;AQUOS 40U1;AQUOS 50U1\xef\xbc\x9bAQUOS 58U1; AQUOS 60LX765A,jazz,AQUOS 60LX765A
+Lenovo,LenovoTV 40S9;LenovoTV 50S9;AQUOS 40U1;AQUOS 50U1\xef\xbc\x9bAQUOS 58U1; AQUOS 60LX765A,jazz,AQUOS 60UE20A
+Lenovo,LenovoTV 40S9;LenovoTV 50S9;AQUOS 40U1;AQUOS 50U1\xef\xbc\x9bAQUOS 58U1; AQUOS 60LX765A,jazz,LenovoTV 40S9
+Lenovo,LenovoTV 40S9;LenovoTV 50S9;AQUOS 40U1;AQUOS 50U1\xef\xbc\x9bAQUOS 58U1; AQUOS 60LX765A,jazz,LenovoTV 58S9
+Lenovo,LenovoTV 50S52;AQUOS LCD-50S1A,bumblebee,AQUOS 50S1
+Lenovo,LenovoTV 50S52;AQUOS LCD-50S1A,bumblebee,LenovoTV 50S52
+Lenovo,Lenovo_K320t,Lenovo_K320t,Lenovo K320t
+Lenovo,Lenvo S960,S960_ROW,Lenovo S960
+Lenovo,Moto E3,taidos_row,XT1700
+Lenovo,Moto E3 Power,taido_row,XT1706
+Lenovo,Motorola M,XT1663,XT1663
+Lenovo,Motorola Moto M,kungfu_m,XT1662
+Lenovo,N300,Lindos2,Lenovo N300
+Lenovo,N308,SmartAIO,Lenovo N308
+Lenovo,NEC  PC-TE507FAW,TE507FAW,PC-TE507FAW
+Lenovo,NEC PC-TS508FAM,PC-TS508FAM,NEC PC-TS508FAM
+Lenovo,NEC PC-TS508FAM,PC-TS508FAM,PC-TS508FAM
+Lenovo,P1,P1a42,Lenovo P1a41
+Lenovo,P1,P1a42,Lenovo P1a42
+Lenovo,P1,passion,Lenovo P1c72
+Lenovo,P1,passionc5,Lenovo P1c58
+Lenovo,P2,P2a42,Lenovo P2a42
+Lenovo,P2,kuntao,Lenovo P2c72
+Lenovo,P70,P70-A,Lenovo P70-A
+Lenovo,P70,P70-t,Lenovo P70-t
+Lenovo,P780,P780,Lenovo P780
+Lenovo,P780,P780_ROW,Lenovo P780
+Lenovo,P780,P780_ROW,Lenovo P780_ROW
+Lenovo,P90,P90,Lenovo P90
+Lenovo,PB1-750M/Lenovo PHAB,PB1-750M,Lenovo PB1-750M
+Lenovo,PB1-770M/Lenovo PHAB Plus,PB1-770M,EveryPad3
+Lenovo,PB1-770M/Lenovo PHAB Plus,PB1-770M,Lenovo PB1-770M
+Lenovo,PB1-770N,PB1-770N,Lenovo PB1-770N
+Lenovo,PB2,PB2,Lenovo PB2-650M
+Lenovo,PB2 plus,PB2-670M,Lenovo PB2-670M
+Lenovo,PB2-650Y,PB2,Lenovo PB2-650Y
+Lenovo,PC-TE510HAW,X704F,PC-TE510HAW
+Lenovo,PHAB 2,PB2,Lenovo PB2-650N
+Lenovo,PHAB 2 Plus,PB2-670N,Lenovo PB2-670N
+Lenovo,PHAB 2 Plus,PB2-670Y,Lenovo PB2-670Y
+Lenovo,PHAB2 Pro,PB2PRO,Lenovo PB2-690M
+Lenovo,PHAB2 Pro,PB2PRO,Lenovo PB2-690N
+Lenovo,PHAB2 Pro,PB2PRO,Lenovo PB2-690Y
+Lenovo,S1,S1a40,Lenovo S1a40
+Lenovo,S1La40,S1La40,Lenovo S1La40
+Lenovo,S5000,S5000,Lenovo S5000-F
+Lenovo,S5000,S5000,Lenovo S5000-H
+Lenovo,S580,S580,Lenovo S580
+Lenovo,S60,sisleylr,Lenovo S60-a
+Lenovo,S60,sisleylt,Lenovo S60-t
+Lenovo,S60,sisleylw,Lenovo S60-w
+Lenovo,S6000L,S6000L,Lenovo S6000L-F
+Lenovo,S61,ideatv_S61,ideatv S61
+Lenovo,S650,S650,Lenovo S650
+Lenovo,S650_ROW,S650_ROW,Lenovo S650
+Lenovo,S658t,S658t,Lenovo S658t
+Lenovo,S660,S660,Lenovo S660
+Lenovo,S668t,S668t,Lenovo S668t
+Lenovo,S686,Alaska,Lenovo S686
+Lenovo,S720,S720,Lenovo S720
+Lenovo,S750,S750,Lenovo S750
+Lenovo,S810t,shellt,Lenovo S810t
+Lenovo,S820,S820,Lenovo S820
+Lenovo,S820,S820_AMX_ROW,Lenovo S820
+Lenovo,S820,S820_ROW,Lenovo S820
+Lenovo,S820,S820_ROW,Lenovo S820_ROW
+Lenovo,S820e,applee,Lenovo S820e
+Lenovo,S850,S850,Lenovo S850
+Lenovo,S850e,sichuan,Lenovo S850e
+Lenovo,S850t,S850t,Lenovo S850t
+Lenovo,S856,shellamx,Lenovo S856
+Lenovo,S856,shellr,Lenovo S856
+Lenovo,S856,shellr_s,Lenovo S856
+Lenovo,S856,shellw,Lenovo S856
+Lenovo,S858t,Selected,Lenovo S858t
+Lenovo,S860,S860,Lenovo S860
+Lenovo,S860e,shelle,Lenovo S860e
+Lenovo,S868,S868t,Lenovo S868t
+Lenovo,S870e,S870e,LNV-Lenovo S870e
+Lenovo,S870e,S870e,Lenovo S870e
+Lenovo,S898t,S898t,Lenovo S898t
+Lenovo,S898t+,S898tp,Lenovo S898t+
+Lenovo,S90,sisleye,Lenovo S90-e
+Lenovo,S90-A,sisleyr,Lenovo S90-A
+Lenovo,S90-L,sisleyr_amx,Lenovo S90-L
+Lenovo,S90-T,sisleyt,Lenovo S90-t
+Lenovo,S90-U,sisleyw,Lenovo S90-u
+Lenovo,S920,S920,Lenovo S920
+Lenovo,S930,S930,Lenovo S930
+Lenovo,S930_ROW,S930_ROW,Lenovo S930
+Lenovo,S938t,S938t,Lenovo S938t
+Lenovo,S939,S939,Lenovo S939
+Lenovo,S960,S960,Lenovo S960
+Lenovo,S960,S960_AMX_ROW,Lenovo S960
+Lenovo,S968t,S968t,Lenovo S968t
+Lenovo,Softbank 501LV,501LV,501LV
+Lenovo,TAB 10,TB-X103F,Lenovo TB-X103F
+Lenovo,TAB 2 A10,A10-70F,Lenovo TAB 2 A10-70F
+Lenovo,TAB 2 A10,A10-70L,Lenovo TAB 2 A10-70L
+Lenovo,TAB 2 A10,A10-70LC,Lenovo TAB 2 A10-70LC
+Lenovo,TAB 2 A7-10F,Tab2A7-10F,Tab2A7-10F
+Lenovo,TAB 2 A7-20F,Tab2A7-20F,Tab2A7-20F
+Lenovo,TAB 2 A7-30F,A7-30F,Lenovo TAB 2 A7-30F
+Lenovo,TAB 2 A7-30HC,A7-30HC,Lenovo 2 A7-30HC
+Lenovo,TAB 2 A7-30HC,A7-30HC,Lenovo TAB 2 A7-30HC
+Lenovo,TAB 2 A7-30TC,A7-30TC,Lenovo 2 A7-30TC
+Lenovo,TAB 2 A8-50F,A8-50F,Lenovo 2 A8-50F
+Lenovo,TAB 2 A8-50F,A8-50F,Lenovo TAB 2 A8-50F
+Lenovo,TAB 3 850F,TB3-850F,Lenovo TB3-850F
+Lenovo,TAB 3 850M,TB3-850M,Lenovo TB3-850M
+Lenovo,TAB A10-80HC,A10_80HC,TAB A10-80HC
+Lenovo,TAB S8-50F,S8-50F,Lenovo TAB S8-50F
+Lenovo,TAB S8-50L,S8-50L,Lenovo TAB S8-50L
+Lenovo,TAB S8-50LC,S8-50LC,Lenovo S8-50LC
+Lenovo,TAB S8-50LC,S8-50LC,Lenovo TAB S8-50LC
+Lenovo,TAB3 7 Plus,TB-7703F,Lenovo TB-7703F
+Lenovo,TAB3 7 Plus,TB-7703N,Lenovo TB-7703N
+Lenovo,TAB3 7 Plus,TB-7703X,Lenovo TB-7703X
+Lenovo,TAB3 730F,TB3-730F,Lenovo TB3-730F
+Lenovo,TAB3 730M,TB3-730M,Lenovo TB3-730M
+Lenovo,TAB3 730X,TB3-730X,Lenovo TB3-730X
+Lenovo,TAB3 8 Plus,TB-8703R,Lenovo TB-8703R
+Lenovo,TAB3 X70L,TB3-X70L,Lenovo TB3-X70L
+Lenovo,TAB3 X70N,TB3-X70N,Lenovo TB3-X70N
+Lenovo,TAB4 10,X304L,Lenovo TB-X304L
+Lenovo,TAB4 10,X304N,Lenovo TB-X304N
+Lenovo,TAB4 10,X304N,TB-X304N
+Lenovo,TAB4 10,X304X,Lenovo TB-X304X
+Lenovo,TAB4 10 Plus,X704L,Lenovo TB-X704L
+Lenovo,TAB4 10 Plus,X704N,Lenovo TB-X704N
+Lenovo,TAB4 10 Plus,X704V,TB-X704V
+Lenovo,TAB4 10 Plus,X704Y,Lenovo TB-X704Y
+Lenovo,TAB4 8,TB-8504F,Lenovo TB-8504F
+Lenovo,TAB4 8,TB-8504L,Lenovo TB-8504L
+Lenovo,TAB4 8,TB-8504N,Lenovo TB-8504N
+Lenovo,TAB4 8,TB-8504X,Lenovo TB-8504X
+Lenovo,TB-8604F,TB-8604F,Lenovo TB-8604F
+Lenovo,TB-8704F,TB-8704F,Lenovo TB-8704F
+Lenovo,TB-8704N,TB-8704N,Lenovo TB-8704N
+Lenovo,TB-8704X,TB-8704X,Lenovo TB-8704X
+Lenovo,TB-8804F,TB-8804F,Lenovo TB-8804F
+Lenovo,TB-8X04F,TB-8X04F,Lenovo TB-8X04F
+Lenovo,TB2-X30F,TB2-X30F,Lenovo TB2-X30F
+Lenovo,TB2-X30F,TB2-X30F,Lenovo TB2-X30F_HFT
+Lenovo,TB2-X30F,TB2-X30F,Lenovo TB2-X30F_JLC
+Lenovo,TB2-X30F,TB2-X30F,Lenovo TB2-X30F_SCP
+Lenovo,TB2-X30F,TB2-X30F,Lenovo TB2-X30F_UK
+Lenovo,TB2-X30F,TB2-X30F,Lenovo TB2-X30F_YZA
+Lenovo,TB2-X30L,TB2-X30L,Lenovo TB2-X30L
+Lenovo,TB2-X30M,TB2-X30M,Lenovo TB2-X30M
+Lenovo,TB2-X30M,TB2-X30M,Lenovo TB2-X30M_PRC_YZ_A
+Lenovo,TB3 8 Plus,TB-8703F,Lenovo TB-8703F
+Lenovo,TB3 8 Plus,TB-8703N,Lenovo TB-8703N
+Lenovo,TB3 8 Plus,TB-8703X,Lenovo TB-8703X
+Lenovo,TB3-601LV,601LV,601LV
+Lenovo,TB3-602LV,602LV,602LV
+Lenovo,TB3-710F,TB3-710F,Lenovo TB3-710F
+Lenovo,TB3-710I,TB3-710I,Lenovo TB3-710I
+Lenovo,TB3-X70F,TB3-X70F,Lenovo TB3-X70F
+Lenovo,Tab 7 Essential,7304F,Lenovo TB-7304F
+Lenovo,Tab 7 Essential,TB-7304F,Lenovo TB-7304F
+Lenovo,ThinkPad 11e Chromebook 3rd Gen,ultima_cheets,ThinkPad 11e Chromebook 3rd Gen (Yoga/Clamshell)
+Lenovo,ThinkVision28,ThinkVision28,ThinkVision28
+Lenovo,Thinkpad 11e Chromebook (4th Gen)/Lenovo Thinkpad Yoga 11e Chromebook (4th Gen),pyro_cheets,Lenovo Thinkpad 11e Chromebook (4th Gen)/Lenovo Thinkpad Yoga 11e Chromebook (4th Gen)
+Lenovo,Thinkpad 13 Chromebook,sentry_cheets,Thinkpad 13 Chromebook
+Lenovo,Thinkpad Stack projector,pj_stack_acc,M123
+Lenovo,VIBE K10,K10a40,Lenovo K10a40
+Lenovo,VIBE K6,K33a48,Lenovo K33a48
+Lenovo,VIBE K6,K33b36,Lenovo K33b36
+Lenovo,VIBE K6,K33b37,Lenovo K33b37
+Lenovo,VIBE K6 Note,K53a48,Lenovo K53a48
+Lenovo,VIBE K6 Note,K53b36,Lenovo K53b36
+Lenovo,VIBE K6 Note,K53b37,Lenovo K53b37
+Lenovo,VIBE K6 Power,K33a42,Lenovo K33a42
+Lenovo,VIBE X3 Lite,A7010a48,Lenovo A7010a48
+Lenovo,VIBE X3 Lite,k5fp,Lenovo K51c78
+Lenovo,VIBE X3 Lite,k5fp_m,Lenovo K51c78
+Lenovo,X2,X2-AP,Lenovo X2-AP
+Lenovo,X2,X2-EU,Lenovo X2-EU
+Lenovo,X2 Pro,s7,Lenovo X2Pt5
+Lenovo,X2 Pro,s7,VIBE X2Pt5
+Lenovo,X2-TO/VIBE X2,X2-TO,Lenovo X2-TO
+Lenovo,X2-TR/VIBE X2,X2-TR,Lenovo X2-TR
+Lenovo,X3a40,x3_row,Lenovo X3a40
+Lenovo,X3c50,X3c50,Lenovo X3c50
+Lenovo,X3c70,X3c70,Lenovo X3c70
+Lenovo,YB1-X90L/YOGA BOOK,yeti,Lenovo YB1-X90L
+Lenovo,YOGA A12,YOGA-A12,Lenovo YB-Q501F
+Lenovo,YOGA BOOK,yeti,Lenovo YB1-X90F
+Lenovo,YOGA BOOK,yeti,Lenovo YB1-X90L
+Lenovo,YOGA Laptop with Android,YOGABOOK12,Lenovo YB-Q501F
+Lenovo,YOGA Laptop with Android,YOGABOOK12,Lenovo YB-Q501L
+Lenovo,YOGA Tablet Pro-1050L/Yoga Tablet 2,YT2,YOGA Tablet 2-1050L
+Lenovo,YOGA Tablet Pro-1050LC/Yoga Tablet 2,YT2,YOGA Tablet 2-1050LC
+Lenovo,YOGA Tablet Pro-1380F/Yoga Tablet 2 Pro,YT2,YOGA Tablet 2 Pro-1380F
+Lenovo,YOGA Tablet Pro-1380L/Yoga Tablet 2 Pro,YT2,YOGA Tablet 2 Pro-1380L
+Lenovo,YOGA Tablet Pro-830L/Yoga Tablet 2,YT2,YOGA Tablet 2-830L
+Lenovo,YOGA Tablet Pro-830LC/Yoga Tablet 2,YT2,YOGA Tablet 2-830LC
+Lenovo,YT3-850F/Lenovo YOGATab3,YT3-850F,Lenovo YT3-850F
+Lenovo,YT3-850L/Lenovo YOGATab3,YT3-850L,Lenovo YT3-850L
+Lenovo,YT3-850M/Lenovo YOGATab3,YT3-850M,Lenovo YT3-850M
+Lenovo,YT3-X50F/Yoga3 Tablet,YT3-X50F,Lenovo YT3-X50F
+Lenovo,YT3-X50L/Yoga3 Tablet,YT3-X50L,Lenovo YT3-X50L
+Lenovo,YT3-X50M/Yoga3 Tablet,YT3-X50M,Lenovo YT3-X50M
+Lenovo,YT3-X90F/YOGA3 Tablet Pro,YT3,Lenovo YT3-X90F
+Lenovo,YT3-X90L/YOGA3 Tablet Pro,YT3,Lenovo YT3-X90L
+Lenovo,YT3-X90X/YOGA3 Tablet Pro,YT3,Lenovo YT3-X90X
+Lenovo,YT3-X90Y/YOGA3 Tablet Pro,YT3,Lenovo YT3-X90Y
+Lenovo,YT3-X90Z/YOGA3 Tablet Pro,YT3,Lenovo YT3-X90Z
+Lenovo,Yoga TAB3 Plus,YT-X703F,Lenovo YT-X703F
+Lenovo,Yoga TAB3 Plus,YT-X703L,Lenovo YT-X703L
+Lenovo,Yoga TAB3 Plus,YT-X703X,Lenovo YT-X703X
+Lenovo,YogaTablet2 -1050F,YT2,YOGA Tablet 2-1050F
+Lenovo,YogaTbalet2-830F,YT2,YOGA Tablet 2-830F
+Lenovo,Z2,z2r,Lenovo Z2
+Lenovo,Z2,z2t,Lenovo Z2
+Lenovo,Z2w,z2w,Lenovo Z2w
+Lenovo,Z90/VIBE Shot,zoom_fdd,Lenovo Z90
+Lenovo,Z90/VIBE Shot,zoom_fdd,Lenovo Z90-7
+Lenovo,Z90/VIBE Shot,zoom_tdd,Lenovo Z90-3
+Lenovo,Z90a40/VIBE Shot,zoom_row,Lenovo Z90a40
+Lenovo,ideatv S52,ideatv_S52,ideatv S52
+Lenovo,ideatvK82 60LX750A  52LX750A  46LX750A  60LX850A  70LX850A 80LX850A,ideatv_K82,ideatv K82
+Lenovo,\xe5\xb0\x8f\xe6\x96\xb0\xe5\xb9\xb3\xe6\x9d\xbf,X804F,Lenovo TB-X804F
+Lexibook,Fluo,MFC145FR1,MFC145FR1
+Lexibook,Fluo XL,MFC191FR2,MFC191FR2
+Lexibook,Fluo XL Premium Edition,MFC510FR1,MFC510FR1
+Lexibook,"LexiTab 10""",MFC512,MFC512FR
+Lexibook,LexiTab 10\'\',mfc511,MFC511DE
+Lexibook,LexiTab 10\'\',mfc511,MFC511EN
+Lexibook,LexiTab 10\'\',mfc511,MFC511FR
+Lexibook,"LexiTab 7""",MFC147,MFC147FR
+Lexibook,LexiTab 7\'\',MFC146DE,MFC146DE
+Lexibook,LexiTab 7\'\',MFC146EN,MFC146EN
+Lexibook,LexiTab 7\'\',MFC146FR,MFC146FR
+Lexibook,LexiTab 7\'\'\t,MFC146ES,MFC146ES
+Lexibook,MFC191,MFC191,S952
+Lexibook,Playdroid,lbox500,LBOX500
+Lgcns,LPT_200AR,LPT_200AR,LPT_200AR
+Lgcns,LPT_201AR,LPT_201AR,LPT_201AR
+LifeWatch,"V , FGL-00004",hp6577_cts,LifeWatch V
+LinkNet,SH960C-LN,SH960C-LN,SH960C-LN
+LinkNet,ST950I-LN,ST950I-LN,ST950I-LN
+LinkNet,Smart Box HD,SH940C-LN,SH940C-LN
+Listo,WEBPAD1002,Listo,WEBPAD1002
+Logic Instrument,FieldBook E1,FieldBook_E1,FieldBook_E1
+Logic Instrument,Fieldbook F1,lifbf1,Logic Instrument Fieldbook F1
+Logic Instrument,Fieldbook F53,lifbf53,Logic Instrument Fieldbook F53
+Logic Instrument,Fieldbook K80,lifbk80,Logic Instrument Fieldbook K80
+Logic Instrument,Logic Instrument Fieldbook KS80,lifbks80,Logic Instrument Fieldbook KS80
+Logic Mobility,LOGIC_L5D,LOGIC_L5D,LOGIC_L5D
+Logic Mobility,X5A,LOGIC_X5A,LOGIC X5A
+Logicom,B bot 50,BBOT50,B BOT 50
+Logicom,B bot 550,BBOT550,B BOT 550
+Logicom,C bot tab 100,CBotTab100,C Bot Tab 100
+Logicom,C bot tab 70,C_Bot_Tab_70,C Bot Tab 70
+Logicom,CT1080,CT1080,CT1080
+Logicom,Connect503,L-ite502,Connect503
+Logicom,E1052GP,E1052GP,E1052GP
+Logicom,E350,E350,E350
+Logicom,E400,E400,E400
+Logicom,E852GP,E852GP,E852GP
+Logicom,ID bot 53,IDbot53,ID bot 53
+Logicom,ID bot 553,IDbot553,IDbot553
+Logicom,ID bot 553+,IDbot553PLUS,IDbot553PLUS
+Logicom,ID bot 56,ID_bot_56,ID bot 56
+Logicom,IDbot53plus,IDbot53plus,ID bot 53+
+Logicom,L-EGANT  ONE-R,L-EGANTONE-R,L-EGANTONE-R
+Logicom,L-EGANT ONE,L-EGANTONE,L-EGANTONE
+Logicom,L-EMENT 403,L-EMENT_403,L-EMENT_403
+Logicom,L-EMENT 505,L-EMENT505,L-EMENT 505
+Logicom,L-EMENT 553,L-EMENT553,L-EMENT 553
+Logicom,L-EMENT TAB 1040,generic,L-EMENT_TAB1040
+Logicom,L-EMENT TAB 741,LEMENTTAB741,L-EMENT 741
+Logicom,L-EMENT TAB 742,LEMENTTAB742,L-EMENT 742
+Logicom,L-EMENT TAB 744,L-ement_Tab_744,L-ement_Tab_744
+Logicom,L-EMENT TAB 744P,L-ementTab744P,L-ementTab744P
+Logicom,L-EMENT350,L-EMENT350,L-EMENT350
+Logicom,L-EMENT400,LEMENT400,L-EMENT 400
+Logicom,L-EMENT500,L-EMENT500L,L-EMENT500L
+Logicom,L-EMENT501,L-EMENT501,L-EMENT501
+Logicom,L-EMENT550,L-EMENT550,L-EMENT550
+Logicom,L-EMENT551,L-EMENT551,L-EMENT551
+Logicom,L-EMENTTAB1042,LEMENTTAB1042BTK,L-EMENT_TAB1042BTK
+Logicom,L-EMENT_TAB1040_BT,generic,L-EMENT_TAB1040_BT
+Logicom,L-ITE 400M,L-ITE400M,L-ITE 400M
+Logicom,L-ITE 502 PLUS,L-ITE502PLUS,L-ITE 502 PLUS
+Logicom,L-ITE 504 HD,L-ITE504HD,L-ITE 504 HD
+Logicom,L-ITE 506 HD,L-ITE506HD,L-ITE 506 HD
+Logicom,L-ITE 506R HD,L-ITE506RHD,L-ITE 506R HD
+Logicom,L-ITE Tab 870 LTE,L-ITETAB870LTE,L-ITE Tab 870 LTE
+Logicom,L-ITE402,L-ITE402,L-ITE 402
+Logicom,L-ITE452,L-ITE452,L-ITE 452
+Logicom,L-ITE502,L-ITE502,L-ITE 502
+Logicom,L-ITE552,L-ITE552,L-ITE 552
+Logicom,L-IXIR TAB 1041,generic,LIXIR1041
+Logicom,L-IXIR TAB 1046HD,L-IXIR_TAB_1046_HD,L-IXIR_TAB_1046_HD
+Logicom,L-IXIR TAB 701 3G,TAB701,L-IXIR TAB 701 3G
+Logicom,L-IXIR TAB 840,L-IXIR_TAB_840,L-IXIR_TAB_840
+Logicom,L-ite_Tab1060,LiteTab1060,L-ite_Tab1060
+Logicom,L743,L-EMENT743,L-EMENT743
+Logicom,LEMENT TAB 740,LEMENTTAB740,L-EMENT 740
+Logicom,LEMENTTAB1042,LEMENTTAB1042,L-EMENT_TAB1042
+Logicom,LEMENTTAB901,LEMENTTAB901,LEMENT_TAB901
+Logicom,L_IXIR_TAB_1047HD,L_IXIR_TAB_1047HD,L_IXIR_TAB_1047HD
+Logicom,La Tab Full HD,La_Tab_Full_HD,La Tab Full HD
+Logicom,LiteTab760,LiteTab760,LiteTab760
+Logicom,Logikids,Logikids_2,Logikids_2
+Logicom,Logikids 3,Logikids_3,Logikids_3
+Logicom,M bot 51,Mbot51,M bot 51
+Logicom,M bot 551,M_BOT_551,M BOT 551
+Logicom,M bot 60,Mbot60,M bot 60
+Logicom,M bot Tab 103,MbotTab103,M bot Tab 103
+Logicom,M bot Tab 1150,M_bot_tab_1150,M_bot_tab_1150
+Logicom,M bot Tab 71,M_bot_tab_71,M_bot_tab_71
+Logicom,M bot tab 100,M_BOT_TAB_100,M BOT TAB 100
+Logicom,M bot tab 101,MBOTTAB101,M BOT TAB 101
+Logicom,M bot tab 70,M_BOT_TAB_70,M BOT TAB 70
+Logicom,M_ bot_ 52,M_bot_52,M bot 52
+Logicom,POWER bot,POWERBOT,POWER BOT
+Logicom,S1052,S1052,S1052
+Logicom,S450,S450,S450
+Logicom,S504,S504,Connect 5
+Logicom,S504,S504,S504
+Logicom,S732,rk3026,S732
+Logicom,S7842,S7842,S7842
+Logicom,S952,S952,S952
+Logicom,Touch Tablet CT730,CT730,CT730
+Logicom,VRBOT552,VRBOT552,VR BOT 552
+Logicom,VRBOT552PLUS,VRBOT552PLUS,VR BOT 552 PLUS
+Logicom,Volt-R,Volt-R,Volt-R
+Logitech,Revue,ka,Revue
+Louis Vuitton,Tambour Horizon,sundial,Tambour
+Lumigon,T2,msm7630_fw8911,T2
+Lumigon,T2 HD,T2HD,T2HD
+Lumigon,T3,Lumigon_T3,Lumigon_T3
+Lyf,LS-4004,LS-4004,LS-4004
+Lyf,LS-4006,LS-4006,LYF_LS-4006
+Lyf,LS-4503,LS-4503,LS-4503
+Lyf,LS-4505,LS-4505,LS-4505
+Lyf,LS-4508,C-451,LS-4508
+Lyf,LS-4510,LS-4510,LS-4510
+Lyf,LS-4511,LS-4511,LS-4511
+Lyf,LS-4512,LS-4512,LS-4512
+Lyf,LS-5002,LS-5002,LS-5002
+Lyf,LS-5004,LS-5004,LS-5004
+Lyf,LS-5008,P839F30,LS-5008
+Lyf,LS-5009,LS-5009,LS-5009
+Lyf,LS-5013,LS-5013,LS-5013
+Lyf,LS-5016,LS-5016,LS-5016
+Lyf,LS-5018,HL-L51P,LS-5018
+Lyf,LS-5020,LS-5020,LS-5020
+Lyf,LS-5021,ZTE_T920,LS-5021
+Lyf,LS-5027,LS-5027,LS-5027
+Lyf,LS-5201,panda01a_msm8952_64,LS-5201
+Lyf,LS-5503,P839F50,LS-5503
+Lyf,LS-5504,zx55q05_64,LS-5504
+Lyf,LS-6001,LS-6001,LS-6001
+Lyf,LT-8001,LT-8001,LT-8001
+Lyf,LT-8001 IRIS,LT-8001-IRIS,LT-8001 IRIS
+Lyf,WATER F1,LS-5505,LS-5505
+M-Horse,M-HORSE,Pure1,Pure1
+M4tel,M4 B1,M4_B1,M4_B1
+M4tel,M4 B2,M4_B2,M4_B2
+M4tel,M4 B3,M4_B3,M4_B3
+M4tel,M4 SS4450,DREAMPLUS02A-S10A,M4 SS4450
+M4tel,M4 SS4450B,DREAMPLUS02C-S10A,M4 SS4450B
+M4tel,M4 SS4451,NOVA02A_S11A,M4 SS4451
+M4tel,M4 SS4452,UDON02A_S10A,M4 SS4452
+M4tel,M4 SS4453,TOUCHPLUS01A-S10A,M4 SS4453
+M4tel,M4 SS4453-R,M4-SS4453-R,M4-SS4453-R
+M4tel,M4 SS4455,NOVA03A_S22A,M4 SS4455
+M4tel,M4 SS4456,UDON04A_S19A,M4 SS4456
+M4tel,M4 SS4457,DREAMPLUS03A-S14A,M4 SS4457
+M4tel,M4 SS4458,TOUCHPLUS02A-S17A,M4 SS4458
+M4tel,M4 SS4458-R,M4-SS4458-R,M4-SS4458-R
+M4tel,M4-SS4457-R,M4-SS4457-R,M4 SS4457-R
+M4tel,M4-SS4457-R,M4-SS4457-R,M4-SS4457-R
+MG Series,Any 302,TR10CS2_3,TR10CS2
+MG series,Any 302,TR10CS1_15,TR10CS1
+MG series,Any 302,TR10CS2_2,TR10CS2
+MG series,Any 302,TR10CS2_3,TR10CS2
+MG series,Any 303,TR10CD2_2,TR10CD2
+MG series,Any 303,TR10CD2_3,TR10CD2
+MJS,T2702,T2702,T2702
+MPman,MPDC1006,MPDC1006,MPDC1006
+MPman,MPDC706,MPDC706,MPDC706
+MSI,Primo73,N71J,Primo73
+MSI,Primo76,N728,Primo76
+MSI,Primo81,N821,Primo 81
+MSI,Primo81,N821,Primo81
+MSI,Primo81,Primo81,Primo81
+MTC,982,MTC_982,MTC 982
+MTC,Vodafone Smart mini,Vodafone_875,MTC 970H
+MTN Group,5982C3,MTN-TBW5982C3,MTN-TBW5982C3
+MTN Group,8978P,MTN-8978P,MTN-8978P
+MTN Group,MTN Sm@rt L840,MTN-L840,MTN Sm@rt L840
+MTN Group,MTN Sm@rt L860,MTN-L860,MTN Sm@rt L860
+MTN Group,MTN Sm@rt L860,MTN-L860,MTN-L860
+MTN Group,MTN Smart S730,MTN-S730,MTN-S730
+MTN Group,MTN Smart S735,MTN-S735,MTN-S735
+MTN Group,MTN Smart S810,MTN-S810,MTN-S810
+MTN Group,MTN Steppa 2 LTE,Steppa2,MTN Steppa 2 LTE
+MTN Group,S620,MTN-S620,MTN-S620
+MTN Group,S720i,MTN-S720i,MTN-S720i
+MTN Group,Sm@rt Mini S630,MTN-S630,MTN-S630
+MTN-E70,MTN-E70,MTN-E70,MTN-E70
+MTT,Master,Master,M.T.T. Master
+MTT,Smart Fun,SmartFun,M.T.T. Smart Fun
+Mach Speed,xtreme,X_treme_Play_Tab,X-treme Play Tab
+MachSpeed (Apollo Brands),STR-9.6-Tablet,STR_96_Tablet,STR-9.6-Tablet
+MachSpeed (Apollo Brands),Trio Stealth_10 Tablet,D_10AL,Trio Stealth_10
+MachSpeed (Apollo Brands),Trio Stealth_8 Tablet,D_8AL,Trio Stealth_8
+MachSpeed (Apollo Brands),Trio Stealth_9 Tablet,D_9AL,Trio Stealth_9
+MachSpeed (Apollo Brands),TrioStealth-7,TrioStealth-7,TrioStealth-7
+Mad Catz,M.O.J.O.,mojo,Mad Catz M.O.J.O.
+Making Life Simple,iQ1012N,iQ1012N,iQ1012N
+Making Life Simple,iQ1805N,iQ1805N,iQ1805N
+Making Life Simple,iQ9013_4N,iQ9013_4N,iQ9013_4N
+Making Life Simple,iQGW516,iQGW516,iQGW516
+Making Life Simple,iQW553N,iQW553N,iQW553N
+Manta,MSP4507,MSP4507,MSP4507
+Marshall,London,KB-1501,London
+Masstel,LT52,Masstel_LT52,Masstel LT52
+Masstel,Masstel Tab7,3G_Tablet_PC,Masstel Tab7
+Masstel,Masstel Tab8,Masstel_Tab8,Masstel Tab8
+Masstel,Masstel_Tab10,Masstel_Tab10,Masstel Tab10
+Masstel,N535,Masstel_N535,Masstel N535
+Masstel,Tab7LTE,Masstel_Tab7LTE,Masstel_Tab7LTE
+Maxcom,MS514,MS514,MS514
+Maxcom,MS553,MS553,MS553
+Maxis,NeXT X1,VFD710,VFD 710
+Maxwest,Astro 5N LTE,Astro_5N_LTE,Astro_5N_LTE
+Maxwest,MAXWEST,Black765857703671,AstroPhablet7s
+MeanIT,C4,C4,C4
+MeanIT,meanIT C80C81,meanIT_C80C81,meanIT_C80C81
+MeanIT,meanIT_C10C11,meanIT_C10C11,meanIT_C10C11
+Mecer,101P51C,101P51C,101P51C
+Mecer,101P51D,101P51D,101P51D
+Mecer,800P31C,800P31C,800P31C
+Mecer,800P71D,800P71D,800P71D
+Mecer,M785P,M785P,M785P
+Mecer,MF716,MF716,MF716
+Mecer,MW16Q9-4G,MW16Q9_4G,MW16Q9_4G
+Mecer,TEI11011,TEI11011MST,TEI11011MST
+Mecer,TF10EA2,TF10EA2_11,TF10EA2
+Mecer,TF10MK1,TF10MK1_2,TF10MK1
+Mediacom,G5M,M-PPxG5M,M-PPxG5M
+Mediacom,M-PPAG4,M-PPAG4,M-PPAG4
+Mediacom,M-PPxG4P,G4P,M-PPxG4P
+Mediacom,M-PPxG5,M-PPxG5,M-PPxG5
+Mediacom,M-PPxG7,M-PPxG7,M-PPxG7
+Mediacom,M-PPxS5,M-PPxS5,M-PPxS5
+Mediacom,M-PPxS5P,M-PPxS5P,M-PPxS5P
+Mediacom,M-PPxS6,M-PPxS6,M-PPxS6
+Mediacom,M-PPxS6P,M-PPxS6P,M-PPxS6P
+Mediacom,M-PPxS7,M-PPxS7,M-PPxS7
+Mediacom,M-PPxS7P,M-PPxS7P,M-PPxS7P
+Mediacom,M-SP10HXxH,M-SP10HXxH,M-SP10HXxH
+Mediacom,M-SP10MXHA,SmartPad,M-SP10MXHA
+Mediacom,M-SP10MXHL,M-SP10MXHL,M-SP10MXHL
+Mediacom,M-SP1AGO3G,M-SP1AGO3G,M-SP1AGO3G
+Mediacom,M-SP7HXAH,M-SP7HXAH,M-SP7HXAH
+Mediacom,M-SP7xGO3G,M-SP7xGO3G,M-SP7xGO3G
+Medion,E1050X,E1050X,E1050X
+Medion,E1051X,E1051X,E1051X
+Medion,E4502,E4502,MEDION E4502
+Medion,E4506,E4506,MEDION E4506
+Medion,E5004,E5004,MEDION E5004
+Medion,E5005,B5060,B5060
+Medion,E5006/P5006,B5032,B5032
+Medion,E5504,B5530,MEDION B5530
+Medion,E691X,E691X,E691X
+Medion,E731x,LIFETAB_E731X,LIFETAB_E731X
+Medion,LIFETAB E10316,LIFETAB_E10316,BOSCH_E10316
+Medion,LIFETAB E10316,LIFETAB_E10316,LIFETAB_E10316
+Medion,LIFETAB E10320,LIFETAB_E10320,LIFETAB_E10320
+Medion,LIFETAB E10320,LIFETAB_E10320,MICROSTAR_E10319
+Medion,LIFETAB E1041X,E1041X,E1041X
+Medion,LIFETAB E723X,LIFETAB_E723X,LIFETAB_E723X
+Medion,LIFETAB E7313,LIFETAB_E7313,LIFETAB_E7313
+Medion,LIFETAB E7316,LIFETAB_E7316,LIFETAB_E7316
+Medion,LIFETAB E7316,LIFETAB_E7316,LIFETAB_S7316
+Medion,LIFETAB E732X,LIFETAB_E732X,LIFETAB_E732X
+Medion,LIFETAB E732X,LIFETAB_E733X,LIFETAB_E733X
+Medion,LIFETAB E732X,LIFETAB_E733X,LIFETAB_S733X
+Medion,LIFETAB P1034X,lifetab_p1034x,LIFETAB_P1034X
+Medion,LIFETAB P733x,lifetab_p733x,LIFETAB_P733X
+Medion,LIFETAB P831X,lifetab_p831x,LIFETAB_P831X
+Medion,LIFETAB P831X,lifetab_p831x,LIFETAB_P831X.2
+Medion,LIFETAB P891X,lifetab_p891x,LIFETAB_P891X
+Medion,LIFETAB P970X,lifetab_p970x,LIFETAB_P970X
+Medion,LIFETAB S1032X,S1032X,S1032X
+Medion,LIFETAB S1033X,LIFETAB_S1033X,LIFETAB_S1033X
+Medion,LIFETAB S1034X,lifetab_s1034x,LIFETAB_S1034X
+Medion,LIFETAB S785X,LIFETAB_S785X,LIFETAB_S785X
+Medion,LIFETAB S786x,LIFETAB_S786X,LIFETAB_S786X
+Medion,LIFETAB S831X,LIFETAB_S831X,LIFETAB_S831X
+Medion,LIFETAB_S1036X,lifetab_s1036x,LIFETAB_S1036X
+Medion,Lifetab P9514,LIFETAB_P9514,LIFETAB_P9514
+Medion,Media Base P740X,P740X,P740X
+Medion,P1032X,P1032X,P1032X
+Medion,P1035X,P1035X,P1035X
+Medion,P1050X,P1050X,P1040X
+Medion,P1050X,P1050X,P1050X
+Medion,P1060X,P1060X,P1060X
+Medion,P1060X,P1060X,X1060X
+Medion,P4501,P4501,P4501
+Medion,P5004,P5004,MEDION P5004
+Medion,P5005,P5005,MEDION P5005
+Medion,P5015,P5015,MEDION P5015
+Medion,P73035,P72035,P72035
+Medion,P850X,P850X,P850X
+Medion,P851X,P851X,P851X
+Medion,S1035X,S1035X,S1035X
+Medion,S5004,S5004,MEDION S5004
+Medion,S5504,B5531,B5531
+Medion,S7322,LIFETAB_S732X,LIFETAB_S732X
+Medion,X1030x,X1030X,X1030X
+Medion,X1031X,X1031X,X1031X
+Medion,X5520,B5532,B5532
+Medion,X6001,X6001,MEDION X6001
+Medion,microstar E10319,E10319,E10319
+MegaFon,Login 3,MFLogin3,MegaFon Login 3
+MegaFon,MFLogin3T,MFLogin3T,MFLogin3T
+MegaFon,MFLoginPh,MFLoginPh,MFLoginPh
+MegaFon,MS4B,Viper_LTE,ALCATEL ONE TOUCH 7030R
+MegaFon,MS4B,Viper_LTE,ALCATEL ONE TOUCH 7030Y
+MegaFon,MS4B,Viper_LTE,MS4B
+MegaFon,MT3A,MT3A,MT3A
+Megahouse,CP-D403,CP-D403,CP-D403
+Meitu,M4,M4,Meitu M4
+Meitu,M6,M6,MP1503
+Meitu,M8s,MayaS,MP1709
+Meitu,Maya,Maya,MP1603
+Meitu,Meitu T8s,VictoriaS,MP1701
+Meitu,V4,V4,Meitu V4
+Meitu,V4s,V4s,Meitu V4s
+Meitu,Victoria,Victoria,MP1602
+Meizu,M6,meizu_M6,M6
+Meizu,M6,meizu_M6,MEIZU M6
+Meizu,M6 Note,M6Note,M6 Note
+Meizu,M6s,MeizuM6s,Meizu M6s
+Meizu,M6s,MeizumbluS6,Meizu mblu S6
+Meizu,Meizu S6,MeizuS6,Meizu S6
+Meizu,PRO 7,PRO7H,PRO 7-H
+Meizu,PRO 7,PRO7S,PRO 7
+Meizu,PRO 7,PRO7S,PRO 7-S
+Meizu,PRO 7 Plus,PRO7Plus,PRO 7 Plus
+Memorex,MTAB-07530A,MTAB-07530A,MTAB-07530A
+Memorex,MTAB-0753AK,MTAB-07535AK,MTAB-07535AK
+Memorex,MTAB-08530A,MTAB-08530A,MTAB-08530A
+Memorex,MTAB-09541AB,MTAB-09541AB,MTAB-09541AB
+Micromax,A110,s9081,Micromax A110
+Micromax,A111,A111,A111
+Micromax,A116,A116,A116
+Micromax,A240,A240,A240
+Micromax,A27,A27,A27
+Micromax,A44,tinnoes13_s7050,A44
+Micromax,A45,tinnoes73_s8030_2g,A45
+Micromax,A50,kpt73_gb,Micromax A50
+Micromax,A54,A54,A54
+Micromax,A56,A56,Micromax A56
+Micromax,A57,A57,A57
+Micromax,A57,A57,Micromax A57
+Micromax,A62,A62,Micromax A62
+Micromax,A72,A72,Micromax A72
+Micromax,A73,A73,A73
+Micromax,A73,A73,Micromax A73
+Micromax,A75,A75,A75
+Micromax,A78,Micromax,A78
+Micromax,A84,A84,A84
+Micromax,A87,A87,A87
+Micromax,A87,A87,Micromax A87
+Micromax,A88,A88,A88
+Micromax,A89,A89,A89
+Micromax,A91,A91,A91
+Micromax,A91,A91,Micromax A91
+Micromax,BOLT,A068,A068
+Micromax,BOLT,A069,Micromax A069
+Micromax,BOLT,A24,Micromax A24
+Micromax,BOLT,A34,Micromax A34
+Micromax,BOLT,A67,Micromax A67
+Micromax,BOLT,A69,Micromax A69
+Micromax,BOLT,A69_IN,Micromax A69
+Micromax,BOLT,Q332,Micromax Q332
+Micromax,BOLT,Q338,Micromax Q338
+Micromax,Bolt,A064,Micromax A064
+Micromax,Bolt,A065,Micromax A065
+Micromax,Bolt,A066,Micromax A066
+Micromax,Bolt,A067,Micromax A067
+Micromax,Bolt,A082,Micromax A082
+Micromax,Bolt,A35,A35
+Micromax,Bolt,A79,Micromax A79
+Micromax,Bolt,A82,Micromax A82
+Micromax,Bolt,AD3520,Micromax AD3520
+Micromax,Bolt,AD4500,Micromax AD4500
+Micromax,Bolt,D200,Micromax_D200
+Micromax,Bolt,D303,Micromax D303
+Micromax,Bolt,D304,Micromax D304
+Micromax,Bolt,D305,Micromax D305
+Micromax,Bolt,D320,Micromax D320
+Micromax,Bolt,D321,Micromax D321
+Micromax,Bolt,D333,Micromax D333
+Micromax,Bolt,D340,Micromax D340
+Micromax,Bolt,Q3001,Micromax Q3001
+Micromax,Bolt,Q301,Micromax Q301
+Micromax,Bolt,Q303,Micromax Q303
+Micromax,Bolt,Q323,Micromax Q323
+Micromax,Bolt,Q324,Micromax Q324
+Micromax,Bolt,Q325,Micromax Q325
+Micromax,Bolt,Q326,Micromax Q326
+Micromax,Bolt,Q331,Micromax Q331
+Micromax,Bolt,Q333,Micromax Q333
+Micromax,Bolt,Q335,Micromax Q335
+Micromax,Bolt,Q336,Micromax Q336
+Micromax,Bolt,Q341,Micromax Q341
+Micromax,Bolt,Q346,Micromax Q346
+Micromax,Bolt,Q381,Micromax Q381
+Micromax,Bolt,Q383,Micromax Q383
+Micromax,Bolt,S300,Micromax S300
+Micromax,Bolt,S301,Micromax S301
+Micromax,Bolt,S302,Micromax S302
+Micromax,Bolt Juice,Q3551,Micromax Q3551
+Micromax,Bolt Pace,Q402,Micromax Q402
+Micromax,Bolt Q3301,Q3301,Micromax Q3301
+Micromax,Bolt Selfie,Q424,Micromax Q424
+Micromax,Bolt Supreme 4,Q352,Micromax Q352
+Micromax,CANVAS 2 COLOURS,A120,Micromax A120
+Micromax,CANVAS 2 PLUS,A110Q,A110Q
+Micromax,CANVAS 2 PLUS,s9086b,Micromax A110Q
+Micromax,CANVAS 4,A210,A210
+Micromax,CANVAS 4,s9111b,A210
+Micromax,CANVAS BEAT,A114R,Micromax A114R
+Micromax,CANVAS BLAZE,MT500,MT500
+Micromax,CANVAS DOODLE 3,MicromaxA102,Micromax A102
+Micromax,CANVAS DUET,AE90,Micromax AE90
+Micromax,CANVAS DUET 2,EG111,Micromax EG111
+Micromax,CANVAS ELANZA 2,A121,Micromax A121
+Micromax,CANVAS ENGAGE,A091,Micromax A091
+Micromax,CANVAS ENTICE,A105,Micromax A105
+Micromax,CANVAS GOLD,A300,Micromax A300
+Micromax,CANVAS KNIGHT,A350,Micromax A350
+Micromax,CANVAS KNIGHT,s9320ae,Micromax A350
+Micromax,CANVAS MAGNUS,s9203,Micromax A117
+Micromax,CANVAS POWER,A96,Micromax A96
+Micromax,CANVAS TUBE,A118R,Micromax A118R
+Micromax,CANVAS TURBO,A250,A250
+Micromax,CANVAS TURBO,s9311,A250
+Micromax,CANVAS TURBO MINI,s8513a,Micromax A200
+Micromax,CANVAS UNITE 2,A106,Micromax A106
+Micromax,Canvas 2,Q4310,Micromax Q4310
+Micromax,Canvas 4+,A315,Micromax A315
+Micromax,Canvas 5,E481,Micromax E481
+Micromax,Canvas 5 Lite,Q463,Micromax Q463
+Micromax,Canvas 6,E485,Micromax E485
+Micromax,Canvas 6 Pro,E484,Micromax E484
+Micromax,Canvas A1,AQ4501_sprout,Micromax AQ4501
+Micromax,Canvas A1,AQ4502_sprout,Micromax AQ4502
+Micromax,Canvas AMAZE,Q395,Micromax Q395
+Micromax,Canvas Blaze,Q400,Micromax Q400
+Micromax,Canvas Blaze 4G Plus,Q414,Micromax Q414
+Micromax,Canvas Doodle4,Q391,Micromax Q391
+Micromax,Canvas Evok,E483,Micromax E483
+Micromax,Canvas FIRE4G,Q411,Micromax Q411
+Micromax,Canvas Fire,A093,Micromax A093
+Micromax,Canvas Fire,A104,Micromax A104
+Micromax,Canvas Fire 4G,Q462,Micromax Q462
+Micromax,Canvas Fire 5,Q386,Micromax Q386
+Micromax,Canvas Fire 6,Q428,Micromax Q428
+Micromax,Canvas Fire3,A096,Micromax A096
+Micromax,Canvas Fire4,A107,Micromax A107
+Micromax,Canvas Fun,A76,Micromax A76
+Micromax,Canvas HD Plus,A190,Micromax A190
+Micromax,Canvas Hue,AQ5000,Micromax AQ5000
+Micromax,Canvas Hue 2,A316,Micromax A316
+Micromax,Canvas Infinity,HS2,Micromax HS2
+Micromax,Canvas Juice,A77,Micromax A77
+Micromax,Canvas Juice 3+,Q394,Micromax Q394
+Micromax,Canvas Juice 4,Q382,Micromax Q382
+Micromax,Canvas Juice 4G,Q461,Micromax Q461
+Micromax,Canvas Juice 6,Q398,Micromax Q398
+Micromax,Canvas Juice2,AQ5001,Micromax AQ5001
+Micromax,Canvas Juice3,Q392,Micromax Q392
+Micromax,Canvas Knight Cameo,A290,Micromax A290
+Micromax,Canvas Knight2,KNIGHT2,Micromax E471
+Micromax,Canvas L,A108,Micromax A108
+Micromax,Canvas Magnus,A117,Micromax A117
+Micromax,Canvas Magnus HD,Q421,Micromax Q421
+Micromax,Canvas Mega,E353,Micromax E353
+Micromax,Canvas Mega,Q417,Micromax Q417
+Micromax,Canvas Mega 2,Q426,Micromax Q426
+Micromax,Canvas Nitro,A310,Micromax A310
+Micromax,Canvas Nitro,A311,Micromax A311
+Micromax,Canvas Nitro2,E311,Micromax E311
+Micromax,Canvas Pace 4G,Q416,Micromax Q416
+Micromax,Canvas Pace MIni,Q401,Micromax Q401
+Micromax,Canvas Pep,Q370,Micromax Q370
+Micromax,Canvas Pep,Q371,Micromax Q371
+Micromax,Canvas Pep,Q375,Micromax Q375
+Micromax,Canvas Play,Q355,Micromax Q355
+Micromax,Canvas Play 4G,Q412,Micromax Q412
+Micromax,Canvas Play4G,Q469,Micromax Q469
+Micromax,Canvas Pulse,E451,Micromax E451
+Micromax,Canvas SPARK2,Q334,Micromax Q334
+Micromax,Canvas Selfie,A255,Micromax A255
+Micromax,Canvas Selfie 4,Q349,Micromax Q349
+Micromax,Canvas Selfie Lens,Q345,Micromax Q345
+Micromax,Canvas Space 2,Q480,Micromax Q480
+Micromax,Canvas Space 2+,Q479,Micromax Q479
+Micromax,Canvas Spark,Q380,Micromax Q380
+Micromax,Canvas Spark 2 Plus,Q350,Micromax Q350
+Micromax,Canvas Spark 3,Q380N,Micromax Q380N
+Micromax,Canvas Spark 3,Q385,Micromax Q385
+Micromax,Canvas Spark 4G,Q4201,Micromax Q4201
+Micromax,Canvas Tab,F666,MicromaxF666
+Micromax,Canvas Tab,P480,MicromaxP480
+Micromax,Canvas Tab,P480,P480
+Micromax,Canvas Tab,P681,Micromax P681
+Micromax,Canvas Tab,P690,Micromax P690
+Micromax,Canvas Tab,P701,Micromax P701
+Micromax,Canvas Tab,P702,MicromaxP702
+Micromax,Canvas Tab,P70221,P70221
+Micromax,Canvas Tab,P802,MicromaxP802
+Micromax,Canvas Tab,P810,Micromax P810
+Micromax,Canvas Tabby,P469,P469
+Micromax,Canvas Turbo,A250,Micromax A250
+Micromax,Canvas Unite 4,Q427,Micromax Q427
+Micromax,Canvas Unite 4 Pro,Q465,Micromax Q465
+Micromax,Canvas XL2,A109,Micromax A109
+Micromax,Canvas Xpress,A99,Micromax A99
+Micromax,Canvas Xpress 2,E314,Micromax E314
+Micromax,Canvas Xpress 4g,Q413,Micromax Q413
+Micromax,Canvas tab,P290,Micromax P290
+Micromax,Canvas tab,P470,P470
+Micromax,Canvas tab,P666,Micromax P666
+Micromax,Canvas tab,P680,MicromaxP680
+Micromax,Doodle 4,Q491,Micromax Q491
+Micromax,Dual 4,E4816,Micromax E4816
+Micromax,EVOK DUAL NOTE,E4815,Micromax E4815
+Micromax,Evok Dual Note,E4817,Micromax E4817
+Micromax,Evok Note,E453,Micromax E453
+Micromax,Evok Power,Q4260,Micromax Q4260
+Micromax,MAD,A94,Micromax A94
+Micromax,MIcromax Bharat 4,Q440,Micromax Q440
+Micromax,Micromax Canvas 1,C1,Micromax C1
+Micromax,Micromax Canvas Music M1,Q4261,Micromax Q4261
+Micromax,Micromax Selfie 2,Q4311,Micromax Q4311
+Micromax,Micromax Selfie 2 Note,Q4601,Micromax Q4601
+Micromax,Micromax Spark 4G Prime(2017),Q452,Micromax Q452
+Micromax,Nitro 3,E352,Micromax E352
+Micromax,Nitro 4G,E455,Micromax E455
+Micromax,P275,P275,P275
+Micromax,P300,crane-M701C_mmx,P300
+Micromax,Q327,Q327,Micromax Q327
+Micromax,Q350R,Q350R,Micromax Q350R
+Micromax,Q354,Q354,Micromax Q354
+Micromax,SUPREME BOLT,Q300,Micromax Q300
+Micromax,Selfie 2,Q340,Micromax Q340
+Micromax,Selfie 3,E460,Micromax E460
+Micromax,Selfie 3,Q348,Micromax Q348
+Micromax,Sliver 5,Q450,Micromax Q450
+Micromax,Spark  4G(2017),Q409,Micromax Q409
+Micromax,UNITE,A092,Micromax A092
+Micromax,Unite 3,Q379,Micromax Q379
+Micromax,Unite2,A106,Micromax A106
+Micromax,Unite3,Q372,Micromax Q372
+Micromax,Vdeo 1,Q4001,Micromax Q4001
+Micromax,Vdeo 2,Q4101_Ru,Micromax Q4101
+Micromax,Vdeo 3,Q4202,Micromax Q4202
+Micromax,Vdeo 4,Q4251,Micromax Q4251
+Micromax,Vdeo 5,Q4220,Micromax Q4220
+Micromax,Xpress 2,E313,Micromax E313
+Micromax,YUNIQUE,YUNIQUE,YU4711
+Micromax,YUREKA S,YUREKA2,YU5200
+Micromax,YUREKA S,YUREKA2,YU5551
+Micromax,Yunique 2 Plus,YU5012,YU5012
+Micromax,Yuphoria,YUPHORIA,YU5010
+Micromax,Yutopia,YUTOPIA,YU5050
+Microtech,e-tab_style_rev.3,e-tab_style_REV3,e-tab_style_REV3
+MiiA,MT-733G,MT-733G,MT-733G
+MiiA,MiiA,TA10CA1_2,TA10CA1
+Mint,Clover,M4CR,M4CR
+Mint,Clover,M4CR,M4CRD
+Mint,Emerald,Emerald,Emerald_M55CR
+Mint,Emerald,Emerald,Emerald_M55CRD
+Mint,M3CR2,Mint_Fox_Plus,Mint Fox+
+Mint,M4,M4,M4
+Mint,M4CR2,Mint_Clover_Plus,Mint Clover+
+Mint,M5,MINT-M5,M5
+Mint,MINT Pandora,MINT_Pandora,MINT Pandora
+Mintt,A1,A1,A1
+Mio Tab,MioTab,MioTab2016,MioTab 2016
+Mio Tab,MioTab2017,MioTab2017,MioTab2017
+Miophone,Mio Phone,MioPhone2016,Mio Phone 2016
+Miophone,Mio Phone,MioPhone2017,MioPhone2017
+Mirage,62S,62S,62S
+Mirage,MI-SO-81T,MI-SO-81T,MI-SO-81T
+Mito,A10,A10_sprout,MITO A10
+Mito,A10,A10_sprout,MITO_A10
+Mito,MITO A17,MITO_A17,MITO A17
+Mito,MITO A39,A39,mito A39
+Mito,MITO_A19_1GB,MITO_A19_1GB,MITO_A19_1GB
+Mito,MITO_A19_2GB,MITO_A19_2GB,MITO_A19_2GB
+Mobell,Mobell S50,Mobell_S50,Mobell S50
+Mobell,NOVA P3,NOVA_P3,NOVA P3
+Mobell,S40,S40,S40
+Mobicell,4U,4U,4U
+Mobicell,ARC,ARC,ARC
+Mobicell,Air,Mobicel_Air,Air
+Mobicell,BERRY,BERRY,BERRY
+Mobicell,CHERRY,CHERRY,CHERRY
+Mobicell,COSMO,COSMO,COSMO
+Mobicell,Candy,Candy,Candy
+Mobicell,DANDY,DANDY,DANDY
+Mobicell,ECHO,ECHO,ECHO
+Mobicell,FEVER,FEVER,FEVER
+Mobicell,FRIO,FRIO,FRIO
+Mobicell,HERO X,HERO_X,HERO_X
+Mobicell,Icon,Mobicel_Icon,Icon
+Mobicell,METRO2,METRO2,MOBICEL METRO2
+Mobicell,Matrix,Matrix,Matrix
+Mobicell,Mobicel,Sonic,Sonic
+Mobicell,Mobicel,Venus,Venus
+Mobicell,Mobicel GEM,GEM,GEM
+Mobicell,Mobicel ICE,ICE,ICE
+Mobicell,Mobicel_R1,Mobicel_R1,Mobicel_R1
+Mobicell,NEO,NEO,NEO
+Mobicell,ONYX,ONYX,ONYX
+Mobicell,PLAY,PLAY,PLAY
+Mobicell,PLUM,PLUM,PLUM
+Mobicell,PURE,PURE,PURE
+Mobicell,PURE MINI,PURE_MINI,PURE MINI
+Mobicell,PURE_PLUS,PURE_PLUS,PURE PLUS
+Mobicell,R3,R3,R3
+Mobicell,R4,R4,R4
+Mobicell,REBEL,REBEL,REBEL
+Mobicell,RUSH,RUSH,RUSH
+Mobicell,Retro,Retro,Retro
+Mobicell,SHIFT,SHIFT,SHIFT
+Mobicell,SWITCH,SWITCH,SWITCH
+Mobicell,Samba,Samba,Samba
+Mobicell,TRIP,TRIP,TRIP
+Mobicell,Trendy,TREDNY,TREDNY
+Mobicell,Trendy,TRENDY,TRENDY
+Mobicell,Trendy Plus,TRENDY_PLUS,TRENDY PLUS
+Mobicell,U2,U2,U2
+Mobicell,ZEN,ZEN,ZEN
+Mobicell,ZOOM,ZOOM,ZOOM
+MobiiStar,LAI YUNA 1,LAI_YUNA_1,mobiistar LAI YUNA 1
+MobiiStar,LAI Z1 4G,LAI_Z1_4G,mobiistar LAI Z1 4G
+MobiiStar,LAI Z2,mobiistar_LAI_Z2,mobiistar_LAI_Z2
+MobiiStar,LAI Zoro 3,LAI_ZORO_3,mobiistar LAI ZORO 3
+MobiiStar,LAI Zumbo S 2017,Zumbo_S_2017,Zumbo_S_2017
+MobiiStar,LAI Zumbo S 2017 Lite,Zumbo_S_2017_Lite,Zumbo_S_2017_Lite
+MobiiStar,PRIME X MAX 2018,PRIME_X_MAX_2018,PRIME X MAX 2018
+MobiiStar,ZORO 4G,mobiistar_ZORO_4G,mobiistar_ZORO_4G
+MobiiStar,ZUMBO J2,Mobiistar_Zumbo_J2,Mobiistar_Zumbo_J2
+MobiiStar,ZUMBO Power,ZUMBO_Power,mobiistar ZUMBO Power
+MobiiStar,ZUMBO S2,mobiistar_Zumbo_S2,mobiistar Zumbo S2
+MobiiStar,ZUMBO_S2_Dual,ZUMBO_S2_Dual,mobiistar ZUMBO S2 Dual
+MobileTeleSystem,MTC SMART Surf 4G,MTC_SMART_Surf_4G,MTC_SMART_Surf_4G
+MobileTeleSystem,SMART Race2 4G,SMART_Race2_4G,SMART_Race2_4G
+MobileTeleSystem,SMART Start 2,MTC_SMART_Start_2,MTC_SMART_Start_2
+MobileTeleSystem,SMART Turbo 4G,SMART_Turbo_4G,SMART_Turbo_4G
+MobileTeleSystem,SMART_Sprint_4G,SMART_Sprint_4G,MTC SMART Sprint 4G
+MobileTeleSystem,Smart Surf2 4G,SMART_Surf2_4G,SMART Surf2 4G
+Mobily,MDB342X,qnbml,MDB342X
+Mobiola,Gaia,MOBIOLA_MS55L1,MS55L1
+Mobiola,MS50L1,MS50L1,MS50L1
+Mobiola,MS55E1,MS55E1,MS55E1
+Mobistel,Cynus E7,Cynus_E7,Cynus E7
+Mobistel,Cynus F10,Cynus_F10,Cynus_F10
+Mobistel,Cynus F9 4G,Cynus_F9_4G,Cynus_F9_4G
+Mobistel,Cynus T6,Cynus_T6,Cynus T6
+Mobistel,Cynus_E8,Cynus_E8,Cynus_E8
+Mobiwire,Ahiga,Ahiga,Ahiga
+Mobiwire,Chenoa,Chenoa,Chenoa
+Mobiwire,Cygnus,Cygnus45,Cygnus
+Mobiwire,Cygnus,Cygnus45,Cygnus45
+Mobiwire,Cygnus mini,Cygnus_mini,Cygnus mini
+Mobiwire,Cygnus mini,Cygnus_mini,Cygnus_mini
+Mobiwire,H,Halona,Halona
+Mobiwire,HALONA,Halona,Halona
+Mobiwire,Halona,Halona,Halona
+Mobiwire,Hawk from EE,Hawk_from_EE,Hawk_from_EE
+Mobiwire,Kaya,Kaya_EU_SKU1,KAYA
+Mobiwire,Kiona,Kiona,Kiona
+Mobiwire,Kohana,Kohana,Kohana
+Mobiwire,Kosumi,Kosumi,Kosumi
+Mobiwire,Kwanita,Kwanita,KWANITA
+Mobiwire,Pegasus,Pegasus,Pegasus
+Mobiwire,S4040,S4040,S4040
+Mobiwire,STARSHINE 5,Cygnus_mini,STARSHINE5
+Mobiwire,STARSHINE 5,Cygnus_mini,STARSHINE_5
+Mobiwire,STARSHINE 5,Cygnus_mini,Smart_A25
+Mobiwire,STARXTREM 5,STARXTREM5,STARXTREM5
+Mobiwire,Tala,Tala,Tala
+Mobiwire,Telenor SmartPlus,Telenor_SmartPlus,Telenor_SmartPlus
+Mobiwire,V.40,Nextel,V.40
+Mobiwire,V.45,VSN,V.45S
+Mobiwire,VSN V.45,up06_h26_v45,V.45
+Mobvoi,Ticwatch S Smartwatch; Ticwatch E Smartwatch,mooneye,Ticwatch E
+Mobvoi,Ticwatch S Smartwatch; Ticwatch E Smartwatch,mooneye,Ticwatch S
+Modecom,FreeTAB 10.1 Silver,silver,FreeTAB 10.1 Silver
+Modecom,FreeTAB 8015 IPS X4 LTE,reverie,FreeTAB 8015 IPS X4
+Modecom,Xino Z46 X4+,xino_z46,Xino Z46 X4+
+Mohu,MH-CHANNELS,MH-CHANNELS,MH-CHANNELS
+Monster,M10,M10,M10
+Montblanc,SUMMIT,lionfish,MB SUMMIT
+Montblanc,Summit,lionfish,MB SUMMIT
+Most Computers,Revo You,RevoYou,RevoYou
+Motorola,,A853,Milestone
+Motorola,,ArgonSpin,XT550
+Motorola,,Graham,MZ505
+Motorola,,TAHITI,MT620
+Motorola,,Triumph,MOTWX435KT
+Motorola,,XT311,XT311
+Motorola,,XT316,XT316
+Motorola,,XT317,XT317
+Motorola,,XT319,XT319
+Motorola,,XT530,XT530
+Motorola,,XT531,XT531
+Motorola,,XT532,XT532
+Motorola,,argonspin_umts,XT550
+Motorola,,cdma_kronos,MB612
+Motorola,,cdma_pax,XT603
+Motorola,,cdma_solana,MILESTONE3
+Motorola,,cdma_spyder,DROID RAZR
+Motorola,,cdma_spyder,IS12M
+Motorola,,cdma_spyder,Motorola RAZR MAXX
+Motorola,,cdma_targa,DROID BIONIC
+Motorola,,cg_tita2,XT800+
+Motorola,,choi,XT711
+Motorola,,choles,XT701
+Motorola,,destino,i867
+Motorola,,dominoq_umts,XT316
+Motorola,,edison,MB865
+Motorola,,edison,ME865
+Motorola,,fawnridge,i940
+Motorola,,fleming,MZ607
+Motorola,,fleming,MZ608
+Motorola,,fleming,MZ609
+Motorola,,fleming,XOOM 2 ME
+Motorola,,graham_wifi,MZ505
+Motorola,,iDEN,Motorola_i1
+Motorola,,morr,MB200
+Motorola,,pasteur,MZ616
+Motorola,,pasteur,MZ617
+Motorola,,pasteur,XOOM 2
+Motorola,,qilin,XT806
+Motorola,,scorpion_mini_u,XT905
+Motorola,,smq_u,XT905
+Motorola,,swordfish,XT882
+Motorola,,tinq_umts,XT560
+Motorola,,ttu_skt,XT800W
+Motorola,,umts_begonia,MB610
+Motorola,,umts_begonia,MB611
+Motorola,,umts_elway,MB632
+Motorola,,umts_elway,ME632
+Motorola,,umts_hubble,MZ605
+Motorola,,umts_kobe,MB520
+Motorola,,umts_lucky,A1680
+Motorola,,umts_sage,MB508
+Motorola,,umts_solana,ME863
+Motorola,,umts_solana,XT860
+Motorola,,umts_spyder,XT910
+Motorola,,umts_spyder,XT910K
+Motorola,,umts_spyder,XT910S
+Motorola,,umts_venus2,XT610
+Motorola,,wifi_hubble,MZ604
+Motorola,,zepp,MB501
+Motorola,Atrix,olympus,MB860
+Motorola,Atrix,olympus,MB861
+Motorola,Atrix,olympus,ME860
+Motorola,Atrix HD,qinara,MB886
+Motorola,Backflip,motus,MB300
+Motorola,Backflip,motus,ME600
+Motorola,CLIQ,morrison,MB200
+Motorola,CLIQ,morrison,morrison
+Motorola,Charm,umts_basil,MB502
+Motorola,Citrus,cdma_ciena,WX442
+Motorola,Citrus,cdma_ciena,WX445
+Motorola,Citrus,cdma_ciena,XT301
+Motorola,Cliq-XT,zeppelin,MB501
+Motorola,Cliq-XT,zeppelin,ME501
+Motorola,DROID MAXX 2,lux,XT1021
+Motorola,DROID MAXX 2,lux,XT1565
+Motorola,DROID RAZR HD,vanquish,DROID RAZR HD
+Motorola,DROID RAZR HD,vanquish_u,RAZR HD
+Motorola,DROID RAZR HD,vanquish_u,XT925
+Motorola,DROID RAZR M,scorpion_mini,XT907
+Motorola,DROID RAZR i,smi,XT890
+Motorola,DROID Turbo 2,kinzie,XT1585
+Motorola,DROID4,cdma_maserati,DROID4
+Motorola,Defy,umts_jordan,MB525
+Motorola,Defy,umts_jordan,MB526
+Motorola,Defy,umts_jordan,ME525
+Motorola,Defy,umts_jordan,ME525+
+Motorola,Defy,umts_jordan,unknown
+Motorola,Defy Mini,TinBoost,XT320
+Motorola,Defy Mini,TinBoost,XT321
+Motorola,Defy Mini,tinboost_umts,XT320
+Motorola,Defy Mini,tinboost_umts,XT321
+Motorola,Defy Pro,XT560,XT560
+Motorola,Devour,calgary,Devour
+Motorola,Devour,calgary,calgary
+Motorola,Droid,miler,A854
+Motorola,Droid,sholes,Droid
+Motorola,Droid,umts_sholes,A853
+Motorola,Droid,umts_sholes,Milestone
+Motorola,Droid,umts_sholes,XT701
+Motorola,Droid,umts_sholes,XT702
+Motorola,Droid,umts_sholes,XT720
+Motorola,Droid,umts_sholes,umts
+Motorola,Droid 3,cdma_solana,DROID3
+Motorola,Droid 4,cdma_maserati,DROID4
+Motorola,Droid Bionic,cdma_targa,DROID BIONIC
+Motorola,Droid II,cdma_droid2,A955
+Motorola,Droid II,cdma_droid2,DROID2
+Motorola,Droid II,cdma_droid2we,DROID2 GLOBAL
+Motorola,Droid MAXX,obake-maxx,XT1080
+Motorola,Droid Mini,obakem,XT1030
+Motorola,Droid Pro,cdma_venus2,DROID PRO
+Motorola,Droid Pro,cdma_venus2,DROID Pro
+Motorola,Droid Pro,cdma_venus2,Milestone PLUS
+Motorola,Droid Pro,cdma_venus2,XT610
+Motorola,Droid RAZR,umts_spyder,XT910
+Motorola,Droid Razr M,scorpion_mini_t,201M
+Motorola,Droid Turbo,quark,XT1250
+Motorola,Droid Turbo,quark,XT1254
+Motorola,Droid Ultra,obake,XT1080
+Motorola,Droid X,cdma_shadow,DROIDX
+Motorola,Droid X,cdma_shadow,MB810
+Motorola,Droid X,cdma_shadow,ME811
+Motorola,Droid X,cdma_shadow,Milestone X
+Motorola,Droid X,cdma_shadow,MotoroiX
+Motorola,Droid X2,daytona,DROID X2
+Motorola,Droid X2,daytona,Milestone X2
+Motorola,ELECTRIFY 2,cdma_yangtze,XT881
+Motorola,Electrify M,solstice,XT901
+Motorola,Flipout,umts_ruth,MB511
+Motorola,Flipout,umts_ruth,ME511
+Motorola,Flipout,umts_ruth,MotoMB511
+Motorola,Glam XT800,titanium,XT800
+Motorola,HS1,Motorola_HS1,Motorola_HS1
+Motorola,Iron Rock,umts_irock,XT627
+Motorola,Master Touch,umts_primus,XT621
+Motorola,Master Touch XT621,umts_primus,XT621
+Motorola,Milestone2,umts_milestone2,A953
+Motorola,Milestone2,umts_milestone2,ME722
+Motorola,Milestone2,umts_milestone2,MotoA953
+Motorola,Moto 360,minnow,Moto 360
+Motorola,Moto 360 (2nd Gen),carp,Moto 360
+Motorola,Moto 360 (2nd Gen),smelt,Moto 360
+Motorola,Moto 360 Sport,carp,Moto 360
+Motorola,Moto C,namath,Moto C
+Motorola,Moto C,namath,XT1754
+Motorola,Moto C,namath,XT1755
+Motorola,Moto C,watson,Moto C
+Motorola,Moto C Plus,panell_d,Moto C Plus
+Motorola,Moto C Plus,panell_dl,Moto C Plus
+Motorola,Moto C Plus,panell_dt,Moto C Plus
+Motorola,Moto C Plus,panell_s,Moto C Plus
+Motorola,Moto Defy XT,XT535,XT535
+Motorola,Moto Defy XT,tinboostplus_cdma,XT555C
+Motorola,Moto Defy XT,tinboostplus_cdma,XT556
+Motorola,Moto Defy XT,tinboostplus_cdma,XT557
+Motorola,Moto Defy XT,tinboostplus_umts,XT535
+Motorola,Moto E (1st Gen),condor_cdma,XT1019
+Motorola,Moto E (1st Gen),condor_cdma,XT830C
+Motorola,Moto E (1st Gen),condor_udstv,XT1025
+Motorola,Moto E (1st Gen),condor_umts,XT1021
+Motorola,Moto E (1st Gen),condor_umts,XT1023
+Motorola,Moto E (1st Gen),condor_umtsds,XT1022
+Motorola,Moto E (2nd Gen),otus,MotoE2
+Motorola,Moto E (2nd Gen),otus,XT0000
+Motorola,Moto E (2nd Gen),otus_ds,MotoE2
+Motorola,Moto E (2nd Gen),otus_ds,XT1021
+Motorola,Moto E (4),perry,Moto E (4)
+Motorola,Moto E (4),perry_f,Moto E (4)
+Motorola,Moto E (4),sperry,Moto E (4)
+Motorola,Moto E (4),woods_f,Moto E (4)
+Motorola,Moto E (4),woods_fn,Moto E (4)
+Motorola,Moto E (4) Plus,nicklaus_f,Moto E (4) Plus
+Motorola,Moto E (4) Plus,nicklaus_fn,Moto E (4) Plus
+Motorola,Moto E (4) Plus,owens,Moto E (4) Plus
+Motorola,Moto E with 4G LTE (2nd Gen),surnia_cdma,MotoE2
+Motorola,Moto E with 4G LTE (2nd Gen),surnia_cdma,MotoE2(4G-LTE)
+Motorola,Moto E with 4G LTE (2nd Gen),surnia_cdma,XT1526
+Motorola,Moto E with 4G LTE (2nd Gen),surnia_cdma,XT1528
+Motorola,Moto E with 4G LTE (2nd Gen),surnia_cdma,XT1528O
+Motorola,Moto E with 4G LTE (2nd Gen),surnia_uds,MotoE2(4G-LTE)
+Motorola,Moto E with 4G LTE (2nd Gen),surnia_udstv,MotoE2(4G-LTE)
+Motorola,Moto E with 4G LTE (2nd Gen),surnia_umts,MotoE2(4G-LTE)
+Motorola,Moto E4,perry_f,Moto E (4)
+Motorola,Moto G (1st Gen),falcon_cdma,XT1028
+Motorola,Moto G (1st Gen),falcon_cdma,XT1031
+Motorola,Moto G (1st Gen),falcon_cdma,XT937C
+Motorola,Moto G (1st Gen),falcon_umts,XT1002
+Motorola,Moto G (1st Gen),falcon_umts,XT1003
+Motorola,Moto G (1st Gen),falcon_umts,XT1008
+Motorola,Moto G (1st Gen),falcon_umts,XT1032
+Motorola,Moto G (1st Gen),falcon_umts,XT1034
+Motorola,Moto G (1st Gen),falcon_umts,XT939G
+Motorola,Moto G (1st Gen),falcon_umtsds,XT1033
+Motorola,Moto G (2nd Gen),titan_udstv,XT1069
+Motorola,Moto G (2nd Gen),titan_udstv,titan_retbr_dstv
+Motorola,Moto G (2nd Gen),titan_umts,XT1063
+Motorola,Moto G (2nd Gen),titan_umts,XT1064
+Motorola,Moto G (2nd Gen),titan_umtsds,XT1068
+Motorola,Moto G (2nd Gen),titan_umtsds,titan_niibr_ds
+Motorola,Moto G (3rd Gen),osprey_cdma,MotoG3
+Motorola,Moto G (3rd Gen),osprey_u2,MotoG3
+Motorola,Moto G (3rd Gen),osprey_ud2,MotoG3
+Motorola,Moto G (3rd Gen),osprey_uds,MotoG3
+Motorola,Moto G (3rd Gen),osprey_udstv,MotoG3
+Motorola,Moto G (3rd Gen),osprey_umts,MotoG3
+Motorola,Moto G (4) Play,harpia_n,Moto G Play
+Motorola,Moto G (5),cedric,Moto G (5)
+Motorola,Moto G (5) Plus,potter_n,Moto G (4)
+Motorola,Moto G (5) Plus,potter_n,Moto G (5) Plus
+Motorola,Moto G (5S),montana,Moto G (5S)
+Motorola,Moto G (5S),montana,XT1799-1
+Motorola,Moto G (5S),montana_n,Moto G (5S)
+Motorola,Moto G (5S),montana_n,XT1799-2
+Motorola,Moto G (5S) Plus,sanders,Moto G (5S) Plus
+Motorola,Moto G (5S) Plus,sanders_n,Moto G (4)
+Motorola,Moto G (5S) Plus,sanders_n,Moto G (5S) Plus
+Motorola,Moto G (5S) Plus,sanders_nt,Moto G (4)
+Motorola,Moto G (5S) Plus,sanders_nt,Moto G (5S) Plus
+Motorola,Moto G (5th Gen),cedric,Moto G (5)
+Motorola,Moto G Google Play edition,falcon_umts,XT1032
+Motorola,Moto G Plus (5th Gen),potter,Moto G (5) Plus
+Motorola,Moto G Plus (5th Gen),potter_nt,Moto G (5) Plus
+Motorola,Moto G Turbo Edition,merlin,MotoG3
+Motorola,Moto G Turbo Edition,merlin,MotoG3-TE
+Motorola,Moto G with 4G LTE (1st Gen),peregrine,XT1039
+Motorola,Moto G with 4G LTE (1st Gen),peregrine,XT1040
+Motorola,Moto G with 4G LTE (1st Gen),peregrine,XT1042
+Motorola,Moto G with 4G LTE (1st Gen),peregrine,XT1045
+Motorola,Moto G with 4G LTE (2nd Gen),thea,XT1072
+Motorola,Moto G with 4G LTE (2nd Gen),thea_ds,XT1077
+Motorola,Moto G with 4G LTE (2nd Gen),thea_ds,XT1079
+Motorola,Moto G with 4G LTE (2nd Gen),thea_umtsds,XT1063
+Motorola,Moto G with 4G LTE (2nd Gen),thea_umtsds,XT1078
+Motorola,Moto G(4),athene,Moto G (4)
+Motorola,Moto G(4),athene_t,Moto G (4)
+Motorola,Moto G(4) Plus,athene_f,Moto G (4)
+Motorola,Moto G4 Play,harpia,Moto G Play
+Motorola,Moto G4 Play,harpia,XT1609
+Motorola,Moto G4 Play,harpia_t,Moto G Play
+Motorola,Moto MAXX,quark_umts,XT1225
+Motorola,Moto Turbo,quark_umts,XT1225
+Motorola,Moto X (1st Gen),ghost,XT1049
+Motorola,Moto X (1st Gen),ghost,XT1050
+Motorola,Moto X (1st Gen),ghost,XT1052
+Motorola,Moto X (1st Gen),ghost,XT1053
+Motorola,Moto X (1st Gen),ghost,XT1055
+Motorola,Moto X (1st Gen),ghost,XT1056
+Motorola,Moto X (1st Gen),ghost,XT1058
+Motorola,Moto X (1st Gen),ghost,XT1060
+Motorola,Moto X (2nd Gen),victara,XT1085
+Motorola,Moto X (2nd Gen),victara,XT1092
+Motorola,Moto X (2nd Gen),victara,XT1093
+Motorola,Moto X (2nd Gen),victara,XT1094
+Motorola,Moto X (2nd Gen),victara,XT1095
+Motorola,Moto X (2nd Gen),victara,XT1096
+Motorola,Moto X (2nd Gen),victara,XT1097
+Motorola,Moto X (2nd Gen),victara,XT1098
+Motorola,Moto X (4),payton,XT1789-05
+Motorola,Moto X (4),payton,moto x4
+Motorola,Moto X (4),payton_sprout,moto x4
+Motorola,Moto X Force,kinzie,XT1580
+Motorola,Moto X Force,kinzie_uds,XT1580
+Motorola,Moto X Force,kinzie_uds,XT1581
+Motorola,Moto X Play,lux,Moto X Play
+Motorola,Moto X Play,lux,XT1021
+Motorola,Moto X Play,lux,XT1562
+Motorola,Moto X Play,lux,XT1563
+Motorola,Moto X Play,lux,XT1564
+Motorola,Moto X Play,lux_uds,Moto X Play
+Motorola,Moto X Play,lux_uds,XT1021
+Motorola,Moto X Play,lux_uds,XT1562
+Motorola,Moto X Play,lux_uds,XT1563
+Motorola,Moto X Pro (China),shamu_t,Moto X Pro
+Motorola,Moto X Pure Edition,clark,XT1575
+Motorola,Moto X Style,clark,XT1572
+Motorola,Moto X Style,clark_ds,XT1570
+Motorola,Moto X Style,clark_ds,XT1572
+Motorola,Moto Z,griffin,XT1650
+Motorola,Moto Z,griffin,XT1650-05
+Motorola,Moto Z (2) Force,nash,Moto Z (2)
+Motorola,Moto Z (2) Force,nash,XT1789-05
+Motorola,Moto Z (2) Play,albus,Moto Z2 Play
+Motorola,Moto Z (2) Play,albus,XT1710-02
+Motorola,Moto Z (2) Play,albus,XT1710-08
+Motorola,Moto Z (2) Play,albus,XT1710-11
+Motorola,Moto Z Droid,griffin,XT1650
+Motorola,Moto Z Play,addison,XT1563
+Motorola,Moto Z Play,addison,XT1635-02
+Motorola,Moto Z Play,addison,XT1635-03
+Motorola,Moto Z Play Droid,addison,XT1635-01
+Motorola,Motoluxe,XT611,XT611
+Motorola,Motoluxe,XT615,XT615
+Motorola,Motoluxe,XT682,XT682
+Motorola,Motoluxe,ironmax_umts,XT615
+Motorola,Motoluxe,ironmax_umts,XT685
+Motorola,Motoluxe,ironmaxct_cdma,Motorola MOT-XT681
+Motorola,Motoluxe,ironmaxtv_umts,XT687
+Motorola,Motoluxe,umts_irock,XT626
+Motorola,Motoluxe,umts_irock,XT627
+Motorola,Motoroi,sholest,Milestone XT720
+Motorola,Motoroi,sholest,Motorola XT720
+Motorola,Motoroi,sholest,XT720
+Motorola,Motosmart,XT389,XT389
+Motorola,Motosmart,XT390,XT390
+Motorola,Motosmart,argonmini_umts,XT389
+Motorola,Motosmart,argonmini_umts,XT390
+Motorola,Motosmart,silversmart_umts,XT303
+Motorola,Motosmart,silversmart_umts,XT305
+Motorola,Nexus 6,shamu,Nexus 6
+Motorola,Opus One,rubicon,Motorola Titanium
+Motorola,Opus One,rubicon,Titanium
+Motorola,Photon,asanti_c,XT897
+Motorola,Photon,asanti_c,XT897S
+Motorola,Photon 4G,sunfire,ISW11M
+Motorola,Photon 4G,sunfire,MB855
+Motorola,Photon 4G,sunfire,Motorola Electrify
+Motorola,Quench XT3,XT502,Motorola-XT502
+Motorola,RAZR D1,hawk35_umts,XT914
+Motorola,RAZR D1,hawk35_umts,XT915
+Motorola,RAZR D1,hawk35_umts,XT916
+Motorola,RAZR D1,hawk35_umts,XT918
+Motorola,RAZR D3,hawk40_umts,XT919
+Motorola,RAZR D3,hawk40_umts,XT920
+Motorola,RAZR HD,vanquish,DROID RAZR HD
+Motorola,RAZR HD,vanquish_u,RAZR HD
+Motorola,RAZR M,smq,XT907
+Motorola,RAZR M,smq_t,201M
+Motorola,RAZR i,smi,XT890
+Motorola,Razr V,umts_yangtze,XT885
+Motorola,Razr V,umts_yangtze,XT886
+Motorola,Spice,sesame,XT300
+Motorola,XOOM,stingray,Xoom
+Motorola,XOOM,umts_everest,MZ601
+Motorola,XOOM,umts_hubble,MZ601
+Motorola,XOOM,umts_hubble,MZ605
+Motorola,XOOM,wifi_hubble,MZ604
+Motorola,XOOM,wifi_hubble,MZ606
+Motorola,XOOM,wingray,Xoom
+Motorola,XOOM 2,fleming,MZ609
+Motorola,XOOM 2,pasteur,MZ617
+Motorola,XT605,umts_jorian,XT605
+Motorola,XT627,umts_irock,XT627
+Motorola Solutions,LEX F10,LEXF10,LEX F10
+Motorola Solutions,LEX L10g,lexl10g,LEX L10g
+Motorola Solutions,LEX L10ig,lexl10ig,LEX L10ig
+Motorola Solutions,TC55,TC55,TC55
+Motorola Solutions,TC55CH,TC55CH,TC55CH
+Movado,Boss Touch / TH 24/7 YOU,weever,BOSS Touch
+Movado,Boss Touch / TH 24/7 YOU,weever,TH 24/7 YOU
+Movado,Movado Connect,stargazer,Movado Connect
+Moviltelco Trade,mtt L509,L509,MTT_L509
+Moxee Technologies,X1,X1,X1
+Moxee Technologies,X10,X10,X10
+Moxee Technologies,X100,X100,X100
+Multilaser,M10A,M10A,M10A
+Multilaser,M10A-Lite,M10A-Lite,M10A-Lite
+Multilaser,M7-3G PLUS,ML-JI-M7_3G_PLUS,ML-JI-M7_3G_PLUS
+Multilaser,M7-3G PLUS,ML-WI-M7_3G_PLUS,ML-WI-M7_3G_PLUS
+Multilaser,M7I-3G,M7I-3G,M7I-3G
+Multilaser,M7I-3G,astar-ococci,ML01-M7S-Quad-Core
+Multilaser,M7SQC Plus,M7SQC_Plus,M7SQC_Plus
+Multilaser,M7s Dual Core,NB116_NB117_NB118,M7s Dual ML03
+Multilaser,M7s Quad Core,astar-ococci,ML01-M7S-Quad-Core
+Multilaser,M9-3G,M9-3G,M9-3G
+Multilaser,M9-3G-2,M9-3G_2,M9-3G_2
+Multilaser,ML-SO-M7_3G_PLUS,ML-SO-M7_3G_PLUS,ML-SO-M7_3G_PLUS
+Multilaser,ML-SO-MLX1,ML-SO-MLX1,ML-SO-MLX1
+Multilaser,MLX8,MLX8,MLX8
+Multilaser,MS40S,MS40S,MS40S
+Multilaser,MS40s,MS40S,MS40S
+Multilaser,MS45,MS45,MS45
+Multilaser,MS45S,MS45S,MS45S
+Multilaser,MS45S,MS45S_A6,MS45S_A6
+Multilaser,MS50,MS50,MS50
+Multilaser,MS50L,MS50L,MS50L
+Multilaser,MS50L 4G,MS50L_4G,MS50L_4G
+Multilaser,MS50M,MS50M,MS50M
+Multilaser,MS50S,MS50S,MS50S
+Multilaser,MS50_4G,MS50_4G,MS50_4G
+Multilaser,MS55,MS55,MS55
+Multilaser,MS55M,MS55M,MS55M
+Multilaser,MS60,MS60,MS60
+Multilaser,MS60F,MS60F,MS60F
+Multilaser,MS60F Plus,MS60F_PLUS,MS60F_PLUS
+Multilaser,MS70,MS70,MS70
+Multilaser,Ms5,MTL-MS5,MS5
+Multilaser,Ms6,MS6,MS6
+My Go,GoTab GBT10,GBT10,GoTab_GBT10
+MyPhone (PL),C-Smart pix,C-Smart_pix_JMP,C-Smart_pix
+MyPhone (PL),Cube LTE,CUBE_LTE_PLAY,CUBE_LTE
+MyPhone (PL),Fun_LTE,Fun_LTE,myPhone Fun LTE
+MyPhone (PL),HAMMER BOLT,Hammer_Bolt,Bolt
+MyPhone (PL),Hammer AXE PRO,Hammer_AXE_Pro_OPM,Hammer AXE Pro
+MyPhone (PL),Hammer Blade,Hammer_Blade,Blade
+MyPhone (PL),Hammer Titan 2,Hammer_Titan_2,Hammer Titan 2
+MyPhone (PL),Hammer_Active,HammerActive,Hammer Active
+MyPhone (PL),Hammer_Energy_3G,Hammer_Energy_3G,Hammer Energy 3G
+MyPhone (PL),Hammer_Iron_2,Hammer_Iron_2,Hammer Iron 2
+MyPhone (PL),Hykker MyTab10,Hykker_MyTab10,Hykker_MyTab10
+MyPhone (PL),MyPhone Go!,myPhone_Go,myPhone Go
+MyPhone (PL),myPhone,Q_Smart_BE,Q_Smart_BE
+MyPhone (PL),myPhone  Q-Smart III Plus,Q-Smart_III_Plus,Q-Smart_III_Plus
+MyPhone (PL),myPhone C-Smart Glam,C-Smart_Glam_JMP,C-Smart_Glam
+MyPhone (PL),myPhone C-Smart IIIS,C_Smart_IIIS,C-Smart IIIS
+MyPhone (PL),myPhone Fun 5,FUN5_OPM,FUN5
+MyPhone (PL),myPhone HAMMER ENERGY,HAMMER_ENERGY_PLAY,HAMMER_ENERGY
+MyPhone (PL),myPhone Hammer Energy,Hammer_Energy,Hammer Energy
+MyPhone (PL),myPhone Luna II,LUNA_II_OPM,LUNA_II
+MyPhone (PL),myPhone MAGNUS,MAGNUS_JMP,MAGNUS
+MyPhone (PL),myPhone PRIME PLUS,Prime_Plus_OPM,Prime_Plus
+MyPhone (PL),myPhone Pocket,Pocket_OPM,Pocket
+MyPhone (PL),myPhone Q-Smart Elite,Q-Smart_Elite_JMP,Q-Smart_Elite
+MyPhone (PL),myPhone Q-Smart Plus,Q-Smart_Plus,Q-Smart_Plus
+MyPhone (PL),myPhone_Fun5,myPhone_Fun5,Fun5
+MyPhone (PL),myPhone_Prime_2,myPhone_Prime_2,Prime 2
+Myphone,CUBE,myphone_cube,myPhone Cube
+Myphone,Hammer AXE M LTE,AXE_M_LTE_OPM,HAMMER_AXE_M_LTE
+Myphone,Iron 2,IRON_2_EN,IRON_2
+Myphone,Iron 2,IRON_2_OPM,IRON_2
+Myphone,My phone PRIME PLUS,Prime_Plus_EN,Prime_Plus
+Myphone,UNO,UNO_sprout,MyPhone UNO
+Myphone,brown 1,V4701_I01,brown 1
+Myphone,my28S,MyPhone_my28S,MyPhone my28S
+Myphone,my28S DTV,MyPhone_my28S_DTV,MyPhone my28S DTV
+Myphone,my28S Smart,MyPhone_my28S_Smart,my28S Smart
+Myphone,my71 DTV,my71_DTV,MyPhone my71 DTV
+Myphone,my72 DTV,MyPhone_my72_DTV,MyPhone my72 DTV
+Myphone,my73 DTV,MyPhone_my73_DTV,MyPhone my73 DTV
+Myphone,my75 DTV,MyPhone_my75_DTV,MyPhone my75 DTV
+Myphone,my76 DTV,MyPhonemy76DTV,MyPhone_my76 DTV
+Myphone,my77 DTV,MyPhone_my77_DTV,MyPhone my77 DTV
+Myphone,my81 DTV,MyPhone_my81_DTV,MyPhone my81 DTV
+Myphone,my85 DTV,MyPhone_my85_DTV,MyPhone my85 DTV
+Myphone,my86 DTV,MyPhone_my86_DTV,MyPhone_my86_DTV
+Myphone,my87 DTV,MyPhone_my87_DTV,MyPhone my87 DTV
+Myphone,my88 DTV,MyPhone_my88_DTV,MyPhone my88 DTV
+Myphone,my89 DTV,MyPhone_my89_DTV,MyPhone my89 DTV
+Myphone,my91 DTV,my91_DTV,MyPhone my91 DTV
+Myphone,my92 DTV,MyPhone_my92_DTV,MyPhone my92 DTV
+Myphone,my93 DTV,MyPhone_my93_DTV,MyPhone my93 DTV
+Myphone,my95 DTV,MyPhone_my95_DTV,MyPhone my95 DTV
+Myphone,my96 DTV,MyPhone_my96_DTV,MyPhone my96 DTV
+Myphone,myA1,MY801,MY801
+Myphone,myA10,myA10,myA10
+Myphone,myA2,MY802,MY802
+Myphone,myA3,MY803,MY803
+Myphone,myA5,MY805,MY805
+Myphone,myA6_DTV,MY806,MY806
+Myphone,myA7 DTV,myA7_DTV,myA7 DTV
+Myphone,myA8 DTV,myA8_DTV,myA8 DTV
+Myphone,myA9 DTV,myA9_DTV,myA9 DTV
+Myphone,myT3 DTV,myT3_DTV,myT3 DTV
+Myphone,myT5 DTV,myT5_DTV,myT5 DTV
+Myria,3G MY8300,3G_MY8300,3G
+Myria,Classic MY8301,Classic_MY8301,Classic
+Myria,Classic MY8301,MY8301,Classic
+Myria,Cozy MY8302,Cozy_MY8302,Cozy
+Myria,Cozy MY8302,MY8302,Cozy
+Myria,Fancy,Myria_Fancy,Fancy
+Myria,Myria 4G MY8303,MY8303,4G
+Myria,Myria FIVE,Myria_FIVE,Myria_FIVE
+Myria,Myria Giant MY8304,MY8304,Giant
+Myria,Myria Grand 4G,Myria_Grand_4G,Myria_Grand_4G
+Myria,Myria Wide 2,Myria_Wide_2,Myria_Wide_2
+Myria,Myria Wide 4G,Myria_Wide_4G,Myria_Wide_4G
+NASCO,Allure_Plus,NASCO_Allure_Plus,NASCO_Allure_Plus
+NASCO,Magic,Magic,Magic
+NAXA,NID-7011,NID-7011,NID-7011
+NAXA,NID_7010,NID_7010,NID_7010
+NEC,101T \xe3\x80\x80MEDIAS,NEC-101,NEC-101T
+NEC,AGT10,AGT10,N8730-411
+NEC,AGT10,AGT10,N8730-41101
+NEC,AGT10,AGT10,N8730-41102
+NEC,AGT10 D000-000039-001,D000000039,NEC-STR
+NEC,CASIO G\'zOne Commando 4G LTE,C811,C811 4G
+NEC,Casio G\'zOne Commando,C771,C771
+NEC,Disney Mobile on docomoN-03E,N-03E,N-03E
+NEC,G\'z One IS11CA,IS11CA,IS11CA
+NEC,G\'zOne TYPE-L CAL21,CAL21,CAL21
+NEC,G\xe2\x80\x99zOne CA-201L,CA201L,CA-201L
+NEC,LaVieTab PC-TE508BAW,TE508BAW,PC-TE508BAW
+NEC,LaVieTab PC-TE508S1W/LaVieTab PC-TE508S1L,PC-TE508S1_nec,LaVieTab PC-TE508S1
+NEC,LaVieTab PC-TE510S1L,PC-TE510S1_nec,LaVieTab PC-TE510S1
+NEC,LifeTouch B,LTB013,D000-000013-101
+NEC,LifeTouch B,LTB018,D000-000018-001
+NEC,LifeTouch B,LTB018,D000-000018-002
+NEC,LifeTouch B,LTB018,D000-000018-003
+NEC,LifeTouch B,LTB018,D000-000018-004
+NEC,LifeTouch B,LTB018,D000-000018-101
+NEC,LifeTouch B,LTB018,D000-000018-102
+NEC,LifeTouch B,LTB018,D000-000018-104
+NEC,LifeTouch B,LTB019G,D000-000019-002
+NEC,LifeTouch B,LTB019W,D000-000019-001
+NEC,LifeTouch B,LTB028,LTB-HS
+NEC,LifeTouch L,D000000023,LT-TLA
+NEC,LifeTouch L,D000000035,NEC-STR
+NEC,LifeTouch L,D000000039,NEC-STR
+NEC,LifeTouch L,LTTLA16,LT-TLA
+NEC,LifeTouch L,LTTLA32,LT-TLA
+NEC,LifeTouch L D000-000035-001,D000000035,NEC-STR
+NEC,LifeTouch L D000-000035-002,D000000035,NEC-STR
+NEC,LifeTouch Note,D000000010N,D000-000010-N
+NEC,LifeTouch Note,D000000011N,D000-000011-N
+NEC,LifeTouch Note,LTNA7,LT-NA7
+NEC,LifeTouch Note,LTNA7F,LT-NA7F
+NEC,LifeTouch S,LifeTouch_D1,D000-000001-B01
+NEC,LifeTouch S,LifeTouch_D1,D000-000001-B02
+NEC,LifeTouch S,LifeTouch_D1,D000-000001-C01
+NEC,LifeTouch S,LifeTouch_D1,D000-000001-K01
+NEC,LifeTouch S,LifeTouch_D1,D000-000001-R01
+NEC,LifeTouch S,LifeTouch_D1,D000-000001-R02
+NEC,LifeTouch S,LifeTouch_D1,D000-000001-R03
+NEC,LifeTouch S,LifeTouch_D1,D000-000001-R04
+NEC,LifeTouch S,LifeTouch_D1,D000-000001-S00
+NEC,LifeTouch S,LifeTouch_D1,D000-000001-S01
+NEC,LifeTouch S,LifeTouch_D1,D000-000001-S05
+NEC,LifeTouch S,LifeTouch_D1,D000-000001-S25
+NEC,LifeTouch S,LifeTouch_D1,D000-000001-S85
+NEC,LifeTouch S,LifeTouch_D7,D000-000007-D01
+NEC,LifeTouch W,LT-W1_1,D000-000002-W01
+NEC,LifeTouch W,LT-W1_2,D000-000002-W02
+NEC,LifeTouch W,LifeTouch_W1,D000-000002-001
+NEC,MEDIAS  X N-06E,N-06E,N-06E
+NEC,MEDIAS BR IS11N,IS11N,IS11N
+NEC,MEDIAS CH 101N,101N,101N
+NEC,MEDIAS ES N-05D,N-05D,N-05D
+NEC,MEDIAS LTE N-04D,N-04D,N-04D
+NEC,MEDIAS N-04C,N-04C,N-04C
+NEC,MEDIAS NE-202,NE-202,NE-202
+NEC,MEDIAS NEC-101S,MAGNUM,NEC-101S
+NEC,MEDIAS NEC-101S,NEC-101,NEC-101S
+NEC,MEDIAS NEC-102,NEC-102,NEC-102
+NEC,MEDIAS PP N-01D,N-01D,N-01D
+NEC,MEDIAS TAB N-06D,N-06D,N-06D
+NEC,MEDIAS TAB UL N-08D,N-08D,N-08D
+NEC,MEDIAS U N-02E,N-02E,N-02E
+NEC,MEDIAS U NE-103T,NE-103,NE-103T
+NEC,MEDIAS W N-05E,N-05E,N-05E
+NEC,MEDIAS WP N-06C,N-06C,N-06C
+NEC,MEDIAS X N-04E,N-04E,N-04E
+NEC,MEDIAS X N-07D,N-07D,N-07D
+NEC,NE-201,NE-201,NEC-NE-201A1A
+NEC,NEC909e,NEC909e,NEC909e
+NEC,PC- TS507N1S,PC-TS507N1S,LaVieTab PC-TS507N1S
+NEC,PC-508T1W,508T1W,PC-TS508T1W
+NEC,PC-708T1W,708T1W,PC-TS708T1W
+NEC,PC-TE307N1W,PC-TE307N1W,PC-TE307N1W
+NEC,PC-TE508HAW,PC-TE508HAW,PC-TE508HAW
+NEC,PC-TE510N1B,LaVieTab,LaVieTab PC-TE510N1B
+NESO,N810 i7,N810_i7_1,N810 i7
+NGM Italia SRL,Danamic Now,DynamicNow,Now
+NGM Italia SRL,Dynamic Racing 3,NGM_Dynamic_Racing_3,Dynamic Racing 3
+NGM Italia SRL,Dynamic_Stylo,NGM_Dynamic_Stylo,NGM_Dynamic_Stylo
+NGM Italia SRL,E407,E407,E407
+NGM Italia SRL,E451,E451,E451
+NGM Italia SRL,E505 Plus,E505plus,E505plus
+NGM Italia SRL,E506plus,E506plus,E506plus
+NGM Italia SRL,E553,E553,E553
+NGM Italia SRL,Endurance,ForwardEndurance,ForwardEndurance
+NGM Italia SRL,ForwardZero,ForwardZero,ForwardZero
+NGM Italia SRL,Forward_Prime,Forward_Prime,Forward_Prime
+NGM Italia SRL,Infinity,Infinity,Infinity
+NGM Italia SRL,LIFE,Life,Life
+NGM Italia SRL,M500,NGM_M500,NGM M500
+NGM Italia SRL,M502,M502,M502
+NGM Italia SRL,NGM Youcolor E400,E400,E400
+NGM Italia SRL,NGM Youcolor E450,E450,E450
+NGM Italia SRL,NGM Youcolor E501,E501,E501
+NGM Italia SRL,NGM Youcolor E505,E505,E505
+NGM Italia SRL,NGM Youcolor E506,E506,E506
+NGM Italia SRL,NGM Youcolor E507,E507,E507
+NGM Italia SRL,P503,NGM_P503,NGM P503
+NGM Italia SRL,P508,P508,P508
+NGM Italia SRL,P509,NGM_P509,P509
+NGM Italia SRL,P550,NGM_P550,NGM P550
+NGM Italia SRL,P551,NGM_P551,P551
+NGM Italia SRL,P552,NGM_P552,P552
+NGM Italia SRL,Ruby,ForwardRuby,Forward Ruby
+NGM Italia SRL,Ruby,ForwardRuby,ForwardRuby
+NGM Italia SRL,Smart5,Smart5,Smart5
+NGM Italia SRL,Smart5.5,Smart55,Smart5.5
+NGM Italia SRL,Smart5.5Plus,Smart55Plus,Smart5.5Plus32GB
+NGM Italia SRL,Smart5Plus,Smart5Plus,Smart5Plus
+NOA Mobile,N8,NOA_N8,NOA_N8
+NOA Mobile,SPRINT 4G,SPRINT4G,SPRINT4G
+NVIDIA,SHIELD Android TV,foster,SHIELD Android TV
+NVIDIA,SHIELD Android TV,foster,SHIELD Console
+NVIDIA,SHIELD TV,darcy,SHIELD Android TV
+NVIDIA,SHIELD Tablet,shieldtablet,SHIELD Tablet
+NVIDIA,Shield,roth,SHIELD
+NVIDIA,TegraNote,tegranote,Tegra Note 7
+NVIDIA,TegraNote,tegranote,TegraNote-P1640
+NVIDIA,TegraNote,tegranote,TegraNote-Premium
+NVIDIA,TegraNote,tegranote7c,Tegra Note 7
+NYX Mobile,A1,NYX_A1,NYX_A1
+NYX Mobile,BLINK,BLiNK,BLiNK
+NYX Mobile,GLAM,GLAM,GLAM
+NYX Mobile,HIT,NYX_HIT,NYX_HIT
+NYX Mobile,KiN,KiN,KiN
+NYX Mobile,NOBA,NOBA,NOBA
+NYX Mobile,REX,Rex,Rex
+NYX Mobile,SENSE,SENSE,SENSE
+NYX Mobile,SHADE,NYX_SHADE,NYX_SHADE
+Nabi,2 Tablet,mt799,NABI2-NV7A
+Nabi,2S Tablet,nabi2S,SNB02-NV7A
+Nabi,American Girl Tablet,NBTY07SMKG,NBTY07SMKG
+Nabi,Barbie Tablet,NBTY07SMKG,NBTY07SMKG
+Nabi,"Big Tab HD\xe2\x84\xa2 20""",DMTAB-NV20A,DMTAB-NV20A
+Nabi,"Big Tab HD\xe2\x84\xa2 24""",DMTAB-NV24A,DMTAB-NV24A
+Nabi,DreamTab HD8 Tablet,DMTAB,DMTAB-IN08A
+Nabi,DreamTab HD8 Tablet,t8400n,DMTAB-NV08B
+Nabi,Fisher Price Learning Tablet,NBFP07PMKG,NBFP07PMKG
+Nabi,Hot Wheels Tablet,NBTY07SMKG,NBTY07SMKG
+Nabi,TOY 7,NBTY07SMKG,NBTY07SMKG
+NanoTech,Nuvola NP-1,nuvola,Nuvola NP-1
+Navitel,Navitel T700 3G Navi,NAVITEL_T700_3G_NAVI,NAVITEL T700 3G NAVI
+Navitel,T500 3G,T500_3G,T500 3G
+Navon,D455,D455,D455
+Navon,D504,D504,D504
+Navon,F552,F552,NAVON F552
+Navon,IQ7,IQ7,IQ7
+Navon,Infinity,Infinity,Navon_Infinity
+Navon,M505,M505_4G,M505_4G
+Navon,Platinum 10 3G,Platinum_10_3G,Platinum 10 3G
+Navon,Platinum 10 3G,Platinum_10_3G_V2,Platinum_10_3G_V2
+Navon,Predator 10,Predator_10,Predator 10
+Navon,Predator 3G,Predator_3G,Predator 3G
+Navon,S450,S450,S450
+Navon,Superme_Max,Superme_Max,Superme_Max
+Navon,Supreme Chief,Supreme_Chief,Supreme Chief
+Navon,Supreme Fine,Supreme_Fine,Supreme_Fine
+Navon,Supreme Fine Mini,Supreme_Fine_Mini,Supreme_Fine_Mini
+Navon,Supreme Fine Plus,Supreme_Fine_Plus,Supreme Fine Plus
+Navon,Supreme Pro,Supreme_Pro,Supreme_Pro
+Navon,Supreme_Fine_Micro,Supreme_Fine_Micro,Supreme_Fine_Micro
+Navon,T400,T400,T400
+Navon,T400 3G,T400_3G,T400 3G 2017
+Navon,T452,T452,T452
+Navon,T503,T503,T503
+Navon,Vision Tab 10,Vision_Tab_10,Vision_Tab_10
+Navon,Vision_Tab_7,Vision_Tab_7,Vision_Tab_7
+Ncredible,NV8,NV8,NV8
+Ncredible,NV8-HD,NV8-HD,NV8
+Neffos,C5,C5,Neffos C5
+Neffos,C5 Max,C5_Max,Neffos C5 Max
+Neffos,C5L,QC601,TP601A
+Neffos,C5L,QC601,TP601B
+Neffos,C5L,QC601,TP601C
+Neffos,C5L,QC601,TP601E
+Neffos,X1,X1,Neffos X1
+Neffos,X1 Lite,X1_Lite,Neffos X1 Lite
+Neffos,X1 Max,X1_Max,Neffos X1 Max
+Neffos,Y5,Y5,Neffos Y5
+Neffos,Y50,Y50,Neffos Y50
+Neffos,Y5L,Y5L,Neffos Y5L
+Neffos,Y5L,Y5LM,Neffos Y5L
+Neffos,Y5s,Y5s,Neffos Y5s
+Neostra,Neostra-R10,Neostra-R10,Neostra-R10
+Neostra,Neostra-R10C,Neostra-R10C,Neostra-R10C
+Neostra,Neostra-R7,Neostra-R7,Neostra-R7
+Neostra,ViewPad 7A,ViewPad-Kids-7A,ViewPad-Kids-7A
+Netgear,NeoTVPrime,NeoTV,GTV100
+New Balance,Run IQ,shasta,NB RunIQ
+Nexian,journey one,Mi438S_sprout,Mi438S
+Next Learning,Nexttab N3,N3,N3
+Nextbase,GoPlayer,NBCGGP01,NBCGGP01
+Nextbit,Robin,ether,Robin
+Nextbook,M-MP7NB3G,7_Plus_HD3G,M-MP7NB3G
+Nextbook,NX16A10132S,NX16A10132S,NX16A10132S
+Nextbook,NX16A11264,NX16A11264,NX16A11264
+Nextbook,NX16A8116K,NX16A8116K,NX16A8116K
+Nextbook,NX700QC,nxm7100lvd_wm,NX700QC
+Nextbook,NX785QC,nxm865lvd_wm,NX785QC
+Nextbook,NX785QC8G,NXM865FD,NX785QC8G
+Nextbook,NXA101LTE116,NXA101LTE116,NXA101LTE116
+Nextbook,NXA116QC164,NXA116QC164,NXA116QC164
+Nextbook,NXA8LTE116,NXA8LTE116,NXA8LTE116
+Nextbook,NXA8QC116,NXA8QC116,NXA8QC116
+Nextel,V.35,up11_vsn_h1_single,Nextel V.35
+Nextel,V.45,H26-VSN,NII Nextel
+Nextel,V.45,H26-VSN,V.45
+Nikon,COOLPIX,S800c,COOLPIX S800c
+Nikon,COOLPIX S810c,s810c,COOLPIX S810c
+Nixon,The Mission,sculpin,The Mission
+Njoy,Arcas 7,Arcas_7,nJoy_Arcas_7
+Njoy,Chronos 10,Chronos_10,Chronos_10
+Njoy,Kali 8,Kali_8,Kali_8
+Njoy,Tityos 10,Tityos_10,nJoy_Tityos_10
+Njoy,Turnus 8,Turnus_8,nJoy_Turnus_8
+Njoy,nJoy Theia 10,nJoy_Theia_10,Theia_10
+Nobis,NB07,NB07,NB07
+Nobis,NB09,M9025,NB09
+Nobis,NB1022,RCT6203W46,NB1022
+Nobis,NB7022S,NB7022S,NB7022S
+Nobis,NB7850S,NB7850S,NB7850S
+Noblex,Go Action,N551,N551
+Noblex,Go Move,N552,N552
+Noblex,Go Street,N504,N504
+Noblex,Go Urban,N503,N503
+Noblex,NBX-T1014N,TA10CA2,TA10CA2
+Noblex,NBX-T7014,E270BSA,NBX-T7014
+Nokia,N1,Nokia_N1,N1
+Nokia,Nokia 2,E1M,Nokia 2
+Nokia,Nokia 3,NE1,TA-1020
+Nokia,Nokia 3,NE1,TA-1028
+Nokia,Nokia 3,NE1,TA-1032
+Nokia,Nokia 3,NE1,TA-1038
+Nokia,Nokia 5,ND1,TA-1024
+Nokia,Nokia 5,ND1,TA-1027
+Nokia,Nokia 5,ND1,TA-1044
+Nokia,Nokia 5,ND1,TA-1053
+Nokia,Nokia 6,D1C,TA-1000
+Nokia,Nokia 6,D1C,TA-1003
+Nokia,Nokia 6,PL2,TA-1054
+Nokia,Nokia 6,PLE,TA-1021
+Nokia,Nokia 6,PLE,TA-1025
+Nokia,Nokia 6,PLE,TA-1033
+Nokia,Nokia 6,PLE,TA-1039
+Nokia,Nokia 7,C1N,TA-1041
+Nokia,Nokia 8,NB1,TA-1004
+Nokia,Nokia 8,NB1,TA-1012
+Nokia,Nokia 8,NB1,TA-1052
+Nomi,CORSA 3 LTE,Nomi_C070030,Nomi_C070030
+Nomi,Corsa 3 3G,Nomi_C070012,Nomi_C070012
+Nomi,I5032,Nomi_i5032,i5032
+Nomi,Libra3 3G,Nomi_C080012,Nomi_C080012
+Nomi,Nomi C070011,Nomi_C070011,Nomi C070011
+Nomi,Nomi C080010,Nomi_C080010_Libra2,Nomi C080010 Libra2
+Nomi,Nomi C101010,Nomi_C101010_Ultra2,C101010 Ultra2
+Nomi,Nomi i5013,i5013,i5013
+Nomi,Nomi i5050,i5050,i5050
+Nomi,Nomi i5071,Nomi_i5071,Nomi i5071
+Nomi,Nomi i5510,Nomi_i5510,i5510
+Nomi,Nomi i5532,Nomi_i5532,i5532
+Nomi,Nomi i6030,i6030,Nomi i6030
+Nomi,ULTRA3 3G,Nomi_C101012,Nomi_C101012
+Nomi,ULTRA3 LTE PRO,Nomi_C101040,Nomi_C101040
+Nomi,i5012,i5012,i5012
+Nous,Fabulous,NS5005,NS5005
+Nous,NS5002,NS5002,NS5002
+Nous,NS5502,NS5502,NS5502
+NuAns,NEO [Reloaded],NEO2,NEO [Reloaded]
+Nubia,NX401,NX40X,NX401
+Nubia,NX501,NX501,NX501
+Nubia,NX503A,NX503A,NX503A
+Nuu,A1,NUU_A1,NUU_A1
+Nuu,A3,NUU_A3,NUU_A3
+Nuu,A3L,NUU_A3L,NUU_A3L
+Nuu,A4L,N5001L,N5001L
+Nuu,M2,NUU_M2,NUU_M2
+Nuu,M3,NUU_M3,NUU_M3
+Nuu,N4L,N4L,N4L
+Nuu,N5L,N5L,N5L
+Nuu,NUU_A2,S4001W,S4001W
+Nuu,X4,X4,X4
+Nuu,X5,NUU_X5,NUU_X5
+Nuu,Z8,Z8,Z8
+Nuvision,TM101A530L,TM101A530L,TM101A530L
+Nuvision,TM101A540N,mid1008a-l,TM101A540N
+Nuvision,TM101A730M,TM101AM,TM101A730M
+Nuvision,TM106A510L,TM106A510L,TM106A510L
+Nuvision,TM1088,fiber-wifibt,CT1000
+Nuvision,TM1088,fiber-wifibt,Endeavour101
+Nuvision,TM1088,fiber-wifibt,TM1088
+Nuvision,TM1088,fiber-wifibt,WEBPAD1002
+Nuvision,TM700A520L,TM700A,TM700A520L
+Nuvision,TM785M3,TM785M3,TM785M3
+Nuvision,TM800A510L,TM800A,TM800A510L
+Nuvision,TM800A550L,TM800A550L,TM800A550L
+Nuvision,TM800A730M,TM800AM,TM800A730M
+Nuvision,TM800A740M,TM800AM,TM800A740M
+O\'NICE,O\'NICE I-TOUCH M1,ONICE_I-TOUCH_M1,i-touch M1
+ODYS,MAVEN_X10_HD_LTE,MAVEN_X10_HD_LTE,MAVEN_X10_HD_LTE
+ODYS,PACE 10,PACE10,PACE10
+ODYS,XELIO_HD10,XELIO_HD10,XELIO_HD10
+Obi,MV1,yam,OBI MV1
+Obi,MV1,yam,Obi MV1
+Obi,OBJ SJ1.5,SJ1-5,SJ1-5
+Oceusnetworks,Xiphos\xc2\xaeTMD,granite,Xiphos(R)TMD
+Odys,UNO X10,UNO_X10,UNO X10
+Odys,UNO X8,UNO_X8,UNO_X8
+Oioo,Model 2,wecct,Model 2
+Oioo,Model 3,wecct3,Model 3
+Olive Oil,CT4,octopus-ct4,Octopus A83 CT4
+Olive Oil,OliveOil Model 3,wecct3,CT3
+Olivetti,Graphos A10,Graphos_A10,Graphos A10
+Olivetti,OP110,OP110,OP110
+Ollee,XT080,XT080,XT080
+OnePlus,2,OnePlus2,ONE A2003
+OnePlus,3,OnePlus3,ONEPLUS A3000
+OnePlus,One,A0001,A0001
+OnePlus,One,A0001,One
+OnePlus,OnePlus,OnePlus,ONE E1003
+OnePlus,OnePlus2,OnePlus2,ONE A2003
+OnePlus,OnePlus3,OnePlus3,ONEPLUS A3000
+OnePlus,OnePlus3T,OnePlus3T,ONEPLUS A3000
+OnePlus,OnePlus5,OnePlus5,ONEPLUS A5000
+OnePlus,OnePlus5T,OnePlus5T,ONEPLUS A5010
+OnePlus,X,OnePlus,ONE E1003
+Onkyo,DP-CMX1,Gravity_128,DP-CMX1
+Onkyo,DP-X1,Rai_Zin_32,DP-X1
+Onkyo,DP-X1A,Rai_Zin2R_64,DP-X1A
+OpenPeak,,CIUS-7,CIUS-7
+OpenPeak,,CIUS-7-AT,CIUS-7-AT
+OpenPeak,,cius,cius
+Oppo,1100,1100,1100
+Oppo,1105,1105,1105
+Oppo,1107,1107,1107
+Oppo,1201,1201,1201
+Oppo,1206,1206,1206
+Oppo,3000,3000,3000
+Oppo,3001,Mirror3,3001
+Oppo,3005,3005,3005
+Oppo,3006,Mirror3,3006
+Oppo,3007,3007,3007
+Oppo,3008,3008,3008
+Oppo,A11,A11,A11
+Oppo,A11f,A11,A11f
+Oppo,A11t,A11,A11t
+Oppo,A11w,A11w,A11w
+Oppo,A13t,A31t,A31t
+Oppo,A1601,A1601,A1601
+Oppo,A1601,A1601,A1601fw
+Oppo,A1601fw,A1601,A1601fw
+Oppo,A1603,A1603,A1603
+Oppo,A31,A31t,A31
+Oppo,A31c,A31c,A31c
+Oppo,A31u,A31u,A31u
+Oppo,A33,A33,A33
+Oppo,A33f,A33,A33f
+Oppo,A33f,A33,A33fw
+Oppo,A33fw,A33,A33fw
+Oppo,A33m,A33,OPPO A33m
+Oppo,A33t,A33t,A33t
+Oppo,A33w,A33w,A33w
+Oppo,A35,A35,OPPO A35
+Oppo,A37,A37,OPPO A37
+Oppo,A37,A37,OPPO A37m
+Oppo,A37f,A37f,A37f
+Oppo,A37f,A37f,A37fw
+Oppo,A37fw,A37f,A37fw
+Oppo,A37fw,A37fs,A37fw
+Oppo,A37fw-International,A37fs,A37f
+Oppo,A37m,A37,OPPO A37m
+Oppo,A37t,A37,OPPO A37t
+Oppo,A37tm,A37,OPPO A37tm
+Oppo,A39,A39,OPPO A39
+Oppo,A39m,A39,OPPO A39m
+Oppo,A39t,A39,OPPO A39t
+Oppo,A39tm,A39,OPPO A39tm
+Oppo,A51,A51,A51
+Oppo,A51,A51,Lava A51
+Oppo,A51f,A51,A51f
+Oppo,A51fa,A51,A51f
+Oppo,A51kc,A51kc,A51kc
+Oppo,A51w,A51,A51w
+Oppo,A53,A53,OPPO A53
+Oppo,A53f,A53,A53f
+Oppo,A53fw,A53,A53fw
+Oppo,A53m,A53,OPPO A53m
+Oppo,A53w,A53,A53w
+Oppo,A57,A57,OPPO A57
+Oppo,A57,A57,OPPO A57t
+Oppo,A57t,A57,OPPO A57t
+Oppo,A59,A59,OPPO A59
+Oppo,A59,A59,OPPO A59m
+Oppo,A59,A59,OPPO A59s
+Oppo,A59m,A59,OPPO A59m
+Oppo,A59st,A59,OPPO A59st
+Oppo,A59t,A59,OPPO A59t
+Oppo,A59tm,A59,OPPO A59tm
+Oppo,A73,A73,OPPO A73
+Oppo,A73,A79,OPPO A73
+Oppo,A73t,A73t,OPPO A73t
+Oppo,A73t,A79,OPPO A73t
+Oppo,A77,A77,OPPO A77
+Oppo,A77,A77,OPPO A77t
+Oppo,A79,A79,OPPO A79
+Oppo,A79k,A79k,OPPO A79k
+Oppo,A79kt,A79kt,OPPO A79kt
+Oppo,A79t,A79,OPPO A79t
+Oppo,A79t,A79t,OPPO A79t
+Oppo,A83,A83,OPPO A83
+Oppo,A83t,A83t,OPPO A83t
+Oppo,CHP1705,CPH1705,CPH1705fw
+Oppo,CPH1605,CPH1605,CPH1605
+Oppo,CPH1605,CPH1605,OPPO CPH1605
+Oppo,CPH1605fw,CPH1605,CPH1605fw
+Oppo,CPH1609,CPH1609,CPH1609
+Oppo,CPH1609fw,CPH1609,CPH1609fw
+Oppo,CPH1613,CPH1613,CPH1613
+Oppo,CPH1613,CPH1613,CPH1613fw
+Oppo,CPH1701,CPH1701,CPH1701
+Oppo,CPH1701,CPH1701,CPH1701fw
+Oppo,CPH1705,CPH1705,CPH1705
+Oppo,CPH1707,CPH1707,CPH1707
+Oppo,CPH1707,CPH1707,CPH1707fw
+Oppo,CPH1715,CPH1715,CPH1715
+Oppo,CPH1717,CPH1717,CPH1717
+Oppo,CPH1719,CPH1719,CPH1719
+Oppo,CPH1721,CPH1721,CPH1721
+Oppo,CPH1723,CPH1723,CPH1723
+Oppo,CPH1725,CPH1725,CPH1725
+Oppo,CPH1727,CPH1727,CPH1727
+Oppo,F1f,F1f,F1f
+Oppo,F1f,F1f,F1fw
+Oppo,F1f,F1f,F1w
+Oppo,F1fw,F1f,F1f
+Oppo,F1fw,F1f,F1fw
+Oppo,F1w,F1f,F1f
+Oppo,F1w,F1f,F1w
+Oppo,Find 5,FIND5,X909
+Oppo,Find5,FIND5,X909
+Oppo,Find5,FIND5,X909T
+Oppo,N1,N1,N1
+Oppo,N1 mimi,N1mini,N5111
+Oppo,N1 mimi,N1mini,N5116
+Oppo,N1T,N1T,N1T
+Oppo,N1W,N1W,N1W
+Oppo,N3,N3,N5206
+Oppo,N3,N3,N5207
+Oppo,N3,N3,N5209
+Oppo,N5110,N5110,N5110
+Oppo,N5117,N5117,N5117
+Oppo,R1001,OPPO72_13076,R1001
+Oppo,R1001,R1001,R1001
+Oppo,R1011,R1011,R1011
+Oppo,R1011w,R1011,R1011
+Oppo,R11,R11,OPPO R11
+Oppo,R11,R11,OPPO R11t
+Oppo,R11 Plus,R11Plus,OPPO R11 Plus
+Oppo,R11 Plusk,R11Plusk,OPPO R11 Plusk
+Oppo,R11 Pluskt,R11Plusk,OPPO R11 Pluskt
+Oppo,R11 Plust,R11Plus,OPPO R11 Plust
+Oppo,R11s,R11s,OPPO R11s
+Oppo,R11sPlus,R11sPlus,OPPO R11s Plus
+Oppo,R11sPlust,R11sPlus,OPPO R11s Plust
+Oppo,R11st,R11s,OPPO R11st
+Oppo,R2001,R2001,R2001
+Oppo,R2010,R2010,R2010
+Oppo,R2017,R2017,R2017
+Oppo,R5,R5,R8106
+Oppo,R5,R5,R8107
+Oppo,R5,R5,R8109
+Oppo,R6006,R3,R6006
+Oppo,R6007,R6007,R6007
+Oppo,R7,R7,OPPO R7
+Oppo,R7,R7,R7
+Oppo,R7 Lite,R7f,R7kf
+Oppo,R7 Plus,R7Plus,R7Plus
+Oppo,R7 Plusf,R7Plusm,R7plusf
+Oppo,R7 Plusm,R7Plusm,R7Plusm
+Oppo,R7005,R3,R7005
+Oppo,R7007,R7007,R7007
+Oppo,R7Plusf,R7Plusm,R7plusf
+Oppo,R7Plust,R7Plus,R7Plust
+Oppo,R7c,R7c,R7c
+Oppo,R7f,R7f,R7f
+Oppo,R7g,R7f,R7g
+Oppo,R7kc,R7kc,R7kc
+Oppo,R7kf,R7f,R7kf
+Oppo,R7kt,R7,R7kt
+Oppo,R7s,R7s,OPPO R7s
+Oppo,R7s,R7s,R7s
+Oppo,R7s Plus,R7sPlus,OPPO R7sPlus
+Oppo,R7sf,R7sm,R7sf
+Oppo,R7sfg,R7sf,R7sf
+Oppo,R7sm,R7sm,R7sm
+Oppo,R7st,R7s,R7st
+Oppo,R7t,R7,R7t
+Oppo,R8000,R1S,R8000
+Oppo,R8001,R8001,R8001
+Oppo,R8006,R8006,R8006
+Oppo,R8007,R8007,R8007
+Oppo,R809T,R809T,R809T
+Oppo,R8106,R5,R8106
+Oppo,R815,R815,R815
+Oppo,R815T,R815T,R815T
+Oppo,R815W,R815W,R815W
+Oppo,R819,R819,R819
+Oppo,R819T,R819T,R819T
+Oppo,R820,R820,R820
+Oppo,R8200,R1C,R8200
+Oppo,R8201,R1x,R8201
+Oppo,R8205,R1C,R8205
+Oppo,R8206,R1x,R8206
+Oppo,R8207,R1C,R8207
+Oppo,R821,R821,R821
+Oppo,R821T,R821T,R821T
+Oppo,R823T,R823T,R823T
+Oppo,R827,R827,R827
+Oppo,R827T,R827T,R827T
+Oppo,R829,R829,R829
+Oppo,R829T,R829T,R829T
+Oppo,R830,R830,R830
+Oppo,R830S,R830S,R830S
+Oppo,R831,R831,R831
+Oppo,R831,R831T,R831T
+Oppo,R831K,R831K,R831K
+Oppo,R831L,R831L,R831L
+Oppo,R831S,R831S,R831S
+Oppo,R831T,R831T,R831T
+Oppo,R833T,OPPO82_13067,R833T
+Oppo,R850,R850,R850
+Oppo,R9,R9,OPPO R9
+Oppo,R9,R9,OPPO R9km
+Oppo,R9,R9,OPPO R9m
+Oppo,R9,R9,OPPO R9tm
+Oppo,R9 Plus,R9PlusA,OPPO R9 Plusm A
+Oppo,R9 Plus,R9PlusA,OPPO R9 Plustm A
+Oppo,R9 Plus A,R9PlusA,OPPO R9 Plus A
+Oppo,R9Plus,X9079,X9079
+Oppo,R9PlusA,R9PlusA,OPPO R9 Plusm A
+Oppo,R9PlusA,R9PlusA,OPPO R9 Plustm A
+Oppo,R9PlusmA,R9PlusA,OPPO R9 Plusm A
+Oppo,R9PlustA,R9PlusA,OPPO R9 Plust A
+Oppo,R9PlustmA,R9PlusA,OPPO R9 Plustm A
+Oppo,R9k,R9,OPPO R9k
+Oppo,R9k,R9,OPPO R9km
+Oppo,R9k,R9,OPPO R9m
+Oppo,R9k,R9,OPPO R9tm
+Oppo,R9km,R9,OPPO R9km
+Oppo,R9m,R9,OPPO R9m
+Oppo,R9s,CPH1607,CPH1607
+Oppo,R9s,CPH1607,CPH1607fw
+Oppo,R9s,R9s,OPPO R9s
+Oppo,R9s Plus,CPH1611,CPH1611
+Oppo,R9s Plus,R9sPlus,OPPO R9s Plus
+Oppo,R9s Plus,R9sPlus,OPPO R9s Plust
+Oppo,R9s Plus,R9sPlus,OPPO R9sPlus
+Oppo,R9sk,R9sk,OPPO R9sk
+Oppo,R9sk,R9sk,OPPO R9skt
+Oppo,R9st,R9s,OPPO R9st
+Oppo,R9t,R9,OPPO R9t
+Oppo,R9tm,R9,OPPO R9tm
+Oppo,U3,U3,U3
+Oppo,U707,U707,U707
+Oppo,U707T,U707T,U707T
+Oppo,U708,U708,U708
+Oppo,Ulike2,U705W,U705W
+Oppo,Ulike2,Ulike2,U705T
+Oppo,X9000,X9000,X9000
+Oppo,X9006,X9006,X9006
+Oppo,X9007,X9007,X9007
+Oppo,X9009,X9009,X9009
+Oppo,X9009fw,X9009,X9009fw
+Oppo,X9070,X9070,X9070
+Oppo,X9076,X9076,X9076
+Oppo,X9077,FIND7,X9077
+Oppo,X9077,X9077,X9077
+Oppo,X9079,X9079,X9079
+Oppo,X909,FIND5,X909
+Oppo,X909,X909,X909
+Oppo,X909,X909T,X909T
+Opticon,H-27,H-27,H-27
+Oraimo,R401,oraimo-R401,oraimo R401
+Oraimo,R402,oraimo-R402,oraimo R402
+Oraimo,oraimo R401S,oraimo-R401,oraimo R401S
+Orange,Dive 30,P635E40,Orange Dive 30
+Orange,Dive 30,P635E40,ZTE Blade A410
+Orange,Dive 50,pixi3_45_4g_orange,Orange Dive 50
+Orange,Dive 50 Dual,pixi3_45_4g_orange,Dive 50 Dual
+Orange,Dive 71,Orange_Dive_71,Orange Dive 71
+Orange,Dive72,mickey6,Orange-Dive72
+Orange,Dive_70,Dive_70,SCL-L01
+Orange,Five,OrangeFive,OrangeFive
+Orange,Luno,Luno,Luno
+Orange,NOS Roya,Alto45,NOS Roya
+Orange,Neva 80,Orange_Neva_80,Orange Neva 80
+Orange,Nura,M812,Orange Nura
+Orange,Nura2,m823_orange,Nura 2
+Orange,Orange Rise 33,Rise33,Orange_Rise_33
+Orange,Rise 30,Pixi3-4,Orange Rise 30
+Orange,Rise 40,ZTE_BLADE_A110,Orange Rise 40
+Orange,Rise 50,Rise50,Rise50
+Orange,Rise30,Pixi3-4,Orange-Rise30
+Orange,Rise31,Pixi4-4,Orange-Rise31
+Orange,Rise32,Orange-Rise32,Orange Rise32
+Orange,Rise51,PIXI4_5_4G,Orange-Rise51
+Orange,Rise51,PIXI4_5_4G,Orange-Rise51B
+Orange,Rise52,BUZZ6T4G,Orange-Rise52
+Orange,Roya,Alto45,Orange Roya
+Orange,Sego,Orange_Sego,Orange Sego
+Orange,Zilo,Orange_Zilo,Zilo
+Orange,idol S,Diablo_LTE,Orange Niva
+Orbic,R370H,R370H,R370L
+Orbic,Wonder,RC555L,RC555L
+Oukitel,C6 Pro,C6_Pro,C6 Pro
+Oukitel,C9,C9,C9
+Oukitel,Coosea,K3,K3
+Oukitel,K10000 Pro,K10000_Pro,K10000 Pro
+Oukitel,K10000_Max,K10000_Max,K10000 Max
+Oukitel,K5000,K5000,K5000
+Oukitel,K6000 Plus,K6000_Plus,K6000 Plus
+Oukitel,K8000,K8000,K8000
+Oukitel,OK6000 PLUS,OK6000_Plus,OK6000 Plus
+Oukitel,U20_Plus,U20_Plus,U20_Plus
+Oukitel,U22,U22,U22
+OwnMobile,FUN VALUE 4G,FUNVALUE4G,FUN VALUE 4G
+OwnMobile,OWN Smart \xc3\x962,SMART_O2,SMART_O2
+OwnMobile,SMART 8,Smart8,Smart8
+OwnMobile,Smart Plus Lte,SMART_PLUS_LTE,SMART PLUS LTE
+Oysters,T72HM3G,T72HM3G,T72HM3G
+Oysters,T72HMs 3G,T72HM3G,T72HMs_3G
+PC Smart,PCSGOB10MVA-A,PCSGOB10MVA-A,PCSGOB10MVA-A
+PC Smart,PCSGOB10SF-A,PCSGOB10SF-A,PCSGOB10SF-A
+PC Smart,PTSGOB8,PTSGOB8,PC_Smart_PTSGOB8
+PCD Argentina,PCD508,PCD508,PCD508
+PCD Argentina,PCD509,PCD509,PCD509
+POC,POC2,CBL7509MM,POC2
+Packard Bell,PB1009,PB1009,PB1009
+Packard Bell,T1000,T1000,T1000
+Panasonic,,H580VT_A,JT-H580VT
+Panasonic,,H581VT_A,JT-H581VT
+Panasonic,,P-08D,P-08D
+Panasonic,,laputa,P-07C
+Panasonic,003P,pana1,003P
+Panasonic,101P,pana2_2s,101P
+Panasonic,102P,pana2_4s,102P
+Panasonic,43DX400C,DX01C,DX01C
+Panasonic,48AX600C,mst918_4G,48AX600C
+Panasonic,55AX600C,mst918_4k2k,55AX600C
+Panasonic,55DX600C,DX600C,TH-55DX600C
+Panasonic,AS650C,AS650C,AS650C
+Panasonic,AX600C,AX600C,AX600C
+Panasonic,Altus 18,Altus18,Altus 18
+Panasonic,Altus 24,Altus24,Altus 24
+Panasonic,Boukenkun-reciever,VW_RCBKK1,VW_RCBKK1
+Panasonic,EB-4063-X,EB-4063-X,EB-4063-X
+Panasonic,ELUGA,pana2_4o,dL1
+Panasonic,ELUGA A,ELUGA_A,Panasonic ELUGA A
+Panasonic,ELUGA A3,ELUGA_A3,ELUGA_A3
+Panasonic,ELUGA A3 Pro,ELUGA_A3_Pro,ELUGA_A3_Pro
+Panasonic,ELUGA A4,ELUGA_A4,ELUGA A4
+Panasonic,ELUGA C,Panasonic_ELUGA_C,Panasonic_ELUGA_C
+Panasonic,ELUGA I,ELUGA_I,Panasonic ELUGA I
+Panasonic,ELUGA I2 Activ,ELUGA_I2_Activ,ELUGA_I2_Activ
+Panasonic,ELUGA I3 Mega,Eluga_I3_Mega,ELUGA I3 Mega
+Panasonic,ELUGA I4,ELUGA_I4,ELUGA I4
+Panasonic,ELUGA I5,ELUGA_I5,ELUGA_I5
+Panasonic,ELUGA I9,ELUGA_I9,Eluga I9
+Panasonic,ELUGA L 4G,ELUGA_L_4G,Panasonic ELUGA L 4G
+Panasonic,ELUGA P,P-03E,P-03E
+Panasonic,ELUGA PURE,ELUGA_Pure,Panasonic_ELUGA_Pure
+Panasonic,ELUGA Power,P-07D,P-07D
+Panasonic,ELUGA Prim,ELUGA_Prim,ELUGA Prim
+Panasonic,ELUGA Ray 500,ELUGA_Ray_500,ELUGA Ray 500
+Panasonic,ELUGA Ray 700,Eluga_Ray_700,Eluga_Ray_700
+Panasonic,ELUGA S,ELUGA_S,Panasonic ELUGA S
+Panasonic,ELUGA S Mini,ELUGA_S_Mini,Panasonic ELUGA S Mini
+Panasonic,ELUGA Turbo,ELUGA_Turbo,ELUGA Turbo
+Panasonic,ELUGA U,ELUGA_U,Panasonic ELUGA U
+Panasonic,ELUGA U2,ELUGA_U2,Panasonic ELUGA U2
+Panasonic,ELUGA V,P-06D,P-06D
+Panasonic,ELUGA WE,ELUGA_WE,Panasonic ELUGA WE
+Panasonic,ELUGA X,P-02E,P-02E
+Panasonic,ELUGA dL1,pana2_4v,Panasonic_dL1
+Panasonic,EX00C,EX00C,EX00C
+Panasonic,EX01C,EX01C,EX01C
+Panasonic,EX02C,EX02C,EX02C
+Panasonic,Eco10 v3,ecov310,Eco v3
+Panasonic,Eco10 v3 Plus,ecov3p10,Eco v3 plus
+Panasonic,Eco11 v2,Eco11v2,Eco11 v2
+Panasonic,Eco12 v3,ecov312,Eco v3
+Panasonic,Eco12 v3 Plus,ecov3p12,Eco v3 plus
+Panasonic,Eco9 v1,Eco,Eco9 v1
+Panasonic,Eco9 v2,Ecov2,Eco9 v2
+Panasonic,Elite 11,Elite11,Elite
+Panasonic,Elite 11,Elite11,Elite 11
+Panasonic,Elite 12,Elite12,Elite
+Panasonic,Elite 12 v3,Elitev3_12,Elitev3
+Panasonic,Elite 12 v3.1,elitev3a_cam,Elite v3a with camera
+Panasonic,Elite 16,Elite16,Elite
+Panasonic,Elite 18,Elite18,Elite
+Panasonic,Elite13 v3,Elitev3_13,Elitev3
+Panasonic,Elitev3a,elitev3a,Elite v3a
+Panasonic,Eluga A2,Eluga_A2,Eluga_A2
+Panasonic,Eluga Arc,ELUGA_Arc,Panasonic ELUGA Arc
+Panasonic,Eluga Arc 2,Eluga_Arc_2,Eluga_Arc_2
+Panasonic,Eluga I2,ELUGA_I2,ELUGA_I2
+Panasonic,Eluga I3,Eluga_I3,Panasonic_Eluga_I3
+Panasonic,Eluga Icon 2,ELUGA_Icon2,Panasonic ELUGA Icon 2
+Panasonic,Eluga Klik,Eluga_Klik,Eluga Klik
+Panasonic,Eluga Mark 2,Eluga_Mark_2,Eluga_Mark_2
+Panasonic,Eluga Pulse,ELUGA_Pulse,ELUGA_Pulse
+Panasonic,Eluga Pulse X,ELUGA_Pulse_X,ELUGA_Pulse_X
+Panasonic,Eluga Ray,ELUGA_Ray,ELUGA Ray
+Panasonic,Eluga Ray Max,ELUGA_Ray_Max,ELUGA Ray Max
+Panasonic,Eluga Ray X,ELUGA_Ray_X,ELUGA Ray X
+Panasonic,Eluga Tapp,Eluga_TAPP,Panasonic ELUGA Tapp
+Panasonic,Eluga Z,ELUGA_Z,Panasonic ELUGA Z
+Panasonic,Eluga_Note,ELUGA_Note,ELUGA Note
+Panasonic,FZ-A1,toughpad,FZ-A1B
+Panasonic,FZ-A1B,toughpad,FZ-A1B
+Panasonic,FZ-A2A,fz_a2a,FZ-A2A
+Panasonic,FZ-B2,fz_b2bb,FZ-B2B
+Panasonic,FZ-B2D,fz_b2d,FZ-B2D
+Panasonic,FZ-N1,FZ-N1,FZ-N1
+Panasonic,FZ-N1,FZ-N1CL,FZ-N1
+Panasonic,FZ-N1,FZ-N1F,FZ-N1
+Panasonic,FZ-N1,FZ-N1VU,FZ-N1
+Panasonic,FZ-N1,FZ-N1VUC,FZ-N1
+Panasonic,FZ-N1,FZ-N1VUCCL,FZ-N1
+Panasonic,FZ-N1,FZ-N1VUCF,FZ-N1
+Panasonic,FZ-N1,FZ-N1VUF,FZ-N1
+Panasonic,FZ-N1VUCL,FZ-N1VUCL,FZ-N1
+Panasonic,FZ-X1,FZ-N1VUC,FZ-N1
+Panasonic,FZ-X1,FZ-X1,FZ-X1
+Panasonic,FZ-X1,FZ-X1VU,FZ-X1
+Panasonic,FZ-X1,FZ-X1VUC,FZ-X1
+Panasonic,HDPSEB v2,HDPSEBv2,HD PSEB v2
+Panasonic,IPSC 4,ipsc4,IPSC4
+Panasonic,JT-B1,B1,JT-B1
+Panasonic,KX-PRXA10,KX-PRXA10,Panasonic KX-PRXA10
+Panasonic,KX-PRXA15,KX-PRXA15,Panasonic KX-PRXA15
+Panasonic,LUMIX CM1,DMC-CM1,DMC-CM1
+Panasonic,P-01D,pana2_1,P-01D
+Panasonic,P-02D,pana2_2,P-02D
+Panasonic,P-04D,pana2_4d,P-04D
+Panasonic,P-05D,pana2_4a,P-05D
+Panasonic,P-07C,pana1,P-07C
+Panasonic,P11,P11,Panasonic P11
+Panasonic,P31,P31,Panasonic P31
+Panasonic,P41,P41,Panasonic P41
+Panasonic,P41 HD,P41HD,Panasonic P41HD
+Panasonic,P51,P51,Panasonic P51
+Panasonic,P55,P55,Panasonic P55
+Panasonic,P55 Max,P55_Max,P55 Max
+Panasonic,P55 Novo,P55_Novo,Panasonic P55 Novo
+Panasonic,P55 Novo,P55_Novo_4G,P55 Novo 4G
+Panasonic,P61,P61,Panasonic P61
+Panasonic,P61,P61,Panasonic_P61
+Panasonic,P66,P66,P66
+Panasonic,P71,P71,P71
+Panasonic,P75,P75,Panasonic P75
+Panasonic,P77,P77,Panasonic P77
+Panasonic,P81,P81,Panasonic P81
+Panasonic,P85,P85,Panasonic P85
+Panasonic,P88,P88,P88
+Panasonic,P9,P9,P9
+Panasonic,P91,P91,P91
+Panasonic,P99,Panasonic_P99,Panasonic P99
+Panasonic,Panasonic P100,P100,P100
+Panasonic,Panasonic P100,P100,Panasonic P100
+Panasonic,Panasonic P90,Panasonic_P90,Panasonic P90
+Panasonic,Panasonic P90 3G,Panasonic_P90_3G,Panasonic P90 3G
+Panasonic,Panasonic P95,P95,Panasonic P95
+Panasonic,Panasonic T70,T70,Panasonic T70
+Panasonic,SDU,SDU,9 inch SDU
+Panasonic,SDU,SDU,SDU
+Panasonic,SM17,SM17,Smart Monitor 17
+Panasonic,SV-ME1000,K1,Panasonic SV-ME1000
+Panasonic,SmartTVBox,C01AS,SMARTTVBOX
+Panasonic,T11,T11,Panasonic T11
+Panasonic,T21,T21,Panasonic T21
+Panasonic,T30,T30,Panasonic T30
+Panasonic,T31,T31,Panasonic T31
+Panasonic,T33,T33,Panasonic T33
+Panasonic,T40,T40,Panasonic T40
+Panasonic,T41,T41,Panasonic T41
+Panasonic,T44,T44,Panasonic T44
+Panasonic,T44 Lite,T44-Lite,Panasonic T44 Lite
+Panasonic,T9,T9,Panasonic T9
+Panasonic,TAB-A01,TAB-A01,TAB-A01-SD
+Panasonic,TAB-A02,TAB-A02,TAB-A02-SD
+Panasonic,TH-49DX400C,DX00C,DX00C
+Panasonic,TH-55DR600C,TH55DR600C,TH55DR600C
+Panasonic,TH-55DX700C,TH_55DX700C,TH_55DX700C
+Panasonic,TH-65DR800C,TH-65DR800C,TH-65DR800C
+Panasonic,TH-65DX400C,TH_65DX400C,TH_65DX400C
+Panasonic,Theater v3,theaterv3,theaterv3
+Panasonic,Translation device,WA-P7,WA-P7
+Panasonic,UN-MT300,A1,Panasonic UN-MT300
+Panasonic,UN-W700,F1,Panasonic UN-W700
+Panasonic,VHS v2,VHS,Video Handset
+Panasonic,VTSH v1,VTSHv1,VTSH v1
+Panasonic,WSCU,wscu,WSCU3
+Panasonic,Yaris M,T31,Panasonic T31
+Pantech,ADR910L,ADR910L,ADR910L
+Pantech,ADR930L,ADR930L,ADR930L
+Pantech,AT1,at1,IM-T100K
+Pantech,Apache,ADR8995,ADR8995
+Pantech,Burst,presto,PantechP9070
+Pantech,Crossover,moon,PantechP8000
+Pantech,EF33S,ef33s,IM-A760S
+Pantech,EF34K,ef34k,IM-A770K
+Pantech,EF35L,ef35l,IM-A780L
+Pantech,Element,pororo,PantechP4100
+Pantech,Flex,oscar,PantechP8010
+Pantech,IM-100GN,ef71g,IM-100GN
+Pantech,IM-100K,ef71k,IM-100K
+Pantech,IM-100S,ef71s,IM-100S
+Pantech,IM-810K,ef40k,IM-A810K
+Pantech,IM-840SP,IM-A840SP,IM-A840SP
+Pantech,IM-A730S,ef30s,IM-A730S
+Pantech,IM-A740S,ef31s,IM-A740S
+Pantech,IM-A760S,ef33s,IM-A760S
+Pantech,IM-A770K,ef34k,IM-A770K
+Pantech,IM-A775C,ef34c,IM-A775C
+Pantech,IM-A780L,ef35l,IM-A780L
+Pantech,IM-A800S,ef39s,IM-A800S
+Pantech,IM-A810K,ef40k,IM-A810K
+Pantech,IM-A810S,ef40s,IM-A810S
+Pantech,IM-A830K,ef45k,IM-A830K
+Pantech,IM-A830KE,ef45kv,IM-A830KE
+Pantech,IM-A830L,ef46l,IM-A830L
+Pantech,IM-A830S,ef47s,IM-A830S
+Pantech,IM-A840S,IM-A840S,IM-A840S
+Pantech,IM-A850K,ef49k,IM-A850K
+Pantech,IM-A850L,ef50l,IM-A850L
+Pantech,IM-A850S,ef48s,IM-A850S
+Pantech,IM-A860K,ef51k,IM-A860K
+Pantech,IM-A860L,ef51l,IM-A860L
+Pantech,IM-A860S,ef51s,IM-A860S
+Pantech,IM-A870K,ef52k,IM-A870K
+Pantech,IM-A870L,ef52l,IM-A870L
+Pantech,IM-A870S,ef52s,IM-A870S
+Pantech,IM-A880S,EF56S,IM-A880S
+Pantech,IM-A910K,ef63k,IM-A910K
+Pantech,IM-A910L,ef63l,IM-A910L
+Pantech,IM-A910S,ef63s,IM-A910S
+Pantech,IM-A920S,ef65s,IM-A920S
+Pantech,IM-A940K,ef65dk,IM-A940K
+Pantech,Izar,sp33k,SKY IM-A630K
+Pantech,MIRACH_J,mirachj,EIS01PT
+Pantech,MIRACH_J,mirachj,IS11PT
+Pantech,Mirach,ef13l,IM-A690L
+Pantech,Mirach,ef13s,IM-A690S
+Pantech,Mirach A,ef32k,IM-A750K
+Pantech,P9090,magnus,PantechP9090
+Pantech,PLANET,mini,PLANET
+Pantech,PTL21,maruko,PTL21
+Pantech,Pocket,mini,PantechP9060
+Pantech,SIRIUS \xce\xb1,jmasai,IS06
+Pantech,Sirius,ef10s,SKY IM-A600S
+Pantech,V955,HS8929QC,Pantech V955
+Pantech,VEGA RACER,ef34k,IM-A770K
+Pantech,VEGA RACER,ef35l,IM-A780L
+Pantech,VEGA Secret Note,EF59K,IM-A890K
+Pantech,VEGA Secret Note,EF59L,IM-A890L
+Pantech,VEGA Secret Note,EF59S,IM-A890S
+Pantech,VEGA Secret UP,EF60S,IM-A900S
+Pantech,VEGA Secret UP,EF61K,IM-A900K
+Pantech,VEGA Secret UP,EF62L,IM-A900L
+Pantech,VEGA Secret UP,ef60s,IM-A900S
+Pantech,VEGA Secret UP,ef61k,IM-A900K
+Pantech,VEGA Secret UP,ef62l,IM-A900L
+Pantech,Vega,ef12s,SKY IM-A650S
+Pantech,Vega LTE M,ef65l,IM-A820L
+Pantech,Vega X,ef14l,IM-A720L
+Pantech,Vega X,ef18k,IM-A710K
+Pantech,ef14lv,ef14lv,IM-A725L
+Pantech,v950,HS8929QC,Pantech V950
+Pantech,v955,HS8929QC,Pantech V955
+Partner,Batman,Batman,S70PCI
+Partner,OT-310,OT-310,OT-310
+Pavapro,PavaPro7bk,Pavapro7bk,Pavapro7bk
+Pavapro,Pavapro10,Pavapro10bk,Pavapro10bk
+Pegatron,,Duke3G,Android Tablet PC
+Pegatron,,DukeWifi,Android Tablet PC
+Pegatron,,TabletPC,Android Tablet PC
+Pegatron,MaxiIQ,MaxiIQ,MaxiIQ
+Pegatron,Olipad,OP111,chagall
+Pegatron,chagall,chagall,Chagall 10.1 WiFi
+Pegatron,chagall,chagall,E-Tab 4G
+Pegatron,chagall,chagall,chagall
+Pendo,Pendo,PNDP70M7BLK,PNDP70M7BLK
+Philco,PTB7PAP_ PTB7PAB _ PTB7PAR,PTB7PA,PTB7PAP_PTB7PAB_PTB7PAR
+Philips,,Philips_GGC3,SA3CNT
+Philips,,Philips_PI5000,Philips_PI5000
+Philips,,SA2CNTxx,Philips GoGear Connect
+Philips,4K & Full HD Slim LED TV powered by Android\xe2\x84\xa2,philips_MT5593FHT_EU,QM152E
+Philips,4K & Full HD Slim LED TV powered by Android\xe2\x84\xa2,philips_MT5593HT_LT,QM152E
+Philips,4K LED TV powered by Android,PH7M_EU_5596,TPM171E
+Philips,4K Razor Slim LED TV powered by Android TV\xe2\x84\xa2,MT5593Uplus,QM151E
+Philips,4K Razor Slim OLED TV powered by Android TV,QM16XE_UB,QM161E
+Philips,4K UHD Razor Slim LED TV powered by Android\xe2\x84\xa2,QV151E,QV151E
+Philips,4K Ultra Slim LED TV powered by Android,QM16XE_U,QM163E
+Philips,Android 2014,philipstv,AND1E
+Philips,E1027,E1027,E1027
+Philips,FHD Ultra Slim LED TV Powered by Android,QM16XE_F,QM164E
+Philips,HMP8100/93,HMP8100_ATV_93,HMP8100_ATV_93
+Philips,HMP8100/98,HMP8100_ATV,HMP8100_ATV_INT
+Philips,PHILIPS,TLE722G,TLE722G
+Philips,PHP-S221C4AFD,MMD_WW,G3SMNTS22
+Philips,PHP-S231C4AFD,G3SMNTS23,G3SMNTS23
+Philips,PI2000,PI2000,PI2000
+Philips,PI2010,PI2010,PI2010
+Philips,PI2011,PI2011,PI2011
+Philips,PI3100/51,PI3100_51,PI3100
+Philips,PI3100/58,PI3100_58,PI3100
+Philips,PI3100/93,PI3100_93,PI3100-93
+Philips,PI3100/98,PI3100_98,PI3100
+Philips,PI3100Z3/93,PI3100Z3_93,PI3100Z3_93
+Philips,PI3105,PI3105,PI3105
+Philips,PI3106,PI3106,PI3106
+Philips,PI3110,PI3110,PI3110
+Philips,PI3205G,PI3205G_93,PI3205G
+Philips,PI3210G,PI3210G,PI3210G
+Philips,PI3900,T7p_Duo_93,PI3900-93
+Philips,PI3900/51,PI3900_51,PI3900
+Philips,PI3900/58,PI3900_58,PI3900
+Philips,PI3900/98,PI3900_98,PI3900
+Philips,PI3910,PI3910,PI3910
+Philips,PI4010G,PI4010G,PI4010G
+Philips,PI7100/93,PI7100_93,PI7100_93
+Philips,Philips S310X,Philips_S310X,Philips S310X
+Philips,Philips S318,S318,Philips S318
+Philips,Philips S329,Philips_S329,Philips S329
+Philips,Philips V787,Philips_Xenium_V787,Philips Xenium V787
+Philips,Philips X596,X596,Philips X596
+Philips,Philips X598,Philips_X598,Philips X598
+Philips,Philips X818,X818_RU,Philips X818
+Philips,Philps S398,Philips_S398,Philips S398
+Philips,S221C3A,MMD_WW,G2SMNT
+Philips,S308,Philips_S308,Philips S308
+Philips,S309,Philips,Philips S309
+Philips,S326,S326,Philips_S326
+Philips,S327,S327,Philips S327
+Philips,S337,S337_AG,Philips S337
+Philips,S337,S337_BG,Philips S337
+Philips,S337,scx35_sp7731gea_hd,Philips S337
+Philips,T8 PI7000,Tablet_8,PI7000
+Philips,TLE722G,TLE722G,TLE722G
+Philips,TLE732,TLE732,TLE732
+Philips,V377,Philips_V377,Philips V377
+Philips,V387,V387,Philips V387
+Philips,V526,Philips_V526,Philips V526
+Philips,V787,Philips_Xenium_V787,Philips Xenium V787
+Philips,W337,W337,W337
+Philips,W3500,Philips_W3500,Philips_W3500
+Philips,W3568,Philips_W3568,Philips W3568
+Philips,W3620,W3620,W3620
+Philips,W6500,Philips_W6500_A,W6500
+Philips,W6610,Marathon,Philips W6610
+Philips,W6620,W6620,W6620
+Philips,W8510,Topaz,Philips W8510
+Philips,W8555,Pride,Philips W8555
+Philips,X586,Philips_X586,Philips_X586
+Philips,X586,Philips_X586_NEW,Philips_X586
+Philips,X588,X588_RU,Philips X588
+Philips,X818,X818,Philips X818
+Philips,X818,X818_EE,Philips X818
+Philips,X818,X818_RU,Philips X818
+Philips,Xenium S386,S386,Philips S386
+Philips,Xenium V377,Philips_V377,Philips V377
+Pioneer,B.PRO\xe3\x82\xab\xe3\x83\xbc\xe3\x83\x8a\xe3\x83\x93,AVIC_BX500,jupiter
+Pioneer,B.PRO\xe3\x82\xab\xe3\x83\xbc\xe3\x83\x8a\xe3\x83\x93,AVIC_BZ500,jupiter
+Pioneer,CyberNavi,AVIC_CE900,jupiter
+Pioneer,CyberNavi,AVIC_CE901,jupiter
+Pioneer,CyberNavi,AVIC_CL900,jupiter
+Pioneer,CyberNavi,AVIC_CL901,jupiter
+Pioneer,CyberNavi,AVIC_CZ700,jupiter
+Pioneer,CyberNavi,AVIC_CZ900,jupiter
+Pioneer,CyberNavi,AVIC_CZ901,jupiter
+Pioneer,Navigation,NVF_0068ZY,jupiter
+Pioneer,Navigation,NVF_0078ZY,jupiter
+Pioneer,Navigation,NVF_0168ZY,jupiter
+Pioneer,Navigation,NVF_0178ZY,jupiter
+Pioneer,R1,RCK8726Y703H,R1
+Pioneer,XDP-100R,Fu_Zin_32,XDP-100R
+Pioneer,XDP-300R,Fu_Zin2R_32,XDP-300R
+Pixela,KSTB5043,KSTB5043,KSTB5043
+Plaisio,A2,Turbo-X_A2,Turbo-X_A2
+Plaisio,Calltab 7\xe2\x80\x9d,Calltab7inch,Calltab7inch
+Plaisio,"Calltab2GB10.1""",Calltab2GB10,Calltab2GB10
+Plaisio,CalltabII 10.1,E1031H2C,Calltab10.1
+Plaisio,Coral II,CoralII,Turbo-X Coral II
+Plaisio,G320,G320,G320
+Plaisio,Hive V 3G,mg978,Hive V 3G
+Plaisio,Hive V 3G,mr978,Hive V 3G
+Plaisio,I4G,I4G,TURBOX_I4G
+Plaisio,Lithium Ion,Turbo-X_e3,Turbo-X_e3
+Plaisio,"Rainbow II 3G 8""",mr801,RainbowII 3G
+Plaisio,RainbowIII3G,RainbowIII3G,RainbowIII3G
+Plaisio,Rubik-II,RubikII7,RubikII7
+Plaisio,"Rubik10.1""II",H1021H4C1_I,Rubik 10.1 II
+Plaisio,"RubikII 10""",q102,Rubik 10.1 II
+Plaisio,Rubik_10_III,Rubik_10_III,Rubik_10_III
+Plaisio,Turbo-X Twister,Twister_IV_IPS,QUAD-CORE A33 inet
+Plaisio,Turbo-X s2,s2,s2
+Plaisio,Turbo-X_epsilon,Turbo-X_epsilon,Turbo-X_epsilon
+Plaisio,Turbo-X_pi_4G,Turbo-X_pi_4G,Turbo-X_pi_4G
+Plaisio,Turbo-X_z,Turbo-X_z,Turbo-X_z
+Plaisio,Turbox_A3,Turbox_A3,Turbox_A3
+Plaisio,Turbox_S3,Turbox_S3,Turbox_S3
+Plaisio,lamda,Turbo-X_lamda,Turbo-X lamda
+Plus4,Q-Touch,Q-Touch,Q-Touch
+Plusone,FREETEL Priori3S,FTU152A,FTU152A
+Plusone,FREETEL SAMURAI KIWAMI 2,SAMURAI_KIWAMI2,FTJ162B
+Plusone,FREETEL Samurai Rei,FTJ161B,FTJ161B
+Plusone,FTJ152C,FTJ152C,FTJ152C
+Plusone,FTJ161A,FTJ161A,FTJ161A
+Plusone,FTU152D,FTU152D,FTU152D
+Plusone,Fun +,FTU161G,FTU161G
+Plusone,Fun +,FTU161G,Fun +
+Plusone,Ice 2,FTJ161E-VN,FTJ161E-VN
+Plusone,Ice 2,ICE2,FTE161E
+Plusone,Ice 2,ICE2,ICE2
+Plusone,Kiwami,FTJ152D,FTJ152D
+Plusone,Priori 3,FTJ152A,FTJ152A
+Plusone,Priori3S,FTJ152B,FTJ152B
+Plusone,Smart HD,Smart_HD,Smart_HD
+PointMobile,PM66,pm66,PM66
+PointMobile,PM70,pm70,PM70
+PointMobile,PM80,pm80,PM80
+Polar,M600,pike,Polar M600
+Polaris,Condroid_X7,polaris-Condroid_X7,Condroid_X7
+Polaroid,A/S10,wing-AS10,A/S10
+Polaroid,A/S7,wing-AS7,A/S7
+Polaroid,A/S8,wing-AS8,A/S8
+Polaroid,A6,A6,A6
+Polaroid,A7X_PTAB735X,PTAB735X,A7X_PTAB735X
+Polaroid,A7_PTAB735,A7_PTAB735,HS-7DTB39
+Polaroid,A9x/PTAB935x,A9xPTAB935x,A9x/PTAB935x
+Polaroid,Cosmo L,P5026A,P5026A
+Polaroid,Cosmo P5s,P5046A,P5046A
+Polaroid,Cosmo Z,P5047A,P5047A
+Polaroid,Cosmo Z2,PSPCZ20A0,PSPCZ20A0
+Polaroid,Infinite,MID1324,MID 1324
+Polaroid,K7,PTAB782,K7/PTAB782
+Polaroid,L9,L9,L9
+Polaroid,MID1028,MID1028,MID1028
+Polaroid,MID4X07,RCT6773W22,MID4X07
+Polaroid,MID4X10,RCT6203W46,MID4X10
+Polaroid,P10/Q10/PTAB1040/PTAB1041,pq10-Polaroid,P10/Q10/PTAB1040/PTAB1041
+Polaroid,P1000,P1000,P1000
+Polaroid,P1001,P1001,P1001
+Polaroid,P4526A,P4526A,P4526A
+Polaroid,P5006A,P5006A,P5006A
+Polaroid,P5526A,P5526A,P5526A
+Polaroid,P7/Q7/PTAB740/PTAB741,pq7-Polaroid,P7/Q7/PTAB740/PTAB741
+Polaroid,P791,P791,P791
+Polaroid,P9/Q9/PTAB940/PTAB941,pq9-Polaroid,P9/Q9/PTAB940/PTAB941
+Polaroid,P900,P900,P900/Q900
+Polaroid,P901,P901,P901
+Polaroid,PMID7102DC,PMID7102DC,PMID7102DC
+Polaroid,PRO5023PW,up06_h25_polaroid,PRO5023PW
+Polaroid,PRO5043,PRO5043,PRO5043
+Polaroid,PRO5044PEE01,Polaroid_PRO5044PEE01,PRO5044PEE01
+Polaroid,PRO5544PEE01,PRO5544PEE01,PRO5544PEE01
+Polaroid,PRO5584PHE01,PRO5584PHE01,PRO5584PHE01
+Polaroid,PSPCK20NA,PSPCK20NA,PSPCK20NA
+Polaroid,PTAB1051-PTAB1055,RCT6203W46,PTAB1051_PTAB1055
+Polaroid,PTAB751,STJR76,PTAB751
+Polaroid,Phantom 5,Phantom5,PRO5023
+Polaroid,SIGMA 5,SIGMA-5,SIGMA-5
+Polaroid,SOHO,SOHO,SOHO
+Polaroid,V45M,V45M,CARBON_PRO4543
+Polaroid,V7,nuclear-M7021,V7
+Polytron,P500,P500,P500
+Polytron,POLYTRON P552,POLYTRON_P552,POLYTRON_P552
+Polytron,POLYTRON R2509,POLYTRON_R2509,POLYTRON R2509
+Polytron,POLYTRON R2509SE,POLYTRON_R2509SE,POLYTRON R2509SE
+Porsche,Rear  Seat  Entertainment,sdis1,Porsche Rear Seat Entertainment
+Positivo,8MA-A,ochoMA_A_3G,8MA-A 3G
+Positivo,AB10PGN,AB10PGN,AB10PGN
+Positivo,AB7,YPY_AB7D,YPY_AB7D
+Positivo,AB7D,YPY_AB7DC,YPY_AB7DC
+Positivo,BGH 7Di-A,Y210,Positivo BGH 7Di-A
+Positivo,BGH Y200,T710,Positivo BGH Y200
+Positivo,BGH Y230,T760,Y230
+Positivo,First,S410,First
+Positivo,Life,S421,S421 Positivo Life
+Positivo,Mini,mini,Positivo Mini
+Positivo,Mini,mini,Positivo Mini TE
+Positivo,Next,X500,Positivo Next
+Positivo,OCTA,OCTA,OCTA
+Positivo,One,S420,Positivo One
+Positivo,One,S420,S420
+Positivo,Positivo BGH +Simple,C805,Positivo BGH +Simple
+Positivo,S380,S380,S380
+Positivo,S430 Positivo Twist Mini,S430,S430 Positivo Twist Mini
+Positivo,S440,S440,S440
+Positivo,S450,S450,S450
+Positivo,S480,S480,S480
+Positivo,S550,S550,S550
+Positivo,SX1000,SX1000,Positivo SX1000
+Positivo,Selfie,S455,S455
+Positivo,Slim,S510,Positivo Slim
+Positivo,Stilo T725,T725,Stilo T725
+Positivo,T1060,t1060,T1060
+Positivo,T1060,t1060,T1060B
+Positivo,T1060,t1060,T1060C
+Positivo,T1075,T1075,Positivo T1075
+Positivo,T701 TV,T701,T701
+Positivo,T705,T705,T705
+Positivo,T705,T705,T705/T708
+Positivo,T705,T705,T705K
+Positivo,T710,T710,Positivo T710
+Positivo,T715,T715,Stilo T715
+Positivo,T730,T730,Positivo Stilo T730 Kids
+Positivo,T750,t750,Positivo T750
+Positivo,Twist,S520,Positivo Twist M
+Positivo,Twist,S520,Positivo Twist S
+Positivo,Twist 2018,S511,Twist (2018)
+Positivo,Twist 4G,S520_4G,Positivo Twist 4G
+Positivo,Twist Max,S540,Twist Max
+Positivo,Twist Metal,S530,Twist Metal
+Positivo,Twist Mini,S430B,Twist Mini
+Positivo,Twist XL,S555,Twist XL
+Positivo,Union US2070,US2070,Positivo US2070
+Positivo,X400,X400,X400
+Positivo,YPY 10 3G,YPY_10FTA,YPY_10FTA
+Positivo,YPY AB7,YPY_AB7,Positivo Ypy AB7E
+Positivo,YPY AB7,YPY_AB7,Positivo Ypy AB7EC
+Positivo,YPY S400,YPY_S400,YPY_S400
+Positivo,YPY7 3G,TB07FTA,Positivo Ypy 7 - TB07FTA
+Positivo,YPY7 3G,TB07FTA,Ypy 7 - TB07FTA
+Positivo,YPY7 3G,YPY_07FTA,YPY_07FTA
+Positivo,YPY7 wifi,TB07STA,Positivo Ypy 7 - TB07STA
+Positivo,YPY7 wifi,TB07STA,Ypy 7 - TB07STA
+Positivo,YPY7 wifi,YPY_07STA,YPY_07STA
+Positivo,Ypy 07FTB,YPY_07FTB,POSITIVO TABLET YPY 07FTB PM BEL\xc3\x89M
+Positivo,Ypy 07FTB,YPY_07FTB,YPY_07FTB
+Positivo,Ypy 07FTBF,YPY_07FTBF,YPY_07FTBF
+Positivo,Ypy 07STB,YPY_07STB,YPY_07STB
+Positivo,Ypy 07STBF,YPY_07STBF,YPY_07STBF
+Positivo,Ypy 10FTB,YPY_10FTB,YPY_10FTB
+Positivo,Ypy 10FTBF,YPY_10FTBF,YPY_10FTBF
+Positivo,Ypy 10STB,YPY_10STB,YPY_10STB
+Positivo,Ypy 10STBF,YPY_10STBF,YPY_10STBF
+Positivo,Ypy AB10,YPY_AB10D,YPY_AB10D
+Positivo,Ypy AB10D,YPY_AB10DC,YPY_AB10DC
+Positivo,Ypy AB10DP,YPY_AB10DP,YPY_AB10DP
+Positivo,Ypy AB10E,YPY_AB10E,Positivo Ypy AB10E
+Positivo,Ypy AB10E,YPY_AB10EC,Positivo Ypy AB10EC
+Positivo,Ypy AB10H,YPY_AB10H,Positivo Ypy AB10H
+Positivo,Ypy AB10i,Ypy_AB10i,Ypy AB10i
+Positivo,Ypy AB7F,YPY_AB7F,Positivo Ypy AB7F
+Positivo,Ypy AB7F,YPY_AB7F,T720
+Positivo,Ypy AB7K,YPY_AB7K,YPY_AB7K
+Positivo,Ypy Kids,YPY_L700,Positivo Ypy L700 Kids
+Positivo,Ypy Kids,YPY_L700,Positivo Ypy L700+ Kids
+Positivo,Ypy L1000,YPY_L1000,Positivo Ypy L1000
+Positivo,Ypy L1000,YPY_L1000,Positivo Ypy L1000F
+Positivo,Ypy L1050,YPY_L1050,Positivo Ypy L1050
+Positivo,Ypy L1050,YPY_L1050,Positivo Ypy L1050F
+Positivo,Ypy L1050E,YPY_L1050E,Positivo Ypy L1050E
+Positivo,Ypy L700,YPY_L700,Positivo Ypy L700
+Positivo,Ypy L700,YPY_L700,Positivo Ypy L700 Ed. Especial
+Positivo,Ypy L700,YPY_L700,Positivo Ypy L700+
+Positivo,Ypy Mini,mini,Positivo BGH Mini
+Positivo,Ypy S350,YPY_S350,YPY_S350
+Positivo,Ypy S350p,YPY_S350,YPY_S350_PLUS
+Positivo,Ypy S405,YPY_S405,YPY_S405
+Positivo,Ypy S450,YPY_S450,YPY_S450
+Positivo,Ypy S460,YPY_S460,YPY_S460
+Positivo,Ypy S500,YPY_S500,YPY_S500
+Positivo,Ypy TQ7,YPY_TQ7,YPY_TQ7
+Positivo,mini I,mini_i,Positivo BGH Y300
+Positivo,mini I,mini_i,Positivo Mini I
+Positivo,quattro,X435,quattro
+Positivo BGH,BGH Y100,Y700,Positivo BGH Y100
+Positivo BGH,BGH Y210,Y210,Positivo BGH 7Di-A
+Positivo BGH,BGH Y210,Y210,Positivo BGH Y210
+Positivo BGH,BGH Y400,Y400,Y400
+Positivo BGH,BGH Y700,Y700,Positivo BGH Y700
+Positivo BGH,BGH Y710 kids,Y700,Positivo BGH Y710 KIDS
+Positivo BGH,Y1000,Y1000,Y1000
+Positivo BGH,Y1010,Y1010,Positivo BGH Y1010
+Positivo BGH,Ypy,T701_AR,L701 TV
+Positivo BGH,Ypy,YPY_L700,Positivo BGH Ypy L700
+Positivo BGH,Ypy Kids,YPY_L700,Positivo BGH Ypy L700 Kids
+Premio,P520,P520,P520
+Premio,P530,P530,P530
+Premio,P540,P540,P540
+Premio,PREMIO P450,P450,P450
+Premio,Premio P610,Premio_P610,P610
+Premio,Premio P620,Premio_P620,P620
+Prestige,7G,Prestige-7G,Prestige 7G
+Prestige,ELITE10Q,Elite10Q,Elite10Q
+Prestige,ELITE7Q,Elite7Q,Elite7Q
+Prestige,ELITE8Q,ELITE8Q,ELITE8Q
+Prestige,ELITE8QS,Elite8QS,Elite8QS
+Prestige,ELITE9Q,ELITE9Q,ELITE9Q
+Prestige,PRO10D,PRO10D,PRO10D
+Prestige,PRO7DS,PRO7DS,PRO7DS
+Prestige,PRO8D,PRO8D,PRO8D
+Prestige,PRO9D,PRO9D,PRO9D
+Prestigio,GV7790,GV7790,GV7790
+Prestigio,Grace,PSP7557,PSP7557
+Prestigio,Grace 3118 3G,JU80A2G,PMT3118_3G
+Prestigio,Grace X3,PSP3455DUO,PSP3455DUO
+Prestigio,Grace X5,PSP5470DUO,PSP5470DUO
+Prestigio,Grace X7,PSP7505DUO,PSP7505DUO
+Prestigio,MT3237_3G,JP70A1W,PMT3237_3G
+Prestigio,MULTIPAD WIZE 3027,HF80A01W,PMT3027_Wi
+Prestigio,MULTIPAD WIZE 3108 3G,PN80A03G,PMT3108_3G
+Prestigio,MULTIPAD WIZE 3111,NS70A03W,PMT3111_Wi
+Prestigio,MULTIPAD WIZE 3121,NS70A03W,PMT3121_Wi
+Prestigio,MULTIPAD WIZE 3308 3G,PN80A03G,PMT3308_3G
+Prestigio,MULTIPAD WIZE 3331 3G,PN10A01G,PMT3331_3G
+Prestigio,MULTIPAD WIZE 3341 3G,PN10A01G,PMT3341_3G
+Prestigio,MULTIPAD WIZE 3787 3G,PMT3777_3G,PMT3787_3G
+Prestigio,MultiPad Thunder 7.0i,g01p,PMT3377_Wi
+Prestigio,MultiPad Wize 3009,PMT3009_Wi_C,PMT3009_Wi_C
+Prestigio,MultiPad Wize 3017,PMT3017_WI,PMT3017_WI
+Prestigio,MultiPad Wize 3018,PMT3018_WI,PMT3018_WI
+Prestigio,MultiPad Wize 3037 3G,PMT3038_3G,PMT3037_3G
+Prestigio,MultiPad Wize 3038 3G,PMT3038_3G,PMT3038_3G
+Prestigio,MultiPhone 5453 DUO,PSP5453DUO,PSP5453DUO
+Prestigio,MultiPhone 5455 DUO,PSP5455DUO,PSP5455DUO
+Prestigio,MultiPhone 5504 DUO,PSP5504DUO,PSP5504DUO
+Prestigio,MultiPhone 5505 DUO,PSP5505DUO,PSP5505DUO
+Prestigio,MultiPhone 5517 DUO,PSP5517DUO,PSP5517DUO
+Prestigio,Multipad Wize 3407 4G,WT70A1L,PMT3407_4G
+Prestigio,Multipad Wize 3408 4G,LS80A1L,PMT3408_4G
+Prestigio,Multipad Wize 3508 4G,LS80A1L,PMT3508_4G
+Prestigio,Multipad Wize 3757 3G,PMT3777_3G,PMT3757_3G
+Prestigio,Multiphone 5508 DUO,PSP5508DUO,PSP5508DUO
+Prestigio,Muze A3,PSP3452DUO,PSP3452DUO
+Prestigio,PGPS7795,PMT3057_3G,PGPS7795
+Prestigio,PMT3008_Wi,PMT3008_Wi_C,PMT3008_Wi_C
+Prestigio,PMT3011_3G,PMT3011_3G,PMT3011_3G
+Prestigio,PMT3021_3G,PMT3011_3G,PMT3021_3G
+Prestigio,PMT3031_3G,PMT3011_3G,PMT3031_3G
+Prestigio,PMT3047_3G,PMT3047_3G,PMT3047_3G
+Prestigio,PMT3057_3G,PMT3057_3G,PMT3057_3G
+Prestigio,PMT3067_3G,PMT3057_3G,PMT3067_3G
+Prestigio,PMT3077_Wi,HF80A01W,PMT3077_Wi
+Prestigio,PMT3087_3G,PMT3057_3G,PMT3087_3G
+Prestigio,PMT3101_4G,CF10A1L,PMT3101_4G
+Prestigio,PMT3137_3G,JP70A1W,PMT3137_3G
+Prestigio,PMT3157_3G,LS70A5G,PMT3157_3G
+Prestigio,PMT3157_4G,LS70A6L,PMT3157_4G
+Prestigio,PMT3177_3G,PMT3177_3G,PMT3177_3G
+Prestigio,PMT3201_4G,CF10A1L,PMT3201_4G
+Prestigio,PMT3208_3G,PN80A03G,PMT3208_3G
+Prestigio,PMT3257_4G,LS70A6L,PMT3257_4G
+Prestigio,PMT3277_3G,PMT3277_3G,PMT3277_3G
+Prestigio,PMT3287_3G,PMT3287_3G,PMT3287_3G
+Prestigio,PMT3301_4G,CF10A1L,PMT3301_4G
+Prestigio,PMT3351_3G,PN10A01G,PMT3351_3G
+Prestigio,PMT3418_4G,LS80A4L,PMT3418_4G
+Prestigio,PMT3437_3G,JP70A1W,PMT3437_3G
+Prestigio,PMT3507_4G,WT70A1L,PMT3507_4G
+Prestigio,PMT3607_4G,WT70A1L,PMT3607_4G
+Prestigio,PMT3608_4G,LS80A1L,PMT3608_4G
+Prestigio,PMT3677_Wi,PMT3677,PMT3677_Wi
+Prestigio,PMT3718_3G,CF80A2G,PMT3718_3G
+Prestigio,PMT3767_3G,PMT3777_3G,PMT3767_3G
+Prestigio,PMT3777_3G,PMT3777_3G,PMT3777_3G
+Prestigio,PMT3797_3G,JU70A1G,PMT3797_3G
+Prestigio,PMT5001_3G,PMT5001_3G,PMT5001_3G
+Prestigio,PMT5002_Wi,PMT5002_Wi,PMT5002_Wi
+Prestigio,PMT5008_3G,PMT5008_3G,PMT5008_3G
+Prestigio,PMT5011_3G,PMT5001_3G,PMT5011_3G
+Prestigio,PMT5018_3G,PMT5008_3G,PMT5018_3G
+Prestigio,PMT5021_3G,PMT5001_3G,PMT5021_3G
+Prestigio,PMT5287_4G,PMT5287_4G,PMT5287_4G
+Prestigio,PMT5487_3G,PMT5487_3G,PMT5487_3G
+Prestigio,PMT5587_Wi,AML8726-MXS,PMT5587_Wi
+Prestigio,PMT5777_3G,PMT5777_3G,PMT5777_3G
+Prestigio,PMT5877C,PMT5877C,PMT5877C
+Prestigio,PMT5887_3G,PMT5887_3G,PMT5887_3G
+Prestigio,PMT7008_4G,PMT7008_4G,PMT7008_4G
+Prestigio,PMT7077_3G,PMT7077_3G,PMT7077_3G
+Prestigio,PMT7177_3G,PMT7177_3G,PMT7177_3G
+Prestigio,PMT7287C3G,PMT7287C3G,PMT7287C3G
+Prestigio,PMT7287_3G,PMT7287_3G,PMT7287_3G
+Prestigio,PMT7787_3G,PMT7787_3G,PMT7787_3G
+Prestigio,PSP3403DUO,GF40B1G,PSP3403DUO
+Prestigio,PSP3404DUO,PSP3404DUO,PSP3404DUO
+Prestigio,PSP3405DUO,PSP3405DUO,PSP3405DUO
+Prestigio,PSP3413DUO,GF40B1G,PSP3413DUO
+Prestigio,PSP3423DUO,GF40B1G,PSP3423DUO
+Prestigio,PSP3450DUO,PSP3450DUO,PSP3450DUO
+Prestigio,PSP3456DUO,PSP3456DUO,PSP3456DUO
+Prestigio,PSP3457DUO,KT45B01G,PSP3457DUO
+Prestigio,PSP3458DUO,TE45B3G,PSP3458DUO
+Prestigio,PSP3459DUO,TE45B3G,PSP3459DUO
+Prestigio,PSP3468DUO,TE45B7G,PSP3468DUO
+Prestigio,PSP3502DUO,PSP3502DUO,PSP3502DUO
+Prestigio,PSP3503DUO,PSP3503DUO,PSP3503DUO
+Prestigio,PSP3504DUO,PSP3504DUO,PSP3504DUO
+Prestigio,PSP3505DUO,PSP3503DUO,PSP3505DUO
+Prestigio,PSP3506DUO,TE50B2G,PSP3506DUO
+Prestigio,PSP3507DUO,TE50B2G,PSP3507DUO
+Prestigio,PSP3508DUO,TE50B4G,PSP3508DUO
+Prestigio,PSP3510DUO,DTE50B8L,PSP3510DUO
+Prestigio,PSP3511DUO,DTE50B8L,PSP3511DUO
+Prestigio,PSP3512,DTE50B8L,PSP3512DUO
+Prestigio,PSP3516DUO,TE50B2G,PSP3516DUO
+Prestigio,PSP3517DUO,TE50B2G,PSP3517DUO
+Prestigio,PSP3518DUO,TE50B4G,PSP3518DUO
+Prestigio,PSP3527DUO,TE50B6G,PSP3527DUO
+Prestigio,PSP3528DUO,IM50B1G,PSP3528DUO
+Prestigio,PSP3530DUO,DW53B01G,PSP3530DUO
+Prestigio,PSP3531DUO,DW53B01G,PSP3531DUO
+Prestigio,PSP3533DUO,DW53B6G,PSP3533DUO
+Prestigio,PSP3537DUO,GF50B2G,PSP3537DUO
+Prestigio,PSP3551,DTE50B8L,PSP3551DUO
+Prestigio,PSP3552DUO,TE55B9G,PSP3552DUO
+Prestigio,PSP5047DUO,MT6589,PSP5047DUO
+Prestigio,PSP5307DUO,PSP5307DUO,PSP5307DUO
+Prestigio,PSP5454DUO,PSP5454DUO,PSP5454DUO
+Prestigio,PSP5457DUO,MT6572,PSP5457DUO
+Prestigio,PSP5502DUO,TE50B3G,PSP5502DUO
+Prestigio,PSP5506DUO,DW50A03G,PSP5506DUO
+Prestigio,PSP5507DUO,PSP5507DUO,PSP5507DUO
+Prestigio,PSP5509DUO,TE50B4L,PSP5509DUO
+Prestigio,PSP5510DUO,EB50B2G,PSP5510DUO
+Prestigio,PSP5512DUO,TE50B3G,PSP5512DUO
+Prestigio,PSP5514DUO,EB50B2G,PSP5514DUO
+Prestigio,PSP5516DUO,DW50A03G,PSP5516DUO
+Prestigio,PSP5519DUO,TE50B4L,PSP5519DUO
+Prestigio,PSP5520DUO,TE52B10G,PSP5520DUO
+Prestigio,PSP5521DUO,TE52B10G,PSP5521DUO
+Prestigio,PSP5530DUO,DW53B4G,PSP5530DUO
+Prestigio,PSP5531,DW53B4G,PSP5531DUO
+Prestigio,PSP5550DUO,PSP5550DUO,PSP5550DUO
+Prestigio,PSP5551DUO,DW55B02L,PSP5551DUO
+Prestigio,PSP5552DUO,UE55B1L,PSP5552DUO
+Prestigio,PSP7501DUO,DW50B5G,PSP7501DUO
+Prestigio,PSP7510DUO,EB50B1L,PSP7510DUO
+Prestigio,PSP7511DUO,DW50B5G,PSP7511DUO
+Prestigio,PSP7512DUO,EB50B1L,PSP7512DUO
+Prestigio,PSP7530DUO,DW53B3G,PSP7530DUO
+Prestigio,PSP7550DUO,DW55B8L,PSP7550DUO
+Prestigio,PSP7551DUO,DW55B8L,PSP7551DUO
+Prestigio,PSP7552DUO,DW55B8L,PSP7552DUO
+Prestigio,Prestigio Muze 3708 3G,CF80A2G,PMT3708_3G
+Prestigio,WIZE A3,PSP3453DUO,PSP3453DUO
+Prestigio,Wize 3131 3G,LS10A3G,PMT3131_3G
+Prestigio,Wize 3147 3G,LS70A2G,PMT3147_3G
+Prestigio,Wize 3401 3G,JU10A3G,PMT3401_3G
+Primux,Primux_ioxphone,Primux_ioxphone,Primux_ioxphone
+Proscan,PLT1065G,PLT1065G,PLT1065G
+Proscan,PLT1077G(1GB/8GB),PLT1077G,PLT1077G
+Proscan,PLT1077G_16G,PLT1077G_16G,PLT1077G_16G
+Proscan,PLT7100G,PLT7100G,PLT7100G
+Proscan,PLT7109G,PLT7109G,PLT7109G
+Proscan,PLT7130G,PLT7130G,PLT7130G
+Proscan,PLT7602G,PLT7602G,PLT7602G
+Proscan,PLT7649G,PLT7649G,PLT7649G
+Proscan,PLT7650G,PLT7650G,PLT7650G
+Proscan,PLT7770G,PLT7770G,PLT7770G
+Proscan,PLT7774G,PLT1074G,PLT1074G
+Proscan,PLT7774G,PLT7774G,PLT7774G
+Proscan,PLT7803G,PLT7803G,PLT7803G
+Proscan,PLT7804G,PLT7804G,PLT7804G
+Proscan,PLT8235G Tablet,MID807_K,PLT8235G
+Proscan,PLT8802G,PLT8802G,PLT8802G
+Proscan,PLT9602G,PLT9602G,PLT9602G
+Proscan,PLT9606G,PLT9606G,PLT9606G
+Proscan,PLT9609G,PLT9609G,PLT9609G
+Proscan,PLT9649G,PLT9649G,PLT9649G
+Proscan,PLT9650G,PLT9650G,PLT9650G
+Proscan,PLT9999G,PLT9999G,PLT9999G
+Protab,PTBPT5QCB7,PTBPT5QCB7,PTBPT5QCB7
+QLA,C600,GBC_bravo,C600
+QMobile,A1,QMobile_Noir_A1,Noir A1
+QMobile,A1 lite,Noir_A1_lite,Noir A1 lite
+QMobile,Beat 1,QMobile_Beat_1,QMobile Beat 1
+QMobile,CS1,CS1,QMobile CS1
+QMobile,CS1 Plus,CS1_Plus,QMobile CS1 Plus
+QMobile,Dual One,QMobile_Dual_One,QMobile Dual One
+QMobile,E1,QMobile_E1,E1
+QMobile,E1,QMobile_E1,QMobile E1
+QMobile,E2,E2_Noir,E2 Noir
+QMobile,E3 Dual,E3_Dual,E3 Dual
+QMobile,E8,GBL5805QM,E8
+QMobile,ENERGY X1,ENERGY_X1,QMobile ENERGY X1
+QMobile,ENERGY X2,ENERGY_X2,QMobile ENERGY X2
+QMobile,Evok Power,QMobile_Evok_Power,QMobile Evok Power
+QMobile,Evok Power Lite,Evok_Power_Lite,QMobile Evok Power Lite
+QMobile,J1,J1,QMobile J1
+QMobile,J2,J2,QMobile J2
+QMobile,J5,J5,J5
+QMobile,J7,J7,J7
+QMobile,J7 PRO,J7_PRO,J7 PRO
+QMobile,JS10,JAZZX_JS10,JAZZX JS10
+QMobile,JazzX JS7 PRO,JS7_PRO,JazzX JS7 PRO
+QMobile,KING KONG MAX,KING_KONG_MAX,KING KONG MAX
+QMobile,L20,L20,QMobile L20
+QMobile,LT100,LT100,QMobile LT100
+QMobile,LT300,LT300,LT300
+QMobile,LT500 PRO,QMobile_LT500_PRO,LT500 PRO
+QMobile,LT550,QMobile_LT550,QMobile LT550
+QMobile,LT600 PRO,QMobile_LT600_PRO,QMobile_LT600_PRO
+QMobile,LT650,LT650,LT650
+QMobile,LT680,QMobile_LT680,LT680
+QMobile,LT700,GBL7325QM,LT700
+QMobile,LT700 PRO,LT700_PRO,LT700 PRO
+QMobile,M350 Pro,M350_Pro,M350 Pro
+QMobile,M6,BBL7551QM,M6
+QMobile,M6 Lite,M6_Lite,M6 Lite
+QMobile,NOIR A3,A3,QMobile A3
+QMobile,NOIR A6,A6,QMobile A6
+QMobile,Noir S9,QMobile_Noir_S9,QMobile Noir S9
+QMobile,Pakistan,A1_sprout,QMobile A1
+QMobile,Q Infinity,Q_Infinity,Q Infinity
+QMobile,QNote,QMobile_QNote,QMobile QNote
+QMobile,S1 Lite,S1_Lite,QMobile S1 Lite
+QMobile,S1 PRO,S1_PRO,QMobile S1 PRO
+QMobile,S2 Plus,S2_Plus,QMobile S2 Plus
+QMobile,S2 Pro,S2_Pro,S2 Pro
+QMobile,S4,QMobile_S4,S4
+QMobile,S6,QMobileS6,QMobile S6
+QMobile,S6 PLUS,QMobile_S6_PLUS,QMobile S6 PLUS
+QMobile,S6S,QMobile_S6S,QMobile S6S
+QMobile,S8,QMobile_S8,S8
+QMobile,S9,S9,S9
+QMobile,V100,QTab_V100,V100
+QMobile,V500,QTab_V500,V500
+QMobile,W70,W70,W70
+QMobile,W80,WBW5615QM,W80
+QMobile,X1S,Noir_X1S,Noir X1S
+QMobile,X32,X32,QMobile X32
+QMobile,X32,X32_new,QMobile X32
+QMobile,X32 Power,X32_Power,QMobile X32 Power
+QMobile,X33,QMobile_X33,QMobile X33
+QMobile,X36,QMobile_X36,QMobile X36
+QMobile,X700 PRO,X700_PRO,QMobile X700 PRO
+QMobile,X700 PRO II,X700_PRO_II,QMobile X700 PRO II
+QMobile,X700 PRO Lite,X700_PRO_Lite,QMobile X700 PRO Lite
+QMobile,X75,WBW5613QM,X75
+QMobile,Z10,Z10,QMobile Z10
+QMobile,Z12,CBL7521QM,Z12
+QMobile,Z12 PRO,Z12_PRO,Z12 PRO
+QMobile,Z14,Z14,Z14
+QMobile,Z9 Plus,WBL7511QM,Z9 Plus
+QMobile,i2 POWER,i2_POWER,QMobile i2 POWER
+QMobile,i2 PRO,i2_PRO,QMobile i2 PRO
+QMobile,i5.5,i5_5,QMobile i5.5
+QMobile,i6 Metal 2017,i6_Metal_2017,QMobile i6 Metal 2017
+QMobile,i6 Metal HD,i6_Metal_HD,i6 Metal HD
+QMobile,i6 Metal ONE,i6_Metal_ONE,QMobile i6 Metal ONE
+QMobile,i6 Metal One,i6_Metal_ONE_new,QMobile i6 Metal ONE
+QMobile,i7i PRO,i7i_PRO,QMobile i7i PRO
+QOOQ,QOOQV3,QOOQ,QOOQ
+Qilive,Q.3778,Q3778,Q.3778
+Qilive,W55,W55,W55
+Quanta,,Nirvana_Tablet,Nirvana_Tablet
+Quanta,,infinity_g,INFINITY G NK2
+Quanta,,nk1,IGS-1000
+Quanta,,nk1,TA1013
+Quanta,,ventana,NK1_111018_002_HC
+Quanta,,ventana,Q10
+Quanta,CT2200,CT2200,CT2200
+Quanta,FT103,FT103,FT103
+Quanta,True Beyond 4G,al7,TRUE BEYOND 4G
+Quanta,VSD220,VSD220,VSD220
+Quantum,FLY,Q7,Quantum Fly
+Quantum,Go,Q1,Quantum Go
+Quantum,Go,Q2,Quantum Go
+Quantum,Go 2,Q19,GO 2
+Quantum,MUV,Q3B,Quantum MUV
+Quantum,MUV 3G,Q3C,MUV
+Quantum,MUV 3G,Q3C,MUV 3G
+Quantum,MUV PRO,Q5,Quantum MUV PRO
+Quantum,MUV UP,Q13,Quantum MUV UP
+Quantum,Muv,Q3,MUV
+Quantum,Muv,Q3,Quantum MUV
+Quantum,QSPT-1952,QF3A,QT-195W-aa2
+Quantum,Sky,QX1,Sky
+Quantum,Twist Neo,S501,twist neo
+Quantum,V,QX2,Quantum V
+Quantum,You,Q17,Quantum You
+Quantum,You,Q17,You
+Quantum,You E,QY77,Quantum You E
+Quantum,You L,Q11,You L
+Quantum,i9i,QMobile_i9i,QMobile I9i
+RCA,10 Viking II,RCT6603W47M7,RCT6603W47M7
+RCA,10 Viking II Pro,RCT6603W87M7,RCT6603W87M7
+RCA,10 Viking Pro,RCT6303W87DK,RCT6303W87DK
+RCA,10 Viking Pro,RCT6303W87M,RCT6303W87M
+RCA,10 Viking Pro,RCT6303W87M7,RCT6303W87M7
+RCA,10 Viking Pro,RCT6K03W13,RCT6K03W13
+RCA,11 Galileo Pro,RCT6513W87,RCT6513W87
+RCA,11 Maven Pro,RCT6213W87DK,RCT6213W87DK
+RCA,7 Mercury,RCT6673W23M,RCT6673W23M
+RCA,7 Mercury,RCT6673W43M,RCT6673W43M
+RCA,7 Voyager,RCT6873W42,RCT6873W42
+RCA,7 Voyager II,RCT6773W22B,RCT6773W22B
+RCA,7 Voyager II,RCT6773W22BM,RCT6773W22BM
+RCA,Atlas 10,RCT6703W12,RCT6703W12
+RCA,BNT-710,BNT-710,BNT-710
+RCA,DAA730R / RCA DAA738R,MD7081,DAA730R
+RCA,DAA730R / RCA DAA738R,MD7081,DAA738R
+RCA,Mercury 7,CT9973W43M,CT9973W43M
+RCA,Pro10 Edition II,RCT6203W46L,RCT6203W46L
+RCA,Pro12,RCT6223W87,RCT6223W87
+RCA,RCA RCT6213W22,RCT6213W22,RCT6213W22
+RCA,RCA RCT6213W23,RCT6213W23,RCT6213W23
+RCA,RCA RCT6213W24,RCT6213W24,RCT6213W24
+RCA,RCA RCT6703W13,RCT6703W13,RCT6703W13
+RCA,RCA RCT6S03W12,RCT6S03W12,RCT6S03W12
+RCA,RCA RCT6S03W14,RCT6S03W14,RCT6S03W14
+RCA,RCS13101T,RCS13101T,RCS13101T
+RCA,RCT6002W46,RCT6002W46,RCT6002W46
+RCA,RCT6077W2,RCT6077W2,RCT6077W2
+RCA,RCT6077W22,RCT6077W22,RCT6077W22
+RCA,RCT6103W46,RCT6103W46,RCT6103W46
+RCA,RCT6203W46,RCT6203W46,RCT6203W46
+RCA,RCT6223W97,RCT6223W97,RCT6223W97
+RCA,RCT6272W23,RCT6272W23,RCT6272W23
+RCA,RCT6273W26,RCT6273W26,RCT6273W26
+RCA,RCT6283W27,RCT6283W27,RCT6283W27
+RCA,RCT6293W23,RCT6293W23,RCT6293W23
+RCA,RCT6378W2,RCT6378W2,RCT6378W2
+RCA,RCT6573W23,RCT6573W23,RCT6573W23
+RCA,RCT6603W47,RCT6603W47DK,RCT6603W47DK
+RCA,RCT6672W23,RCT6672W23,RCT6672W23
+RCA,RCT6673W-V1,RCT6673W-V1,RCT6673W-V1
+RCA,RCT6691W3,RCT6691W3,RCT6691W3
+RCA,RCT6773W22,RCT6773W22,RCT6773W22
+RCA,RCT6773W42B,RCT6773W42B,RCT6773W42B
+RCA,RCT6873W42M,RCT6873W42M,RCT6873W42M
+RCA,RCT6973W43,RCT6973W43,RCT6973W43
+RCA,RCT6973W43M,RCT6973W43M,RCT6973W43M
+RCA,Voyager Pro,RCT6873W42M_F7,RCT6873W42M_F7
+RCA,XLD Series,XLDRCAV1,XLDRCAV1
+REACH,Q882,Q882,Q882
+Rainbow,WIKO,s5501,RAINBOW
+Razer,Forge TV,pearlyn,Forge
+Razer,Razer Phone,cheryl,Phone
+Razer,Razer phone,cheryl_ckh,Phone
+Reeder,A8i Q2,A8i-Q2,A8i-Q2
+Reeder,M7 Plus,reeder_M7Plus,M7Plus
+Reeder,P10,P10,P10
+Reeder,P10S,P10S,P10S
+Reeder,P10SE,P10SE,P10SE
+Reeder,P9C,P9C,P9C
+Reeder,T8,reeder_T8,reeder_T8
+Reeder,reeder P12,P12,P12
+Reliance,FL7008,FL7008,FL7008
+Reliance,LS-4008,LS-4008,LS-4008
+Reliance,LS-5506,LS-5506,LS-5506
+Reliance,LS-5512,LS-5512,LS-5512
+Reliance,MCM3000,MCM3000,IPSetTopBox
+Reliance,Orbic RC505L-RW,RC505L-RW,RC505L-RW
+Reliance,RC500L,RC500L,RC500L
+Reliance,RC501L,RC501L,RC501L
+Reliance,Smartphone JS LS-5010,LS-5010,LS-5010
+Revo,Pearl,Pearl,Pearl
+Revo,Power,Power,Power
+Revtel,R45,Revel_R45,R45
+Royaltek,FGAD,FGAD,FGAD
+Ruggear,CP250,cp250_gts,cp250_gts
+Ruggear,DEWALT MD501,md501,DeWalt MD501
+Ruggear,IMO S,IMO_S,IMO_S
+Ruggear,RG730,rg730,RugGear RG730
+Ruio,RUIO i7c Tablet,i7c,i7c
+Ruio,Ruio_S5Plus,Ruio_S5Plus,Ruio_S5Plus
+Ruio,S4,RUIO_S4,RUIO_S4
+SAKAISIO,FP-U320-711-WIFI,U320-WF,FP-U320-711-WIFI
+SAKAISIO,FP-U320-711-WWAN,U320-3G,FP-U320-711-WWAN
+SED Wireless,GPH-650R,SPH_650R,GPH-650R
+SELECLINE,MID7526CM,MID7526CM,NID_7010
+SELECLINE,MID_9526CM,MID_9526CM,S952
+SFR,G8800,stb_dvb_sfr,SFR-G8800
+SFR,STARADDICT 4,staraddict4,STARADDICT 4
+SFR,STARXTREM3,STARXTREM3,STARXTREM3
+SFR,Star Shine II,up11_sfr_mensa,STARSHINE II
+SFR,Star Trail 5,STARTRAIL5,STARTRAIL5
+SFR,Star Trail 6,STARTRAIL6,STARTRAIL6
+SFR,Star Trail III,mobiwire_startrail3,StarTrail III
+SK Broadband,B tv smart,BHX-S100,BHX-S100
+SK Broadband,B tv smart,BKO-S200,BKO-S200
+SK Telesys,,K4,SK-S170
+SK Telesys,,msm8255_k5,SK-S150
+SK Telesys,,qsd8250_s1,SK-S100
+SK Telesys,AN200,AN200,AN200
+SK Telesys,EG68BE,EG668BE,EG668
+SK Telesys,EG978TW,EG978TW,EG978
+SK Telesys,EG980,eg980tw,EG980
+SK Telesys,Fly,htt77_ics2,Fly
+SK Telesys,ITP-E410W,willow,ITP-E410W
+SK Telesys,ITP-R208W,rk30sdk,ITP-R208W
+SK Telesys,Ice-Phone Forever,z262_wvga_mge,Ice-Phone Forever
+SK Telesys,K2401,K2401,S201
+SK Telesys,S150,msm8255_k5,S150
+SK Telesys,T720,T720,Clear
+SK Telesys,UTA200,htt75_nand_6628_ics,UTA200
+SK Telesys,WA966,u966e_2,WA966
+SK Telesys,WA978,u978e_1,WA978
+SK Telesys,icube-830,icube-830,icube-830
+SOSMART,T5,SOSMART_T5,SOSMART_T5
+SPC Mobile,L50,SPC_L50,L50
+SPC Mobile,L51 BLITZ,L51,L51
+SPC Mobile,L51 PRO,L51_Pro,L51 Pro
+SPC Mobile,L52 PRO,L52_Pro,L52 Pro
+SPC Mobile,L52 STEEL+,L52,L52
+SPC Mobile,L53,L53,L53
+STF Mobile,AERIAL,STFAERIAL,AERIAL
+STF Mobile,AERIAL PLUS,AERIAL,AERIAL PLUS
+STF Mobile,DUO,DUO,DUO
+STF Mobile,Fractal,Fractal,Fractal
+STF Mobile,HK-914581,HK-914581,HK-914581
+STF Mobile,IO,IO,IO
+STF Mobile,Joy Pro,Joy_Pro,Joy Pro
+STF Mobile,NATIVO,NATIVO,NATIVO
+STF Mobile,Origins Pro,Origins_Pro,Origins Pro
+STF Mobile,STF-BLOCK,Block,Block
+STK(Santok),Hero X,STK_Hero_X,STK_Hero_X
+STK(Santok),SYNC 5C,STK_Sync_5c,STK_Sync_5c
+STK(Santok),Storm 2e  Plus,Storm_2e_Plus,Storm 2e Plus
+STK(Santok),Storm 2e Pluz,Storm_2e_Pluz,Storm 2e Pluz
+STK(Santok),Storm 3,W230,STK Storm 3
+STK(Santok),Sync 5e,STK_Sync_5e,STK_Sync_5e
+STK(Santok),Sync 5z,STK_Sync_5z,STK Sync 5z
+STK(Santok),Transporter 1,STK_Transporter_1,STK_Transporter_1
+Safaricom,SFCSTB2LITE,SFCSTB2LITE,SFCSTB2LITE
+Saltillo,CF10,CF10,CF10
+Samsung,,GT-I5510M,GT-I5510M
+Samsung,,GT-I5510T,GT-I5510T
+Samsung,,GT-I5800L,GT-I5800L
+Samsung,,GT-N7000B,GT-N7000B
+Samsung,,GT-P7300B,GT-P7300B
+Samsung,,GT-P7320T,GT-P7320T
+Samsung,,GT-P7500M,GT-P7500M
+Samsung,,GT-P7500R,GT-P7500R
+Samsung,,GT-P7500V,GT-P7500V
+Samsung,,GT-S5698,GT-S5698
+Samsung,,GT-S5820,GT-S5820
+Samsung,,GT-S5830V,GT-S5830V
+Samsung,,SCH-I339,SCH-I339
+Samsung,,SCH-I405U,SCH-I405U
+Samsung,,SCH-I509U,SCH-I509U
+Samsung,,SCH-I519,SCH-I519
+Samsung,,SCH-I559,SCH-I559
+Samsung,,SCH-I559,SCH-i559
+Samsung,,SCH-I639,SCH-I639
+Samsung,,SCH-I659,SCH-I659
+Samsung,,SCH-I699,SCH-I699
+Samsung,,SCH-I779,SCH-I779
+Samsung,,SCH-I919U,SCH-I919U
+Samsung,,SCH-W899,SCH-W899
+Samsung,,SCH-W999,SCH-W999
+Samsung,,SCH-i809,SCH-i809
+Samsung,,SCH-i919,SCH-i919
+Samsung,,SGH-I987,SGH-I987
+Samsung,,SGH_T939,Behold II
+Samsung,,SHV-E150S,SHV-E150S
+Samsung,,SHW-M115S,SHW-M115S
+Samsung,,SHW-M135K,SHW-M135K
+Samsung,,SHW-M135L,SHW-M135L
+Samsung,,SHW-M340D,SHW-M340D
+Samsung,,SHW-M340K,SHW-M340K
+Samsung,,SHW-M460D,SHW-M460D
+Samsung,,amazingtrf,SGH-S730G
+Samsung,,aruba3gchn,GT-I8262D
+Samsung,,espressorfcmcc,GT-P3108
+Samsung,,gd1ltektt,EK-KC120K
+Samsung,,godivaltevzw,SCH-I425
+Samsung,,ironcmcc,GT-B9388
+Samsung,,m0grandectc,SCH-W2013
+Samsung,,m0grandectc,SCH-W9913
+Samsung,,p4noterfskt,SHW-M480S
+Samsung,,stunnerltespr,SPH-L500
+Samsung,,superiorchn,GT-I9260
+Samsung,\t Galaxy A7(2016),a7xltechn,SM-A710XZ
+Samsung,Absolute,GT-B9120,GT-B9120
+Samsung,Acclaim,SCH-R880,SCH-R880
+Samsung,Admire,SCH-R720,SCH-R720
+Samsung,Amazing,amazingtrf,SGH-S730M
+Samsung,Baffin,baffinltelgt,SHV-E270L
+Samsung,Captivate Glide,SGH-I927,SAMSUNG-SGH-I927
+Samsung,Captivate Glide,SGH-I927,SGH-I927
+Samsung,China Telecom,kylevectc,SCH-I699I
+Samsung,Chromebook 3,celes_cheets,Samsung Chromebook 3
+Samsung,Chromebook Plus,kevin_cheets,Samsung Chromebook Plus
+Samsung,Chromebook Plus,kevin_cheets,kevin
+Samsung,Chromebook Pro,caroline_cheets,Samsung Chromebook Pro
+Samsung,Chromebook Pro,caroline_cheets,caroline
+Samsung,Conquer,SPH-D600,SPH-D600
+Samsung,DoubleTime,SGH-I857,SAMSUNG-SGH-I857
+Samsung,Droid Charge,SCH-I510,SCH-I510
+Samsung,Elite,eliteltechn,SM-G1600
+Samsung,Elite,elitexltechn,SM-G1650
+Samsung,Europa,GT-I5500B,GT-I5500B
+Samsung,Europa,GT-I5500L,GT-I5500L
+Samsung,Europa,GT-I5500M,GT-I5500M
+Samsung,Europa,GT-I5503T,GT-I5503T
+Samsung,Europa,GT-I5510L,GT-I5510L
+Samsung,Exhibit,SGH-T759,SGH-T759
+Samsung,GALAXY Camera,gd1,EK-GC100
+Samsung,Galaxy (China),GT-B9062,GT-B9062
+Samsung,Galaxy 070,hendrix,YP-GI2
+Samsung,Galaxy A,archer,SHW-M100S
+Samsung,Galaxy A,archer,archer
+Samsung,Galaxy A3,a33g,SM-A300H
+Samsung,Galaxy A3,a3lte,SM-A300F
+Samsung,Galaxy A3,a3lte,SM-A300M
+Samsung,Galaxy A3,a3lte,SM-A300XZ
+Samsung,Galaxy A3,a3lte,SM-A300YZ
+Samsung,Galaxy A3,a3ltechn,SM-A3000
+Samsung,Galaxy A3,a3ltechn,SM-A300X
+Samsung,Galaxy A3,a3ltectc,SM-A3009
+Samsung,Galaxy A3,a3ltedd,SM-A300G
+Samsung,Galaxy A3,a3lteslk,SM-A300F
+Samsung,Galaxy A3,a3ltezh,SM-A3000
+Samsung,Galaxy A3,a3ltezt,SM-A300YZ
+Samsung,Galaxy A3,a3ulte,SM-A300FU
+Samsung,Galaxy A3,a3ulte,SM-A300XU
+Samsung,Galaxy A3,a3ulte,SM-A300Y
+Samsung,Galaxy A3 (2017),a3y17lte,SM-A320Y
+Samsung,Galaxy A3(2016),a3xelte,SM-A310F
+Samsung,Galaxy A3(2016),a3xelte,SM-A310M
+Samsung,Galaxy A3(2016),a3xelte,SM-A310X
+Samsung,Galaxy A3(2016),a3xelte,SM-A310Y
+Samsung,Galaxy A3(2016),a3xeltekx,SM-A310N0
+Samsung,Galaxy A3(2017),a3y17lte,SM-A320F
+Samsung,Galaxy A3(2017),a3y17lte,SM-A320FL
+Samsung,Galaxy A3(2017),a3y17lte,SM-A320X
+Samsung,Galaxy A5,a53g,SM-A500H
+Samsung,Galaxy A5,a5lte,SM-A500F
+Samsung,Galaxy A5,a5lte,SM-A500G
+Samsung,Galaxy A5,a5lte,SM-A500M
+Samsung,Galaxy A5,a5lte,SM-A500XZ
+Samsung,Galaxy A5,a5ltechn,SM-A5000
+Samsung,Galaxy A5,a5ltechn,SM-A500X
+Samsung,Galaxy A5,a5ltectc,SM-A5009
+Samsung,Galaxy A5,a5ltezh,SM-A5000
+Samsung,Galaxy A5,a5ltezt,SM-A500YZ
+Samsung,Galaxy A5,a5ulte,SM-A500FU
+Samsung,Galaxy A5,a5ulte,SM-A500Y
+Samsung,Galaxy A5,a5ultebmc,SM-A500W
+Samsung,Galaxy A5,a5ultektt,SM-A500K
+Samsung,Galaxy A5,a5ultelgt,SM-A500L
+Samsung,Galaxy A5,a5ulteskt,SM-A500F1
+Samsung,Galaxy A5,a5ulteskt,SM-A500S
+Samsung,Galaxy A5(2016),a5xelte,SM-A510F
+Samsung,Galaxy A5(2016),a5xelte,SM-A510M
+Samsung,Galaxy A5(2016),a5xelte,SM-A510X
+Samsung,Galaxy A5(2016),a5xelte,SM-A510Y
+Samsung,Galaxy A5(2016),a5xeltecmcc,SM-A5108
+Samsung,Galaxy A5(2016),a5xeltektt,SM-A510K
+Samsung,Galaxy A5(2016),a5xeltelgt,SM-A510L
+Samsung,Galaxy A5(2016),a5xelteskt,SM-A510S
+Samsung,Galaxy A5(2016),a5xeltextc,SM-A510Y
+Samsung,Galaxy A5(2016),a5xltechn,SM-A5100
+Samsung,Galaxy A5(2016),a5xltechn,SM-A5100X
+Samsung,Galaxy A5(2016),a5xltechn,SM-A510XZ
+Samsung,Galaxy A5(2017),a5y17lte,SM-A520F
+Samsung,Galaxy A5(2017),a5y17lte,SM-A520X
+Samsung,Galaxy A5(2017),a5y17ltecan,SM-A520W
+Samsung,Galaxy A5(2017),a5y17ltektt,SM-A520K
+Samsung,Galaxy A5(2017),a5y17ltelgt,SM-A520L
+Samsung,Galaxy A5(2017),a5y17lteskt,SM-A520S
+Samsung,Galaxy A5x(2016),a5xeltextc,SM-A510Y
+Samsung,Galaxy A7,a73g,SM-A700H
+Samsung,Galaxy A7,a7alte,SM-A700F
+Samsung,Galaxy A7,a7lte,SM-A700FD
+Samsung,Galaxy A7,a7lte,SM-A700X
+Samsung,Galaxy A7,a7ltechn,SM-A7000
+Samsung,Galaxy A7,a7ltechn,SM-A700YD
+Samsung,Galaxy A7,a7ltectc,SM-A7009
+Samsung,Galaxy A7,a7ltektt,SM-A700K
+Samsung,Galaxy A7,a7ltelgt,SM-A700L
+Samsung,Galaxy A7,a7lteskt,SM-A700S
+Samsung,Galaxy A7(2016),a7xelte,SM-A710F
+Samsung,Galaxy A7(2016),a7xelte,SM-A710M
+Samsung,Galaxy A7(2016),a7xelte,SM-A710X
+Samsung,Galaxy A7(2016),a7xeltecmcc,SM-A7108
+Samsung,Galaxy A7(2016),a7xeltektt,SM-A710K
+Samsung,Galaxy A7(2016),a7xeltelgt,SM-A710L
+Samsung,Galaxy A7(2016),a7xelteskt,SM-A710S
+Samsung,Galaxy A7(2016),a7xeltextc,SM-A710Y
+Samsung,Galaxy A7(2016),a7xltechn,SM-A7100
+Samsung,Galaxy A7(2017),a7y17lte,SM-A720F
+Samsung,Galaxy A7(2017),a7y17lteskt,SM-A720S
+Samsung,Galaxy A8,SCV32,SCV32
+Samsung,Galaxy A8,a8elte,SM-A800F
+Samsung,Galaxy A8,a8elte,SM-A800YZ
+Samsung,Galaxy A8,a8elteskt,SM-A800S
+Samsung,Galaxy A8,a8hplte,SM-A800I
+Samsung,Galaxy A8,a8hplte,SM-A800IZ
+Samsung,Galaxy A8,a8ltechn,SM-A8000
+Samsung,Galaxy A8,a8ltechn,SM-A800X
+Samsung,Galaxy A8(2016),a8xelte,SM-A810F
+Samsung,Galaxy A8(2016),a8xelte,SM-A810YZ
+Samsung,Galaxy A8(2016),a8xelteskt,SM-A810S
+Samsung,Galaxy A8(2018),jackpotlte,SM-A530F
+Samsung,Galaxy A8(2018),jackpotlte,SM-A530X
+Samsung,Galaxy A8(2018),jackpotlteks,SM-A530N
+Samsung,Galaxy A8+(2018),jackpot2lte,SM-A730F
+Samsung,Galaxy A8+(2018),jackpot2lte,SM-A730X
+Samsung,Galaxy A9 Pro,a9xproltechn,SM-A9100
+Samsung,Galaxy A9 Pro,a9xproltesea,SM-A910F
+Samsung,Galaxy A9(2016),a9xltechn,SM-A9000
+Samsung,Galaxy Ace,GT-S5830,GT-S5830
+Samsung,Galaxy Ace,GT-S5830B,GT-S5830B
+Samsung,Galaxy Ace,GT-S5830C,GT-S5830C
+Samsung,Galaxy Ace,GT-S5830D,GT-S5830D
+Samsung,Galaxy Ace,GT-S5830F,GT-S5830F
+Samsung,Galaxy Ace,GT-S5830G,GT-S5830G
+Samsung,Galaxy Ace,GT-S5830L,GT-S5830L
+Samsung,Galaxy Ace,GT-S5830M,GT-S5830M
+Samsung,Galaxy Ace,GT-S5830T,GT-S5830T
+Samsung,Galaxy Ace,GT-S5830i,GT-S5830i
+Samsung,Galaxy Ace,GT-S5831i,GT-S5831i
+Samsung,Galaxy Ace,GT-S5838,GT-S5838
+Samsung,Galaxy Ace,GT-S5839i,GT-S5839i
+Samsung,Galaxy Ace,GT-S6358,GT-S6358
+Samsung,Galaxy Ace,SCH-I619,SCH-I619
+Samsung,Galaxy Ace,SHW-M240S,SHW-M240S
+Samsung,Galaxy Ace,heat3gou,SM-G310R5
+Samsung,Galaxy Ace,heatlte,SM-G357M
+Samsung,Galaxy Ace 4,vivaltods5m,SM-G313HU
+Samsung,Galaxy Ace 4,vivaltods5m,SM-G313HY
+Samsung,Galaxy Ace 4,vivaltods5m,SM-G313M
+Samsung,Galaxy Ace 4,vivaltods5m,SM-G313MY
+Samsung,Galaxy Ace 4 Lite,vivalto3g,SM-G313U
+Samsung,Galaxy Ace Advance,GT-S6800,GT-S6800
+Samsung,Galaxy Ace Duos,GT-S6352,GT-S6352
+Samsung,Galaxy Ace Duos,GT-S6802,GT-S6802
+Samsung,Galaxy Ace Duos,GT-S6802B,GT-S6802B
+Samsung,Galaxy Ace Duos,SCH-I579,SCH-i579
+Samsung,Galaxy Ace Duos,SCH-I589,SCH-I589
+Samsung,Galaxy Ace Duos,SCH-I589,SCH-i589
+Samsung,Galaxy Ace Duos,SCH-i579,SCH-i579
+Samsung,Galaxy Ace Duos,SCH-i589,SCH-i589
+Samsung,Galaxy Ace Plus,GT-S7500,GT-S7500
+Samsung,Galaxy Ace Plus,GT-S7500L,GT-S7500L
+Samsung,Galaxy Ace Plus,GT-S7500T,GT-S7500T
+Samsung,Galaxy Ace Plus,GT-S7500W,GT-S7500W
+Samsung,Galaxy Ace Plus,GT-S7508,GT-S7508
+Samsung,Galaxy Ace Q,SGH-I827D,SGH-I827D
+Samsung,Galaxy Ace Style,heat3gtfnvzw,SM-S765C
+Samsung,Galaxy Ace Style,heat3gtfnvzw,SM-S766C
+Samsung,Galaxy Ace Style,heatnfc3g,SM-G310HN
+Samsung,Galaxy Ace Style,heatqlte,SM-G357FZ
+Samsung,Galaxy Ace2,GT-I8160,GT-I8160
+Samsung,Galaxy Ace2,GT-I8160L,GT-I8160L
+Samsung,Galaxy Ace2,GT-I8160P,GT-I8160P
+Samsung,Galaxy Ace2 X,kylessopen,GT-S7560
+Samsung,Galaxy Ace2 X,kylessopen,GT-S7560M
+Samsung,Galaxy Ace3,logan,GT-S7270
+Samsung,Galaxy Ace3,logan,GT-S7270L
+Samsung,Galaxy Ace3,logan,SCH-I679
+Samsung,Galaxy Ace3,logan3gcmcc,GT-S7278
+Samsung,Galaxy Ace3,logands,GT-S7272
+Samsung,Galaxy Ace3,loganlte,GT-S7275
+Samsung,Galaxy Ace3,loganrelte,GT-S7275B
+Samsung,Galaxy Ace3,loganrelte,GT-S7275R
+Samsung,Galaxy Ace3,loganrelte,GT-S7275T
+Samsung,Galaxy Ace3,loganrelte,GT-S7275Y
+Samsung,Galaxy Ace3 Duos,loganlite3g,GT-S7272C
+Samsung,Galaxy Ace3 Duos,loganu3gcmcc,GT-S7278U
+Samsung,Galaxy Ace3 Duos TV,logandsdtv,GT-S7273T
+Samsung,Galaxy Ace4,vivalto3g,SM-G313ML
+Samsung,Galaxy Ace4,vivalto3mve3g,SM-G316H
+Samsung,Galaxy Ace4,vivalto5mve3g,SM-G316HU
+Samsung,Galaxy Ace4,vivalto5mve3g,SM-G316M
+Samsung,Galaxy Ace4,vivalto5mve3g,SM-G316MY
+Samsung,Galaxy Ace4,vivaltolte,SM-G313F
+Samsung,Galaxy Ace4,vivaltolte,SM-G313MU
+Samsung,Galaxy Ace4,vivaltonfc3g,SM-G313HN
+Samsung,Galaxy Ace4 Lite,vivalto,SM-G3139D
+Samsung,Galaxy Ace4 Lite,vivalto3g,SM-G313H
+Samsung,Galaxy Ace4 Lite,vivalto3mve3gltn,SM-G316U
+Samsung,Galaxy Ace4 Lite,vivalto3mveml3g,SM-G318H
+Samsung,Galaxy Ace4 Lite,vivalto3mveml3g,SM-G318ML
+Samsung,Galaxy Ace4 Lite,vivalto3mveml3gsea,SM-G318HZ
+Samsung,Galaxy Ace4 Lite,vivalto3mveml3gsea,SM-G318MZ
+Samsung,Galaxy Ace4 Neo,vivalto3mve3gltn,SM-G316ML
+Samsung,Galaxy Active neo,SC-01H,SC-01H
+Samsung,Galaxy Admire,SCH-R820,SCH-R820
+Samsung,Galaxy Admire 2,goghcri,SCH-R830C
+Samsung,Galaxy Alpha,slte,SM-G850F
+Samsung,Galaxy Alpha,slte,SM-G850FQ
+Samsung,Galaxy Alpha,slte,SM-G850M
+Samsung,Galaxy Alpha,slte,SM-G850X
+Samsung,Galaxy Alpha,slte,SM-G850Y
+Samsung,Galaxy Alpha,slteatt,SAMSUNG-SM-G850A
+Samsung,Galaxy Alpha,sltecan,SM-G850W
+Samsung,Galaxy Alpha,sltechn,SM-G8508S
+Samsung,Galaxy Alpha,sltektt,SM-G850K
+Samsung,Galaxy Alpha,sltelgt,SM-G850L
+Samsung,Galaxy Alpha,slteskt,SM-G850S
+Samsung,Galaxy Amp,kyleatt,SAMSUNG-SGH-I407
+Samsung,Galaxy Apollo,GT-I5800,GT-I5800
+Samsung,Galaxy Apollo,GT-I5800,GT-I5800L
+Samsung,Galaxy Apollo,GT-I5800D,GT-I5800D
+Samsung,Galaxy Apollo,GT-I5801,GT-I5801
+Samsung,Galaxy Appeal,SGH-I827,SAMSUNG-SGH-I827
+Samsung,Galaxy Attain,SCH-R920,SCH-R920
+Samsung,Galaxy Avant,afyonltetmo,SM-G386T
+Samsung,Galaxy Axiom,infiniteusc,SCH-R830
+Samsung,Galaxy Beam,GT-I8250,GT-I8250
+Samsung,Galaxy Beam,GT-I8530,GT-I8530
+Samsung,Galaxy C5,c5ltechn,SM-C5000
+Samsung,Galaxy C5,c5ltechn,SM-C500X
+Samsung,Galaxy C5,c5pltechn,SM-C5000
+Samsung,Galaxy C5 Pro,c5proltechn,SM-C5010
+Samsung,Galaxy C5 Pro,c5proltechn,SM-C5018
+Samsung,Galaxy C7,c7ltechn,SM-C7000
+Samsung,Galaxy C7,c7ltechn,SM-C700X
+Samsung,Galaxy C7,c7proltechn,SM-C701X
+Samsung,Galaxy C7 Pro,c7prolte,SM-C701F
+Samsung,Galaxy C7 Pro,c7proltechn,SM-C7010
+Samsung,Galaxy C7 Pro,c7proltechn,SM-C7018
+Samsung,Galaxy C8,jadeltechn,SM-C7100
+Samsung,Galaxy C8,jadeltechn,SM-C710X
+Samsung,Galaxy C8,jadeltecmcc,SM-C7108
+Samsung,Galaxy C9 Pro,c9lte,SM-C900F
+Samsung,Galaxy C9 Pro,c9lte,SM-C900Y
+Samsung,Galaxy C9 Pro,c9ltechn,SM-C9000
+Samsung,Galaxy C9 Pro,c9ltechn,SM-C9008
+Samsung,Galaxy C9 Pro,c9ltechn,SM-C900X
+Samsung,Galaxy Camera,gd1,EK-GC100
+Samsung,Galaxy Camera,gd1att,SAMSUNG-EK-GC100
+Samsung,Galaxy Camera,gd1can,EK-GC100
+Samsung,Galaxy Camera,gd1ktt,EK-KC100K
+Samsung,Galaxy Camera,gd1ltelgt,EK-KC120L
+Samsung,Galaxy Camera,gd1lteskt,EK-KC120S
+Samsung,Galaxy Camera,gd1ltevzw,EK-GC120
+Samsung,Galaxy Camera,gd1skt,EK-KC100S
+Samsung,Galaxy Camera,gd1wifi,EK-GC110
+Samsung,Galaxy Camera,gd1wifiany,EK-GC110
+Samsung,Galaxy Camera,u0lte,EK-GN100
+Samsung,Galaxy Camera,u0lte,EK-GN120
+Samsung,Galaxy Camera 2,sf2wifi,EK-GC200
+Samsung,Galaxy Centura,amazing3gtrf,SCH-S738C
+Samsung,Galaxy Chat,zanin,GT-B5330
+Samsung,Galaxy Chat,zanin,GT-B5330B
+Samsung,Galaxy Chat,zanin,GT-B5330L
+Samsung,Galaxy Core,afyonlteMetroPCS,SM-G386T1
+Samsung,Galaxy Core,afyonltecan,SM-G386W
+Samsung,Galaxy Core,arubaslim,GT-I8262
+Samsung,Galaxy Core,arubaslimss,GT-I8260
+Samsung,Galaxy Core,arubaslimss,GT-I8260L
+Samsung,Galaxy Core 2,kanas,SM-G355H
+Samsung,Galaxy Core Advance,cane3g,GT-I8580
+Samsung,Galaxy Core Advance,cane3gskt,SHW-M570S
+Samsung,Galaxy Core LTE,afyonlte,SM-G386F
+Samsung,Galaxy Core LTE,cs03lte,SM-G3518
+Samsung,Galaxy Core Lite,victorlte,SM-G3586V
+Samsung,Galaxy Core Lite,victorlte,SM-G3589W
+Samsung,Galaxy Core Max,kleoslte,SM-G5108
+Samsung,Galaxy Core Max Duos,kleoslte,SM-G5108Q
+Samsung,Galaxy Core Plus,cs02,SM-G350
+Samsung,Galaxy Core Plus,cs023g,SM-G3502
+Samsung,Galaxy Core Plus,cs02ve3g,SM-G3502L
+Samsung,Galaxy Core Plus,cs02ve3gdtv,SM-G3502T
+Samsung,Galaxy Core Plus,cs02ve3gss,SM-G350L
+Samsung,Galaxy Core Plus,cs02ve3gss,SM-G350M
+Samsung,Galaxy Core Prime,core33g,SM-G360H
+Samsung,Galaxy Core Prime,core33g,SM-G360HU
+Samsung,Galaxy Core Prime,coreprimelte,SM-G360F
+Samsung,Galaxy Core Prime,coreprimelte,SM-G360FY
+Samsung,Galaxy Core Prime,coreprimelte,SM-G360M
+Samsung,Galaxy Core Prime,coreprimelteaio,SAMSUNG-SM-G360AZ
+Samsung,Galaxy Core Prime,coreprimeltelra,SM-G360R6
+Samsung,Galaxy Core Prime,coreprimeltespr,SM-G360P
+Samsung,Galaxy Core Prime,coreprimeltetfnvzw,SM-S820L
+Samsung,Galaxy Core Prime,coreprimeltevzw,SM-G360V
+Samsung,Galaxy Core Prime,coreprimeve3g,SM-G361H
+Samsung,Galaxy Core Prime,coreprimeve3g,SM-G361HU
+Samsung,Galaxy Core Prime,coreprimevelte,SM-G361F
+Samsung,Galaxy Core Prime,coreprimevelte,SM-G361M
+Samsung,Galaxy Core Prime,cprimeltemtr,SM-G360T1
+Samsung,Galaxy Core Prime,cprimeltetmo,SM-G360T
+Samsung,Galaxy Core Prime,rossalte,SM-G3606
+Samsung,Galaxy Core Prime,rossalte,SM-G3608
+Samsung,Galaxy Core Prime,rossaltectc,SM-G3609
+Samsung,Galaxy Core Prime,rossaltexsa,SM-G360GY
+Samsung,Galaxy Core Safe,arubaslimss,GT-I8260E
+Samsung,Galaxy Core Safe,arubaslimss,SHW-M580D
+Samsung,Galaxy Core Safe,arubaslimss,SHW-M585D
+Samsung,Galaxy Core2,kanas,SM-G355H
+Samsung,Galaxy Core2,kanas,SM-G355HQ
+Samsung,Galaxy Core2,kanas,SM-G355M
+Samsung,Galaxy Core2,kanas3g,SM-G3556D
+Samsung,Galaxy Core2,kanas3gcmcc,SM-G3558
+Samsung,Galaxy Core2,kanas3gctc,SM-G3559
+Samsung,Galaxy Core2,kanas3gnfc,SM-G355HN
+Samsung,Galaxy Discover,amazing3gcri,SCH-R740C
+Samsung,Galaxy Discover,amazingtrfcd,SCH-S735C
+Samsung,Galaxy Duos,aruba3gcmcc,GT-I8268
+Samsung,Galaxy E5,e53g,SM-E500H
+Samsung,Galaxy E5,e5lte,SM-E500F
+Samsung,Galaxy E5,e5lte,SM-E500M
+Samsung,Galaxy E5,e5ltetfnvzw,SM-S978L
+Samsung,Galaxy E5,e5ltetw,SM-E500YZ
+Samsung,Galaxy E7,e73g,SM-E700H
+Samsung,Galaxy E7,e7lte,SM-E700F
+Samsung,Galaxy E7,e7lte,SM-E700M
+Samsung,Galaxy E7,e7ltechn,SM-E7000
+Samsung,Galaxy E7,e7ltectc,SM-E7009
+Samsung,Galaxy E7,e7ltehktw,SM-E7000
+Samsung,Galaxy Elite,elite3gkx,SM-G165N
+Samsung,Galaxy Elite,eliteltekx,SM-G160N
+Samsung,Galaxy Europa,GT-I5500,GT-I5500
+Samsung,Galaxy Europa,GT-I5503,GT-I5503
+Samsung,Galaxy Europa,GT-I5508,GT-I5508
+Samsung,Galaxy Europa,GT-I5510,GT-I5510
+Samsung,Galaxy Exhibit,codinaMetroPCS,SGH-T599N
+Samsung,Galaxy Exhibit,codinatmo,SGH-T599
+Samsung,Galaxy Exhibit,codinavid,SGH-T599V
+Samsung,Galaxy Exhibit2,SGH-T679,SGH-T679
+Samsung,Galaxy Exhilarate,SGH-I577,SAMSUNG-SGH-I577
+Samsung,Galaxy Express,expressatt,SAMSUNG-SGH-I437
+Samsung,Galaxy Express,expressatt,SAMSUNG-SGH-I437P
+Samsung,Galaxy Express,expresslte,GT-I8730
+Samsung,Galaxy Express,expresslte,GT-I8730T
+Samsung,Galaxy Express,expressziglteatt,SAMSUNG-SGH-I437Z
+Samsung,Galaxy Express2,wilcoxlte,SM-G3815
+Samsung,Galaxy Fame,SCH-I629,SCH-I629
+Samsung,Galaxy Fame,nevis,GT-S6810
+Samsung,Galaxy Fame,nevis,GT-S6810B
+Samsung,Galaxy Fame,nevis,GT-S6810E
+Samsung,Galaxy Fame,nevis,GT-S6810L
+Samsung,Galaxy Fame,nevis3g,GT-S6812i
+Samsung,Galaxy Fame,nevis3gcmcc,GT-S6818
+Samsung,Galaxy Fame,nevis3gcmcc,GT-S6818V
+Samsung,Galaxy Fame,nevisds,GT-S6812
+Samsung,Galaxy Fame,nevisds,GT-S6812B
+Samsung,Galaxy Fame,nevisnvess,GT-S6790N
+Samsung,Galaxy Fame,nevisp,GT-S6810M
+Samsung,Galaxy Fame,nevisp,GT-S6810P
+Samsung,Galaxy Fame,nevisvess,GT-S6790
+Samsung,Galaxy Fame,nevisvess,GT-S6790E
+Samsung,Galaxy Fame,nevisvess,GT-S6790L
+Samsung,Galaxy Fame,nevisw,GT-S6812C
+Samsung,Galaxy Fame Lite Duos,nevisw,GT-S6792L
+Samsung,Galaxy Feel,SC-04J,SC-04J
+Samsung,Galaxy Fit,GT-S5670,GT-S5670
+Samsung,Galaxy Fit,GT-S5670B,GT-S5670B
+Samsung,Galaxy Fit,GT-S5670L,GT-S5670L
+Samsung,Galaxy Folder,novel3gskt,SM-G155S
+Samsung,Galaxy Folder,novelltektt,SM-G150NK
+Samsung,Galaxy Folder,novelltekx,SM-G150N0
+Samsung,Galaxy Folder,novelltelgt,SM-G150NL
+Samsung,Galaxy Folder,novellteskt,SM-G150NS
+Samsung,Galaxy Fresh,kylevess,GT-S7390
+Samsung,Galaxy Fresh,kylevess,GT-S7390E
+Samsung,Galaxy Fresh,kylevess,GT-S7390G
+Samsung,Galaxy Gio,GT-S5660,GT-S5660
+Samsung,Galaxy Gio,GT-S5660B,GT-S5660B
+Samsung,Galaxy Gio,GT-S5660L,GT-S5660L
+Samsung,Galaxy Gio,GT-S5660M,GT-S5660M
+Samsung,Galaxy Gio,GT-S5660V,GT-S5660V
+Samsung,Galaxy Gio,SCH-i569,SCH-i569
+Samsung,Galaxy Gio,SHW-M290K,SHW-M290K
+Samsung,Galaxy Gio,SHW-M290S,SHW-M290S
+Samsung,Galaxy Go Prime,grandprimelteatt,SAMSUNG-SM-G530A
+Samsung,Galaxy Golden,ks02lte,GT-I9230
+Samsung,Galaxy Golden,ks02lte,GT-I9235
+Samsung,Galaxy Golden,ks02ltektt,SHV-E400K
+Samsung,Galaxy Golden,ks02lteskt,SHV-E400S
+Samsung,Galaxy Golden 2,pateklte,SM-W2015
+Samsung,Galaxy Grand,baffin3gduosctc,SCH-I879
+Samsung,Galaxy Grand,baffincmcc,GT-I9128
+Samsung,Galaxy Grand,baffincmcc,GT-I9128V
+Samsung,Galaxy Grand,baffinltektt,SHV-E270K
+Samsung,Galaxy Grand,baffinlteskt,SHV-E270S
+Samsung,Galaxy Grand,baffinrd,GT-I9118
+Samsung,Galaxy Grand,baffinss,GT-I9080E
+Samsung,Galaxy Grand,baffinss,GT-I9080L
+Samsung,Galaxy Grand,baffinvektt,SHV-E275K
+Samsung,Galaxy Grand,baffinveskt,SHV-E275S
+Samsung,Galaxy Grand,baffinvetd3g,GT-I9128E
+Samsung,Galaxy Grand,baffinvetd3g,GT-I9128I
+Samsung,Galaxy Grand Duos,baffin,GT-I9082
+Samsung,Galaxy Grand Duos,baffin,GT-I9082L
+Samsung,Galaxy Grand Max,grandmax3g,SM-G7202
+Samsung,Galaxy Grand Max,grandmaxltechn,SM-G7200
+Samsung,Galaxy Grand Max,grandmaxltechn,SM-G720AX
+Samsung,Galaxy Grand Neo,baffinlite,GT-I9060
+Samsung,Galaxy Grand Neo,baffinlite,GT-I9060L
+Samsung,Galaxy Grand Neo,baffinlite,GT-I9082C
+Samsung,Galaxy Grand Neo,baffinlitedtv,GT-I9063T
+Samsung,Galaxy Grand Neo,baffinq3g,GT-I9168
+Samsung,Galaxy Grand Neo,baffinq3g,GT-I9168I
+Samsung,Galaxy Grand Neo Plus,grandneove3g,GT-I9060C
+Samsung,Galaxy Grand Neo Plus,grandneove3g,GT-I9060I
+Samsung,Galaxy Grand Neo Plus,grandneove3g,GT-I9060M
+Samsung,Galaxy Grand Neo+,baffinq3gduosctc,SCH-I879E
+Samsung,Galaxy Grand Prime,fortuna3g,SM-G530H
+Samsung,Galaxy Grand Prime,fortuna3gdtv,SM-G530BT
+Samsung,Galaxy Grand Prime,fortunalte,SM-G5306W
+Samsung,Galaxy Grand Prime,fortunalte,SM-G5308W
+Samsung,Galaxy Grand Prime,fortunalte,SM-G530F
+Samsung,Galaxy Grand Prime,fortunalte,SM-G530M
+Samsung,Galaxy Grand Prime,fortunaltectc,SM-G5309W
+Samsung,Galaxy Grand Prime,fortunaltezh,SM-G5308W
+Samsung,Galaxy Grand Prime,fortunaltezt,SM-G530MU
+Samsung,Galaxy Grand Prime,fortunaltezt,SM-G530Y
+Samsung,Galaxy Grand Prime,fortunave3g,SM-G530H
+Samsung,Galaxy Grand Prime,gprimelteacg,SM-G530R7
+Samsung,Galaxy Grand Prime,gprimelteacg,gprimelteacg
+Samsung,Galaxy Grand Prime,gprimeltecan,SM-G530W
+Samsung,Galaxy Grand Prime,gprimeltemtr,SM-G530T1
+Samsung,Galaxy Grand Prime,gprimeltespr,SM-G530P
+Samsung,Galaxy Grand Prime,gprimeltetfnvzw,SM-S920L
+Samsung,Galaxy Grand Prime,gprimeltetmo,SM-G530T
+Samsung,Galaxy Grand Prime,gprimelteusc,SM-G530R4
+Samsung,Galaxy Grand Prime,grandprimelte,SM-G530FZ
+Samsung,Galaxy Grand Prime,grandprimelteaio,SAMSUNG-SM-G530AZ
+Samsung,Galaxy Grand Prime,grandprimeve3g,SM-G531H
+Samsung,Galaxy Grand Prime,grandprimeve3gdtv,SM-G531BT
+Samsung,Galaxy Grand Prime,grandprimevelte,SM-G531F
+Samsung,Galaxy Grand Prime,grandprimevelteltn,SM-G531M
+Samsung,Galaxy Grand Prime,grandprimeveltezt,SM-G531Y
+Samsung,Galaxy Grand Prime Pro,j2y18lte,SM-J250F
+Samsung,Galaxy Grand duos,baffin,GT-I9082i
+Samsung,Galaxy Grand-Max,grandmaxltekx,SM-G720N0
+Samsung,Galaxy Grand2,ms013g,SM-G7102
+Samsung,Galaxy Grand2,ms013g,SM-G7106
+Samsung,Galaxy Grand2,ms013g,SM-G7108
+Samsung,Galaxy Grand2,ms013g,SM-G7109
+Samsung,Galaxy Grand2,ms013gdtv,SM-G7102T
+Samsung,Galaxy Grand2,ms013gss,SM-G710
+Samsung,Galaxy Grand2,ms01lte,SM-G7105
+Samsung,Galaxy Grand2,ms01lte,SM-G7105H
+Samsung,Galaxy Grand2,ms01lte,SM-G7105L
+Samsung,Galaxy Grand2,ms01ltektt,SM-G710K
+Samsung,Galaxy Grand2,ms01ltelgt,SM-G710L
+Samsung,Galaxy Grand2,ms01lteskt,SM-G710S
+Samsung,Galaxy Indulge,SCH-R910,SCH-R910
+Samsung,Galaxy Indulge,SCH-R915,SCH-R915
+Samsung,Galaxy Infinite,infinite3gduosctc,SCH-I759
+Samsung,Galaxy J,hltejs01tw,SGH-N075T
+Samsung,Galaxy J1,j13g,SM-J100H
+Samsung,Galaxy J1,j13g,SM-J100ML
+Samsung,Galaxy J1,j13gtfnvzw,SM-S777C
+Samsung,Galaxy J1,j1lte,SM-J100F
+Samsung,Galaxy J1,j1lte,SM-J100G
+Samsung,Galaxy J1,j1lte,SM-J100M
+Samsung,Galaxy J1,j1nlte,SM-J100FN
+Samsung,Galaxy J1,j1nlte,SM-J100MU
+Samsung,Galaxy J1,j1nlte,SM-J100Y
+Samsung,Galaxy J1,j1qltevzw,SM-J100VPP
+Samsung,Galaxy J1,j1xlte,SM-J120F
+Samsung,Galaxy J1,j1xlte,SM-J120FN
+Samsung,Galaxy J1,j1xlte,SM-J120M
+Samsung,Galaxy J1,j1xlteaio,SAMSUNG-SM-J120AZ
+Samsung,Galaxy J1,j1xlteatt,SAMSUNG-SM-J120A
+Samsung,Galaxy J1,j1xltecan,SM-J120W
+Samsung,Galaxy J1,j1xqltespr,SM-J120P
+Samsung,Galaxy J1,j1xqltetfnvzw,SM-S120VL
+Samsung,Galaxy J1 Ace,j1acelte,SM-J110F
+Samsung,Galaxy J1 Ace,j1acelte,SM-J110G
+Samsung,Galaxy J1 Ace,j1acelteltn,SM-J110M
+Samsung,Galaxy J1 Ace,j1acevelte,SM-J111F
+Samsung,Galaxy J1 Ace,j1acevelte,SM-J111M
+Samsung,Galaxy J1 Ace,j1pop3g,SM-J110H
+Samsung,Galaxy J1 Ace,j1pop3g,SM-J110L
+Samsung,Galaxy J1 Mini,j1mini3g,SM-J105B
+Samsung,Galaxy J1 Mini,j1mini3g,SM-J105H
+Samsung,Galaxy J1 Mini,j1mini3gdx,SM-J105B
+Samsung,Galaxy J1 Mini,j1mini3gxw,SM-J105H
+Samsung,Galaxy J1 Mini,j1minilte,SM-J105F
+Samsung,Galaxy J1 Mini,j1minilte,SM-J105M
+Samsung,Galaxy J1 Mini,j1minilte,SM-J105Y
+Samsung,Galaxy J1 Mini Prime,j1minive3g,SM-J106B
+Samsung,Galaxy J1 Mini Prime,j1minive3g,SM-J106H
+Samsung,Galaxy J1 Mini Prime,j1minive3gxtc,SM-J106B
+Samsung,Galaxy J1 Mini Prime,j1minivelte,SM-J106M
+Samsung,Galaxy J1(2016),j1x3g,SM-J120H
+Samsung,Galaxy J1(2016),j1xlte,SM-J120G
+Samsung,Galaxy J1(2016),j1xlte,SM-J120ZN
+Samsung,Galaxy J2,j23g,SM-J200H
+Samsung,Galaxy J2,j2lte,SM-J200F
+Samsung,Galaxy J2,j2lte,SM-J200G
+Samsung,Galaxy J2,j2lte,SM-J200GU
+Samsung,Galaxy J2,j2lte,SM-J200M
+Samsung,Galaxy J2,j2lte,SM-J200Y
+Samsung,Galaxy J2,j2ltedtv,SM-J200BT
+Samsung,Galaxy J2 (2018),j2y18lte,SM-J250F
+Samsung,Galaxy J2 Prime,grandpplte,SM-G532G
+Samsung,Galaxy J2 Prime,grandpplte,SM-G532M
+Samsung,Galaxy J2(2016),j2xlte,SM-J210F
+Samsung,Galaxy J2(2016),j2xlteins,SM-J210F
+Samsung,Galaxy J3,j3ltectc,SM-J3109
+Samsung,Galaxy J3,j3ltespr,SM-J320P
+Samsung,Galaxy J3,j3popelteue,SM-J327U
+Samsung,Galaxy J3,j3x3g,SM-J320H
+Samsung,Galaxy J3 Pop,j3popelteaio,SAMSUNG-SM-J326AZ
+Samsung,Galaxy J3 Pop,j3popelteaio,SAMSUNG-SM-J327AZ
+Samsung,Galaxy J3 Pop,j3popelteatt,SAMSUNG-SM-J327A
+Samsung,Galaxy J3 Pop,j3popeltecan,SM-J327W
+Samsung,Galaxy J3 Pop,j3popeltetfntmo,SM-S337TL
+Samsung,Galaxy J3 Pop,j3poplteacg,SM-J327R7
+Samsung,Galaxy J3 Pop,j3popltelra,SM-J327R6
+Samsung,Galaxy J3 Pop,j3popltespr,SM-J327P
+Samsung,Galaxy J3 Pop,j3popltetfnvzw,SM-S327VL
+Samsung,Galaxy J3 Pop,j3poplteusc,SM-J327R4
+Samsung,Galaxy J3 Pop,j3popltevzw,SM-J327V
+Samsung,Galaxy J3 Pop,j3popltevzw,SM-J327VPP
+Samsung,Galaxy J3 Prime,j3popeltemtr,SM-J327T1
+Samsung,Galaxy J3 Prime,j3popeltetmo,SM-J327T
+Samsung,Galaxy J3 Pro,j3xpro6mltechn,SM-J3119S
+Samsung,Galaxy J3 Pro,j3xproltechn,SM-J3110
+Samsung,Galaxy J3 Pro,j3xproltectc,SM-J3119
+Samsung,Galaxy J3 Pro,j3y17lte,SM-J330G
+Samsung,Galaxy J3(2016),j3ltekx,SM-J320N0
+Samsung,Galaxy J3(2016),j3ltetfnvzw,SM-S320VL
+Samsung,Galaxy J3(2016),j3ltetw,SM-J320Y
+Samsung,Galaxy J3(2016),j3ltetw,SM-J320YZ
+Samsung,Galaxy J3(2016),j3lteusc,SM-J320R4
+Samsung,Galaxy J3(2016),j3ltevzw,SM-J320V
+Samsung,Galaxy J3(2016),j3ltevzw,SM-J320VPP
+Samsung,Galaxy J3(2016),j3ltexsa,SM-J320ZN
+Samsung,Galaxy J3(2016),j3xlte,SM-J320F
+Samsung,Galaxy J3(2016),j3xlte,SM-J320G
+Samsung,Galaxy J3(2016),j3xlte,SM-J320M
+Samsung,Galaxy J3(2016),j3xlteaio,SAMSUNG-SM-J320AZ
+Samsung,Galaxy J3(2016),j3xlteaio,SAMSUNG-SM-J321AZ
+Samsung,Galaxy J3(2016),j3xlteatt,SAMSUNG-SM-J320A
+Samsung,Galaxy J3(2016),j3xltebmc,SM-J320W8
+Samsung,Galaxy J3(2016),j3xnlte,SM-J320FN
+Samsung,Galaxy J3(2017),j3y17lte,SM-J330F
+Samsung,Galaxy J3(2017),j3y17lte,SM-J330FN
+Samsung,Galaxy J3(2017),j3y17ltekx,SM-J330N
+Samsung,Galaxy J3(2017),j3y17ltelgt,SM-J330L
+Samsung,Galaxy J3(2017),j3y17qltecmcc,SM-J3300
+Samsung,Galaxy J3(2017),j3y17qltecmcc,SM-J3308
+Samsung,Galaxy J5,j53g,SM-J500H
+Samsung,Galaxy J5,j5lte,SM-J5007
+Samsung,Galaxy J5,j5lte,SM-J500F
+Samsung,Galaxy J5,j5lte,SM-J500G
+Samsung,Galaxy J5,j5lte,SM-J500M
+Samsung,Galaxy J5,j5ltechn,SM-J5008
+Samsung,Galaxy J5,j5ltekx,SM-J500N0
+Samsung,Galaxy J5,j5nlte,SM-J500FN
+Samsung,Galaxy J5,j5ylte,SM-J500Y
+Samsung,Galaxy J5 Prime,on5xelte,SM-G570F
+Samsung,Galaxy J5 Prime,on5xelte,SM-G570M
+Samsung,Galaxy J5 Prime,on5xelte,SM-G570Y
+Samsung,Galaxy J5 Prime,on5xelteins,SM-G570F
+Samsung,Galaxy J5 Prime,on5xltechn,SM-G5700
+Samsung,Galaxy J5 Pro,j5y17ltedx,SM-J530Y
+Samsung,Galaxy J5 Pro,j5y17ltextc,SM-J530YM
+Samsung,Galaxy J5(2016),j5x3g,SM-J510H
+Samsung,Galaxy J5(2016),j5xltecmcc,SM-J5108
+Samsung,Galaxy J5(2016),j5xnlte,SM-J510F
+Samsung,Galaxy J5(2016),j5xnlte,SM-J510FN
+Samsung,Galaxy J5(2016),j5xnlte,SM-J510FQ
+Samsung,Galaxy J5(2016),j5xnlte,SM-J510GN
+Samsung,Galaxy J5(2016),j5xnlte,SM-J510MN
+Samsung,Galaxy J5(2016),j5xnlte,SM-J510UN
+Samsung,Galaxy J5(2016),j5xnltektt,SM-J510K
+Samsung,Galaxy J5(2016),j5xnltelgt,SM-J510L
+Samsung,Galaxy J5(2016),j5xnlteskt,SM-J510S
+Samsung,Galaxy J5(2017),j5y17lte,SM-J530F
+Samsung,Galaxy J5(2017),j5y17lte,SM-J530FM
+Samsung,Galaxy J5(2017),j5y17lte,SM-J530G
+Samsung,Galaxy J5(2017),j5y17lte,SM-J530GM
+Samsung,Galaxy J5(2017),j5y17ltektt,SM-J530K
+Samsung,Galaxy J5(2017),j5y17ltelgt,SM-J530L
+Samsung,Galaxy J5(2017),j5y17lteskt,SM-J530S
+Samsung,Galaxy J7,j75ltektt,SM-J700K
+Samsung,Galaxy J7,j7e3g,SM-J700H
+Samsung,Galaxy J7,j7elte,SM-J700F
+Samsung,Galaxy J7,j7elte,SM-J700M
+Samsung,Galaxy J7,j7ltechn,SM-J7008
+Samsung,Galaxy J7 Max,j7maxlte,SM-G615F
+Samsung,Galaxy J7 Neo,j7velte,SM-J701F
+Samsung,Galaxy J7 Neo,j7velte,SM-J701M
+Samsung,Galaxy J7 Neo,j7velte,SM-J701MT
+Samsung,Galaxy J7 Pop,j7popelteaio,SAMSUNG-SM-J727AZ
+Samsung,Galaxy J7 Pop,j7popelteatt,SAMSUNG-SM-J727A
+Samsung,Galaxy J7 Pop,j7popeltetfntmo,SM-S737TL
+Samsung,Galaxy J7 Pop,j7popelteue,SM-J727U
+Samsung,Galaxy J7 Pop,j7popltespr,SM-J727P
+Samsung,Galaxy J7 Pop,j7poplteusc,SM-J727R4
+Samsung,Galaxy J7 Pop,j7popltevzw,SM-J727V
+Samsung,Galaxy J7 Pop,j7popltevzw,SM-J727VPP
+Samsung,Galaxy J7 Pop,j7popqltetfnvzw,SM-S727VL
+Samsung,Galaxy J7 Prime,j7popeltemtr,SM-J727T1
+Samsung,Galaxy J7 Prime,j7popeltetmo,SM-J727T
+Samsung,Galaxy J7 Prime,on7xelte,SM-G610F
+Samsung,Galaxy J7 Prime,on7xelte,SM-G610M
+Samsung,Galaxy J7 Prime,on7xelte,SM-G610Y
+Samsung,Galaxy J7 Prime,on7xltechn,SM-G6100
+Samsung,Galaxy J7 Pro,j7y17lte,SM-J730G
+Samsung,Galaxy J7 Pro,j7y17lte,SM-J730GM
+Samsung,Galaxy J7(2015),j7ltespr,SM-J700P
+Samsung,Galaxy J7(2016),j7eltemtr,SM-J700T1
+Samsung,Galaxy J7(2016),j7eltetmo,SM-J700T
+Samsung,Galaxy J7(2016),j7xelte,SM-J710F
+Samsung,Galaxy J7(2016),j7xelte,SM-J710FQ
+Samsung,Galaxy J7(2016),j7xelte,SM-J710GN
+Samsung,Galaxy J7(2016),j7xelte,SM-J710MN
+Samsung,Galaxy J7(2016),j7xeltecmcc,SM-J7108
+Samsung,Galaxy J7(2016),j7xeltektt,SM-J710K
+Samsung,Galaxy J7(2016),j7xltectc,SM-J7109
+Samsung,Galaxy J7(2017),j7y17lte,SM-J730F
+Samsung,Galaxy J7(2017),j7y17lte,SM-J730FM
+Samsung,Galaxy J7(2017),j7y17lte,SM-J730G
+Samsung,Galaxy J7(2017),j7y17lte,SM-J730GM
+Samsung,Galaxy J7(2017),j7y17ltektt,SM-J730K
+Samsung,Galaxy J7+,jadelte,SM-C710F
+Samsung,Galaxy K,SHW-M130K,SHW-M130K
+Samsung,Galaxy K Zoom,m2a3g,SM-C111
+Samsung,Galaxy K Zoom,m2a3g,SM-C111M
+Samsung,Galaxy K Zoom,m2alte,SM-C115
+Samsung,Galaxy K Zoom,m2alte,SM-C115M
+Samsung,Galaxy K Zoom,m2altecan,SM-C115W
+Samsung,Galaxy K Zoom,m2altelgt,SM-C115L
+Samsung,Galaxy M Pro2,lucas,GT-B7810
+Samsung,Galaxy M Style,SHW-M340L,SHW-M340L
+Samsung,Galaxy M Style,SHW-M340S,SHW-M340S
+Samsung,Galaxy M Style,vastoicmcc,GT-I8258
+Samsung,Galaxy Mega 2,mega23g,SM-G750H
+Samsung,Galaxy Mega 5.8,crater,GT-I9152
+Samsung,Galaxy Mega 5.8,crater3gctc,SCH-P709
+Samsung,Galaxy Mega 5.8,craterss,GT-I9150
+Samsung,Galaxy Mega 5.8,cratertd3g,GT-I9158
+Samsung,Galaxy Mega 6.3,melius3g,GT-I9200
+Samsung,Galaxy Mega 6.3,melius3g,GT-I9208
+Samsung,Galaxy Mega 6.3,melius3gduosctc,SCH-P729
+Samsung,Galaxy Mega 6.3,meliuslte,GT-I9205
+Samsung,Galaxy Mega 6.3,meliuslteMetroPCS,SGH-M819N
+Samsung,Galaxy Mega 6.3,meliuslteatt,SAMSUNG-SGH-I527
+Samsung,Galaxy Mega 6.3,meliusltecan,SGH-I527M
+Samsung,Galaxy Mega 6.3,meliusltektt,SHV-E310K
+Samsung,Galaxy Mega 6.3,meliusltelgt,SHV-E310L
+Samsung,Galaxy Mega 6.3,meliuslteskt,SHV-E310S
+Samsung,Galaxy Mega 6.3,meliusltespr,SPH-L600
+Samsung,Galaxy Mega 6.3,meliuslteusc,SCH-R960
+Samsung,Galaxy Mega Plus,craterq3g,GT-I9152P
+Samsung,Galaxy Mega Plus,craterq3g,GT-I9158P
+Samsung,Galaxy Mega Plus,megapluslte,GT-I9158V
+Samsung,Galaxy Mega2,mega2lte,SM-G750F
+Samsung,Galaxy Mega2,mega2lteatt,SAMSUNG-SM-G750A
+Samsung,Galaxy Mega2,vasta3g,SM-G750H
+Samsung,Galaxy Mega2,vastalte,SM-G7508Q
+Samsung,Galaxy Mega2,vastaltezh,SM-G7508Q
+Samsung,Galaxy Mini,GT-S5570,GT-S5570
+Samsung,Galaxy Mini,GT-S5570B,GT-S5570B
+Samsung,Galaxy Mini,GT-S5570I,GT-S5570I
+Samsung,Galaxy Mini,GT-S5570L,GT-S5570L
+Samsung,Galaxy Mini,GT-S5578,GT-S5578
+Samsung,Galaxy Mini,SGH-T499,SGH-T499
+Samsung,Galaxy Mini,SGH-T499V,SGH-T499V
+Samsung,Galaxy Mini,SGH-T499Y,SGH-T499Y
+Samsung,Galaxy Mini2,GT-S6500,GT-S6500
+Samsung,Galaxy Mini2,GT-S6500D,GT-S6500D
+Samsung,Galaxy Mini2,GT-S6500L,GT-S6500L
+Samsung,Galaxy Mini2,GT-S6500T,GT-S6500T
+Samsung,Galaxy Music,ivoryss,GT-S6010
+Samsung,Galaxy Music,ivoryss,GT-S6010L
+Samsung,Galaxy Music Duos,ivory,GT-S6012
+Samsung,Galaxy Music Duos,ivory,GT-S6012B
+Samsung,Galaxy NX,u0lte,EK-GN120
+Samsung,Galaxy NX,u0lte,EK-GN120A
+Samsung,Galaxy NX,u0lteue,EK-GN120A
+Samsung,Galaxy Neo,SHW-M220L,SHW-M220L
+Samsung,Galaxy Nexus,maguro,Galaxy Nexus
+Samsung,Galaxy Nexus,maguro,Galaxy X
+Samsung,Galaxy Nexus,toro,Galaxy Nexus
+Samsung,Galaxy Nexus,toroplus,Galaxy Nexus
+Samsung,Galaxy Note,GT-I9220,GT-I9220
+Samsung,Galaxy Note,GT-I9228,GT-I9228
+Samsung,Galaxy Note,GT-N7000,GT-N7000
+Samsung,Galaxy Note,GT-N7005,GT-N7005
+Samsung,Galaxy Note,SC-05D,SC-05D
+Samsung,Galaxy Note,SCH-i889,SCH-i889
+Samsung,Galaxy Note,SGH-I717,SAMSUNG-SGH-I717
+Samsung,Galaxy Note,SGH-I717,SGH-I717
+Samsung,Galaxy Note,SGH-I717D,SGH-I717D
+Samsung,Galaxy Note,SGH-I717M,SGH-I717M
+Samsung,Galaxy Note,SGH-I717R,SGH-I717R
+Samsung,Galaxy Note,SGH-T879,SGH-T879
+Samsung,Galaxy Note,SHV-E160K,SHV-E160K
+Samsung,Galaxy Note,SHV-E160L,SHV-E160L
+Samsung,Galaxy Note,SHV-E160S,SHV-E160S
+Samsung,Galaxy Note 10.1,lt033g,SM-P601
+Samsung,Galaxy Note 10.1,lt033g,SM-P602
+Samsung,Galaxy Note 10.1,lt03ltektt,SM-P605K
+Samsung,Galaxy Note 10.1,lt03ltelgt,SM-P605L
+Samsung,Galaxy Note 10.1,lt03lteskt,SM-P605S
+Samsung,Galaxy Note 10.1,p4notelte,GT-N8020
+Samsung,Galaxy Note 10.1,p4noteltektt,SHV-E230K
+Samsung,Galaxy Note 10.1,p4noteltelgt,SHV-E230L
+Samsung,Galaxy Note 10.1,p4notelteskt,SHV-E230S
+Samsung,Galaxy Note 10.1,p4noteltespr,SPH-P600
+Samsung,Galaxy Note 10.1,p4notelteusc,SCH-I925U
+Samsung,Galaxy Note 10.1,p4noteltevzw,SCH-I925
+Samsung,Galaxy Note 10.1,p4noterf,GT-N8000
+Samsung,Galaxy Note 10.1,p4noterf,GT-N8005
+Samsung,Galaxy Note 10.1,p4noterfktt,SHW-M480K
+Samsung,Galaxy Note 10.1,p4notewifi,GT-N8013
+Samsung,Galaxy Note 10.1,p4notewifi43241any,SHW-M486W
+Samsung,Galaxy Note 10.1,p4notewifiany,SHW-M480W
+Samsung,Galaxy Note 10.1,p4notewifiktt,SHW-M485W
+Samsung,Galaxy Note 10.1,p4notewifiww,GT-N8010
+Samsung,Galaxy Note 10.1 2014 Edition,lt033g,SM-P601
+Samsung,Galaxy Note 10.1 2014 Edition,lt03lte,SM-P605
+Samsung,Galaxy Note 10.1 2014 Edition,lt03lte,SM-P605M
+Samsung,Galaxy Note 10.1 2014 Edition,lt03ltetmo,SM-P607T
+Samsung,Galaxy Note 10.1 2014 Edition,lt03ltevzw,SM-P605V
+Samsung,Galaxy Note 10.1 2014 Edition,lt03wifi,SM-P600
+Samsung,Galaxy Note 10.1 2014 Edition,lt03wifikx,SM-P600
+Samsung,Galaxy Note 10.1 2014 Edition,lt03wifiue,SM-P600
+Samsung,Galaxy Note 8.0,kona3g,GT-N5100
+Samsung,Galaxy Note 8.0,kona3g,GT-N5105
+Samsung,Galaxy Note 8.0,konalte,GT-N5120
+Samsung,Galaxy Note 8.0,konalteatt,SAMSUNG-SGH-I467
+Samsung,Galaxy Note 8.0,konaltecan,SGH-I467M
+Samsung,Galaxy Note 8.0,konawifi,GT-N5110
+Samsung,Galaxy Note 8.0,konawifiany,SHW-M500W
+Samsung,Galaxy Note Edge,SC-01G,SC-01G
+Samsung,Galaxy Note Edge,SCL24,SCL24
+Samsung,Galaxy Note Edge,tbeltektt,SM-N915K
+Samsung,Galaxy Note Edge,tbeltelgt,SM-N915L
+Samsung,Galaxy Note Edge,tbelteskt,SM-N915S
+Samsung,Galaxy Note Edge,tblte,SM-N9150
+Samsung,Galaxy Note Edge,tblte,SM-N915F
+Samsung,Galaxy Note Edge,tblte,SM-N915FY
+Samsung,Galaxy Note Edge,tblte,SM-N915G
+Samsung,Galaxy Note Edge,tblte,SM-N915X
+Samsung,Galaxy Note Edge,tblteatt,SAMSUNG-SM-N915A
+Samsung,Galaxy Note Edge,tbltecan,SM-N915W8
+Samsung,Galaxy Note Edge,tbltechn,SM-N9150
+Samsung,Galaxy Note Edge,tbltespr,SM-N915P
+Samsung,Galaxy Note Edge,tbltetmo,SM-N915T
+Samsung,Galaxy Note Edge,tbltetmo,SM-N915T3
+Samsung,Galaxy Note Edge,tblteusc,SM-N915R4
+Samsung,Galaxy Note Edge,tbltevzw,SM-N915V
+Samsung,Galaxy Note Fan Edition,gracerlte,SM-N935F
+Samsung,Galaxy Note Fan Edition,gracerltektt,SM-N935K
+Samsung,Galaxy Note Fan Edition,gracerltelgt,SM-N935L
+Samsung,Galaxy Note Fan Edition,gracerlteskt,SM-N935S
+Samsung,Galaxy Note II,t0lteatt,SAMSUNG-SGH-I317
+Samsung,Galaxy Note Pro 12.2,v1a3g,SM-P901
+Samsung,Galaxy Note Pro 12.2,v1awifi,SM-P900
+Samsung,Galaxy Note Pro 12.2,v1awifikx,SM-P900
+Samsung,Galaxy Note Pro 12.2,viennalte,SM-P905
+Samsung,Galaxy Note Pro 12.2,viennalte,SM-P905M
+Samsung,Galaxy Note Pro 12.2,viennalteatt,SAMSUNG-SM-P907A
+Samsung,Galaxy Note Pro 12.2,viennaltekx,SM-P905F0
+Samsung,Galaxy Note Pro 12.2,viennaltevzw,SM-P905V
+Samsung,Galaxy Note2,SC-02E,SC-02E
+Samsung,Galaxy Note2,t03g,GT-N7100
+Samsung,Galaxy Note2,t03g,GT-N7100T
+Samsung,Galaxy Note2,t03gchn,GT-N7100
+Samsung,Galaxy Note2,t03gchnduos,GT-N7102
+Samsung,Galaxy Note2,t03gchnduos,GT-N7102i
+Samsung,Galaxy Note2,t03gcmcc,GT-N7108
+Samsung,Galaxy Note2,t03gctc,SCH-N719
+Samsung,Galaxy Note2,t03gcuduos,GT-N7102
+Samsung,Galaxy Note2,t03gcuduos,GT-N7102i
+Samsung,Galaxy Note2,t0lte,GT-N7105
+Samsung,Galaxy Note2,t0lte,GT-N7105T
+Samsung,Galaxy Note2,t0lteatt,SAMSUNG-SGH-I317
+Samsung,Galaxy Note2,t0ltecan,SGH-I317M
+Samsung,Galaxy Note2,t0ltecan,SGH-T889V
+Samsung,Galaxy Note2,t0ltecmcc,GT-N7108D
+Samsung,Galaxy Note2,t0ltedcm,SC-02E
+Samsung,Galaxy Note2,t0ltektt,SHV-E250K
+Samsung,Galaxy Note2,t0ltelgt,SHV-E250L
+Samsung,Galaxy Note2,t0lteskt,SHV-E250S
+Samsung,Galaxy Note2,t0ltespr,SPH-L900
+Samsung,Galaxy Note2,t0ltetmo,SGH-T889
+Samsung,Galaxy Note2,t0lteusc,SCH-R950
+Samsung,Galaxy Note2,t0ltevzw,SCH-I605
+Samsung,Galaxy Note3,SC-01F,SC-01F
+Samsung,Galaxy Note3,SC-02F,SC-02F
+Samsung,Galaxy Note3,SCL22,SCL22
+Samsung,Galaxy Note3,ha3g,SM-N900
+Samsung,Galaxy Note3,ha3g,SM-N9000Q
+Samsung,Galaxy Note3,hlte,SM-N9005
+Samsung,Galaxy Note3,hlte,SM-N9006
+Samsung,Galaxy Note3,hlte,SM-N9007
+Samsung,Galaxy Note3,hlte,SM-N9008V
+Samsung,Galaxy Note3,hlte,SM-N9009
+Samsung,Galaxy Note3,hlte,SM-N900U
+Samsung,Galaxy Note3,hlteatt,SAMSUNG-SM-N900A
+Samsung,Galaxy Note3,hltecan,SM-N900W8
+Samsung,Galaxy Note3,hltektt,SM-N900K
+Samsung,Galaxy Note3,hltelgt,SM-N900L
+Samsung,Galaxy Note3,hlteskt,SM-N900S
+Samsung,Galaxy Note3,hltespr,SM-N900P
+Samsung,Galaxy Note3,hltetmo,SM-N900T
+Samsung,Galaxy Note3,hlteusc,SM-N900R4
+Samsung,Galaxy Note3,hltevzw,SM-N900V
+Samsung,Galaxy Note3,htdlte,SM-N9007
+Samsung,Galaxy Note3 Duos,hlte,SM-N9002
+Samsung,Galaxy Note3 Duos,hlte,SM-N9008
+Samsung,Galaxy Note3 Neo,frescoltektt,SM-N750K
+Samsung,Galaxy Note3 Neo,frescoltelgt,SM-N750L
+Samsung,Galaxy Note3 Neo,frescolteskt,SM-N750S
+Samsung,Galaxy Note3 Neo,hl3g,SM-N750
+Samsung,Galaxy Note3 Neo,hl3g,SM-N7500Q
+Samsung,Galaxy Note3 Neo,hl3gds,SM-N7502
+Samsung,Galaxy Note3 Neo,hllte,SM-N7505
+Samsung,Galaxy Note3 Neo,hllte,SM-N7505L
+Samsung,Galaxy Note3 Neo,hllte,SM-N7507
+Samsung,Galaxy Note4,tre3caltektt,SM-N916K
+Samsung,Galaxy Note4,tre3caltelgt,SM-N916L
+Samsung,Galaxy Note4,tre3calteskt,SM-N916S
+Samsung,Galaxy Note4,tre3g,SM-N910H
+Samsung,Galaxy Note4,trelte,SM-N910C
+Samsung,Galaxy Note4,treltektt,SM-N910K
+Samsung,Galaxy Note4,treltelgt,SM-N910L
+Samsung,Galaxy Note4,trelteskt,SM-N910S
+Samsung,Galaxy Note4,trhplte,SM-N910U
+Samsung,Galaxy Note4,trlte,SM-N910F
+Samsung,Galaxy Note4,trlte,SM-N910G
+Samsung,Galaxy Note4,trlte,SM-N910X
+Samsung,Galaxy Note4,trlteatt,SAMSUNG-SM-N910A
+Samsung,Galaxy Note4,trlteatt,SM-N910F
+Samsung,Galaxy Note4,trltecan,SM-N910W8
+Samsung,Galaxy Note4,trltechn,SM-N9100
+Samsung,Galaxy Note4,trltechn,SM-N9106W
+Samsung,Galaxy Note4,trltechn,SM-N9108V
+Samsung,Galaxy Note4,trltechn,SM-N9109W
+Samsung,Galaxy Note4,trltechnzh,SM-N9100
+Samsung,Galaxy Note4,trltespr,SM-N910P
+Samsung,Galaxy Note4,trltetmo,SM-N910T
+Samsung,Galaxy Note4,trltetmo,SM-N910T2
+Samsung,Galaxy Note4,trltetmo,SM-N910T3
+Samsung,Galaxy Note4,trlteusc,SM-N910R4
+Samsung,Galaxy Note4,trltevzw,SM-N910V
+Samsung,Galaxy Note5,noblelte,SM-N9208
+Samsung,Galaxy Note5,noblelte,SM-N920C
+Samsung,Galaxy Note5,noblelte,SM-N920F
+Samsung,Galaxy Note5,noblelte,SM-N920G
+Samsung,Galaxy Note5,noblelte,SM-N920I
+Samsung,Galaxy Note5,noblelte,SM-N920X
+Samsung,Galaxy Note5,noblelteacg,SM-N920R7
+Samsung,Galaxy Note5,noblelteatt,SAMSUNG-SM-N920A
+Samsung,Galaxy Note5,nobleltebmc,SM-N920W8
+Samsung,Galaxy Note5,nobleltechn,SM-N9200
+Samsung,Galaxy Note5,nobleltecmcc,SM-N9208
+Samsung,Galaxy Note5,nobleltehk,SM-N9200
+Samsung,Galaxy Note5,nobleltektt,SM-N920K
+Samsung,Galaxy Note5,nobleltelgt,SM-N920L
+Samsung,Galaxy Note5,nobleltelra,SM-N920R6
+Samsung,Galaxy Note5,noblelteskt,SM-N920S
+Samsung,Galaxy Note5,nobleltespr,SM-N920P
+Samsung,Galaxy Note5,nobleltetmo,SM-N920T
+Samsung,Galaxy Note5,noblelteusc,SM-N920R4
+Samsung,Galaxy Note5,nobleltevzw,SM-N920V
+Samsung,Galaxy Note7,SC-01J,SC-01J
+Samsung,Galaxy Note7,SCV34,SCV34
+Samsung,Galaxy Note7,gracelte,SM-N930F
+Samsung,Galaxy Note7,gracelte,SM-N930X
+Samsung,Galaxy Note7,graceltektt,SM-N930K
+Samsung,Galaxy Note7,graceltelgt,SM-N930L
+Samsung,Galaxy Note7,gracelteskt,SM-N930S
+Samsung,Galaxy Note7,graceqlteacg,SM-N930R7
+Samsung,Galaxy Note7,graceqlteatt,SAMSUNG-SM-N930A
+Samsung,Galaxy Note7,graceqltebmc,SM-N930W8
+Samsung,Galaxy Note7,graceqltechn,SM-N9300
+Samsung,Galaxy Note7,graceqltedcm,SGH-N037
+Samsung,Galaxy Note7,graceqltelra,SM-N930R6
+Samsung,Galaxy Note7,graceqltespr,SM-N930P
+Samsung,Galaxy Note7,graceqltetfnvzw,SM-N930VL
+Samsung,Galaxy Note7,graceqltetmo,SM-N930T
+Samsung,Galaxy Note7,graceqlteue,SM-N930U
+Samsung,Galaxy Note7,graceqlteusc,SM-N930R4
+Samsung,Galaxy Note7,graceqltevzw,SM-N930V
+Samsung,Galaxy Note8,SC-01K,SC-01K
+Samsung,Galaxy Note8,SCV37,SCV37
+Samsung,Galaxy Note8,greatlte,SM-N950F
+Samsung,Galaxy Note8,greatlteks,SM-N950N
+Samsung,Galaxy Note8,greatlteks,SM-N950XN
+Samsung,Galaxy Note8,greatqlte,SM-N950U
+Samsung,Galaxy Note8,greatqltechn,SM-N9500
+Samsung,Galaxy Note8,greatqltecmcc,SM-N9508
+Samsung,Galaxy Note8,greatqltecs,SM-N950W
+Samsung,Galaxy Note8,greatqlteue,SM-N950U1
+Samsung,Galaxy On Max,j7maxlte,SM-G615FU
+Samsung,Galaxy On Nxt,on7xelte,SM-G610F
+Samsung,Galaxy On5,o5lte,SM-G550FY
+Samsung,Galaxy On5,o5ltechn,SM-G5500
+Samsung,Galaxy On5,o5prolte,SM-G550FY
+Samsung,Galaxy On5,on5ltemtr,SM-G550T1
+Samsung,Galaxy On5,on5ltetfntmo,SM-S550TL
+Samsung,Galaxy On5,on5ltetmo,SM-G550T
+Samsung,Galaxy On5,on5ltetmo,SM-G550T2
+Samsung,Galaxy On5(2016),on5xfltechn,SM-G5520
+Samsung,Galaxy On5(2016),on5xfltechn,SM-G5528
+Samsung,Galaxy On5(2016),on5xlltechn,SM-G5510
+Samsung,Galaxy On5(2016),on5xltechn,SM-G5700
+Samsung,Galaxy On7,o7lte,SM-G600FY
+Samsung,Galaxy On7,o7ltechn,SM-G6000
+Samsung,Galaxy On7,on7elte,SM-G600F
+Samsung,Galaxy On7 Pro,o7prolte,SM-G600FY
+Samsung,Galaxy On7(2016),on7xeltektt,SM-G610K
+Samsung,Galaxy On7(2016),on7xeltelgt,SM-G610L
+Samsung,Galaxy On7(2016),on7xelteskt,SM-G610S
+Samsung,Galaxy On7(2016),on7xltechn,SM-G6100
+Samsung,Galaxy On8,j7xlte,SM-J710FN
+Samsung,Galaxy Player,YP-GB70,YP-GB70
+Samsung,Galaxy Player 3.6,YP-GS1,YP-GS1
+Samsung,Galaxy Player 4,YP-GB1,YP-GB1
+Samsung,Galaxy Player 4.0,YP-G1,YP-G1
+Samsung,Galaxy Player 4.2,YP-GI1,YP-GI1
+Samsung,Galaxy Player 5,YP-G70,YP-G70
+Samsung,Galaxy Player 5.8,harrison,YP-GP1
+Samsung,Galaxy Player 5.8,harrisonkrktt,YP-GP1
+Samsung,Galaxy Player 5.8,harrisonkrlgt,YP-GP1
+Samsung,Galaxy Player 50,YP-G50,YP-G50
+Samsung,Galaxy Pocket,GT-S5300,GT-S5300
+Samsung,Galaxy Pocket,GT-S5300B,GT-S5300B
+Samsung,Galaxy Pocket,GT-S5300L,GT-S5300L
+Samsung,Galaxy Pocket,GT-S5302,GT-S5302
+Samsung,Galaxy Pocket,GT-S5302B,GT-S5302B
+Samsung,Galaxy Pocket,coriplus,GT-S5301
+Samsung,Galaxy Pocket,coriplusds,GT-S5303
+Samsung,Galaxy Pocket Neo,corsica,GT-S5312
+Samsung,Galaxy Pocket Neo,corsica,GT-S5312B
+Samsung,Galaxy Pocket Neo,corsica,GT-S5312L
+Samsung,Galaxy Pocket Neo,corsicass,GT-S5310
+Samsung,Galaxy Pocket Neo,corsicass,GT-S5310B
+Samsung,Galaxy Pocket Neo,corsicass,GT-S5310E
+Samsung,Galaxy Pocket Neo,corsicass,GT-S5310G
+Samsung,Galaxy Pocket Neo,corsicass,GT-S5310L
+Samsung,Galaxy Pocket Neo,corsicass,GT-S5310T
+Samsung,Galaxy Pocket Neo,corsicave3g,GT-S5310I
+Samsung,Galaxy Pocket Neo,corsicave3g,GT-S5310N
+Samsung,Galaxy Pocket Neo,corsicaveds3gvj,GT-S5312C
+Samsung,Galaxy Pocket Neo,corsicaveds3gvj,GT-S5312M
+Samsung,Galaxy Pocket Neo,d2aio,SAMSUNG-SGH-I747Z
+Samsung,Galaxy Pocket Plus,coriplus,GT-S5301
+Samsung,Galaxy Pocket Plus,coriplus,GT-S5301B
+Samsung,Galaxy Pocket Plus,coriplus,GT-S5301L
+Samsung,Galaxy Pocket SS,corsicave3g,GT-S5310C
+Samsung,Galaxy Pocket SS,corsicave3g,GT-S5310M
+Samsung,Galaxy Pocket2,pocket23g,SM-G110B
+Samsung,Galaxy Pocket2,pocket23g,SM-G110M
+Samsung,Galaxy Pocket2,pocket2ss3g,SM-G110H
+Samsung,Galaxy Pop,superiorlteskt,SHV-E220S
+Samsung,Galaxy Pop (CDMA),SCH-i559,SCH-i559
+Samsung,Galaxy Precedent,SCH-M828C,SCH-M828C
+Samsung,Galaxy Premier,superior,GT-I9260
+Samsung,Galaxy Premier,superiorcmcc,GT-I9268
+Samsung,Galaxy Prevail,SPH-M820,SPH-M820-BST
+Samsung,Galaxy Prevail2,raybst,SPH-M840
+Samsung,Galaxy Pro,GT-B7510,GT-B7510
+Samsung,Galaxy Pro,GT-B7510B,GT-B7510B
+Samsung,Galaxy Pro,GT-B7510L,GT-B7510L
+Samsung,Galaxy Proclaim,SCH-S720C,SCH-S720C
+Samsung,Galaxy Q,SGH-T589,SGH-T589
+Samsung,Galaxy Q,SGH-T589R,SGH-T589R
+Samsung,Galaxy Q,SGH-T589W,SGH-T589W
+Samsung,Galaxy R-Style,jaguark,SHV-E170K
+Samsung,Galaxy R-Style,jaguarl,SHV-E170L
+Samsung,Galaxy R-Style,jaguars,SHV-E170S
+Samsung,Galaxy Reverb,iconvmu,SPH-M950
+Samsung,Galaxy Round,flteskt,SM-G910S
+Samsung,Galaxy Rugby,comanchecan,SGH-I547C
+Samsung,Galaxy Rugby Pro,comancheatt,SAMSUNG-SGH-I547
+Samsung,Galaxy Rush,prevail2spr,SPH-M830
+Samsung,Galaxy S,GT-I9000,GT-I9000
+Samsung,Galaxy S,GT-I9000B,GT-I9000B
+Samsung,Galaxy S,GT-I9000M,GT-I9000M
+Samsung,Galaxy S,GT-I9000T,GT-I9000T
+Samsung,Galaxy S,GT-I9003,GT-I9003
+Samsung,Galaxy S,GT-I9003L,GT-I9003L
+Samsung,Galaxy S,GT-I9008L,GT-I9008L
+Samsung,Galaxy S,GT-I9010,GT-I9010
+Samsung,Galaxy S,GT-I9018,GT-I9018
+Samsung,Galaxy S,GT-I9050,GT-I9050
+Samsung,Galaxy S,SC-02B,SC-02B
+Samsung,Galaxy S,SCH-I500,SCH-I500
+Samsung,Galaxy S,SCH-S950C,SCH-S950C
+Samsung,Galaxy S,SCH-i909,SCH-i909
+Samsung,Galaxy S,SGH-I897,SAMSUNG-SGH-I897
+Samsung,Galaxy S,SGH-T959V,SGH-T959V
+Samsung,Galaxy S,SGH-T959W,SGH-T959W
+Samsung,Galaxy S,SHW-M110S,SHW-M110S
+Samsung,Galaxy S,SHW-M190S,SHW-M190S
+Samsung,Galaxy S,SPH-D700,SPH-D700
+Samsung,Galaxy S,loganlte,GT-S7275
+Samsung,Galaxy S Advance,GT-I9070,GT-I9070
+Samsung,Galaxy S Advance,GT-I9070P,GT-I9070P
+Samsung,Galaxy S Aviator,SCH-R930,SCH-R930
+Samsung,Galaxy S Blaze,SGH-T769,SGH-T769
+Samsung,Galaxy S BlazeQ,apexqtmo,SGH-T699
+Samsung,Galaxy S Captivate,SGH-I896,SAMSUNG-SGH-I896
+Samsung,Galaxy S Captivate,SGH-I896,SGH-I896
+Samsung,Galaxy S Continuum,SCH-I400,SCH-I400
+Samsung,Galaxy S DUOS,kyleopen,GT-S7562
+Samsung,Galaxy S DUOS,kyleopen,GT-S7562L
+Samsung,Galaxy S Duos,kylechn,GT-S7562
+Samsung,Galaxy S Duos,kyleopen,GT-S7562
+Samsung,Galaxy S Duos,kyletdcmcc,GT-S7568
+Samsung,Galaxy S Duos2,kyleprods,GT-S7582
+Samsung,Galaxy S Duos2,kyleprods,GT-S7582L
+Samsung,Galaxy S Duos3,vivalto3gvn,SM-G313HZ
+Samsung,Galaxy S Epic,SPH-D700,SPH-D700
+Samsung,Galaxy S Fascinate,SGH-T959P,SGH-T959P
+Samsung,Galaxy S Glide,SGH-I927R,SAMSUNG-SGH-I927R
+Samsung,Galaxy S Lightray,SCH-R940,SCH-R940
+Samsung,Galaxy S Plus,GT-I9001,GT-I9001
+Samsung,Galaxy S Stratosphere,SCH-I405,SCH-I405
+Samsung,Galaxy S Vibrant,SGH-T959,SGH-T959
+Samsung,Galaxy S Vibrant,SGH-T959D,SGH-T959D
+Samsung,Galaxy S duos,kyleichn,GT-S7566
+Samsung,Galaxy S2,GT-I9100,GT-I9100
+Samsung,Galaxy S2,GT-I9100M,GT-I9100M
+Samsung,Galaxy S2,GT-I9100P,GT-I9100P
+Samsung,Galaxy S2,GT-I9100T,GT-I9100T
+Samsung,Galaxy S2,GT-I9103,GT-I9103
+Samsung,Galaxy S2,GT-I9108,GT-I9108
+Samsung,Galaxy S2,GT-I9210T,GT-I9210T
+Samsung,Galaxy S2,SC-02C,SC-02C
+Samsung,Galaxy S2,SCH-R760X,SCH-R760X
+Samsung,Galaxy S2,SGH-I777,SAMSUNG-SGH-I777
+Samsung,Galaxy S2,SGH-S959G,SGH-S959G
+Samsung,Galaxy S2,SGH-T989,SGH-T989
+Samsung,Galaxy S2,SHV-E110S,SHV-E110S
+Samsung,Galaxy S2,SHW-M250K,SHW-M250K
+Samsung,Galaxy S2,SHW-M250L,SHW-M250L
+Samsung,Galaxy S2,SHW-M250S,SHW-M250S
+Samsung,Galaxy S2,t1cmcc,GT-I9108
+Samsung,Galaxy S2 Duos,SCH-i929,SCH-i929
+Samsung,Galaxy S2 Duos TV,logandsdtv,GT-S7273T
+Samsung,Galaxy S2 Epic,SCH-R760,SCH-R760
+Samsung,Galaxy S2 Epic,SPH-D710,SPH-D710
+Samsung,Galaxy S2 Epic,SPH-D710BST,SPH-D710BST
+Samsung,Galaxy S2 Epic,SPH-D710VMUB,SPH-D710VMUB
+Samsung,Galaxy S2 HD LTE,SGH-I757M,SGH-I757M
+Samsung,Galaxy S2 HD LTE,SHV-E120K,SHV-E120K
+Samsung,Galaxy S2 HD LTE,SHV-E120L,SHV-E120L
+Samsung,Galaxy S2 HD LTE,SHV-E120S,SHV-E120S
+Samsung,Galaxy S2 LTE,GT-I9210,GT-I9210
+Samsung,Galaxy S2 LTE,SC-03D,SC-03D
+Samsung,Galaxy S2 LTE,SGH-I727R,SGH-I727R
+Samsung,Galaxy S2 Plus,GT-I9100G,GT-I9100G
+Samsung,Galaxy S2 Plus,s2ve,GT-I9105
+Samsung,Galaxy S2 Plus,s2vep,GT-I9105P
+Samsung,Galaxy S2 Skyrocket,SGH-I727,SAMSUNG-SGH-I727
+Samsung,Galaxy S2 Skyrocket,SGH-I727,SGH-I727
+Samsung,Galaxy S2 Wimax,ISW11SC,ISW11SC
+Samsung,Galaxy S2 X,SGH-T989D,SGH-T989D
+Samsung,Galaxy S3,SC-03E,SC-03E
+Samsung,Galaxy S3,c1att,SGH-I748
+Samsung,Galaxy S3,c1ktt,SHV-E210K
+Samsung,Galaxy S3,c1lgt,SHV-E210L
+Samsung,Galaxy S3,c1skt,SHV-E210S
+Samsung,Galaxy S3,d2att,SAMSUNG-SGH-I747
+Samsung,Galaxy S3,d2can,SGH-I747M
+Samsung,Galaxy S3,d2can,SGH-T999V
+Samsung,Galaxy S3,d2cri,SCH-R530C
+Samsung,Galaxy S3,d2dcm,Gravity
+Samsung,Galaxy S3,d2dcm,SC-06D
+Samsung,Galaxy S3,d2lteMetroPCS,SGH-T999N
+Samsung,Galaxy S3,d2lterefreshspr,SPH-L710T
+Samsung,Galaxy S3,d2ltetmo,SGH-T999L
+Samsung,Galaxy S3,d2mtr,SCH-R530M
+Samsung,Galaxy S3,d2spi,SCH-L710
+Samsung,Galaxy S3,d2spr,SPH-L710
+Samsung,Galaxy S3,d2tfnspr,SCH-S960L
+Samsung,Galaxy S3,d2tfnvzw,SCH-S968C
+Samsung,Galaxy S3,d2tmo,SGH-T999
+Samsung,Galaxy S3,d2usc,SCH-R530U
+Samsung,Galaxy S3,d2vmu,SPH-L710
+Samsung,Galaxy S3,d2vzw,SCH-I535
+Samsung,Galaxy S3,d2vzw,SCH-I535PP
+Samsung,Galaxy S3,d2xar,SCH-R530X
+Samsung,Galaxy S3,m0,GT-I9300
+Samsung,Galaxy S3,m0,GT-I9300T
+Samsung,Galaxy S3,m0apt,SCH-I939
+Samsung,Galaxy S3,m0chn,GT-I9300
+Samsung,Galaxy S3,m0cmcc,GT-I9308
+Samsung,Galaxy S3,m0ctc,SCH-I939
+Samsung,Galaxy S3,m0ctcduos,SCH-I939D
+Samsung,Galaxy S3,m0skt,SHW-M440S
+Samsung,Galaxy S3,m3,GT-I9305
+Samsung,Galaxy S3,m3,GT-I9305N
+Samsung,Galaxy S3,m3,GT-I9305T
+Samsung,Galaxy S3,m3dcm,GravityQuad
+Samsung,Galaxy S3,m3dcm,SC-03E
+Samsung,Galaxy S3 Duos,arubaslim,GT-I8262B
+Samsung,Galaxy S3 Mini,golden,GT-I8190
+Samsung,Galaxy S3 Mini,golden,GT-I8190L
+Samsung,Galaxy S3 Mini,golden,GT-I8190N
+Samsung,Galaxy S3 Mini,golden,GT-I8190T
+Samsung,Galaxy S3 Mini,goldenlteatt,SAMSUNG-SM-G730A
+Samsung,Galaxy S3 Mini,goldenltebmc,SM-G730W8
+Samsung,Galaxy S3 Mini,goldenltevzw,SM-G730V
+Samsung,Galaxy S3 Mini,goldenve3g,GT-I8200L
+Samsung,Galaxy S3 Mini Value Edition,goldenve3g,GT-I8200N
+Samsung,Galaxy S3 Mini Value Edition,goldenvess3g,GT-I8200
+Samsung,Galaxy S3 Mini Value Edition,goldenvess3g,GT-I8200Q
+Samsung,Galaxy S3 Neo,s3ve3g,GT-I9300I
+Samsung,Galaxy S3 Neo,s3ve3g,GT-I9301I
+Samsung,Galaxy S3 Neo,s3ve3g,GT-I9301Q
+Samsung,Galaxy S3 Neo,s3ve3gdd,GT-I9300I
+Samsung,Galaxy S3 Neo,s3ve3gds,GT-I9300I
+Samsung,Galaxy S3 Neo,s3ve3gdsdd,GT-I9300I
+Samsung,Galaxy S3 Neo Plus,s3ve3g,GT-I9300I
+Samsung,Galaxy S3 Neo Plus,s3ve3g,GT-I9308I
+Samsung,Galaxy S3 Progre,SCL21,SCL21
+Samsung,Galaxy S3 Slim,wilcoxds,SM-G3812B
+Samsung,Galaxy S4,SC-04E,SC-04E
+Samsung,Galaxy S4,ja3g,GT-I9500
+Samsung,Galaxy S4,ja3gduosctc,SCH-I959
+Samsung,Galaxy S4,jaltektt,SHV-E300K
+Samsung,Galaxy S4,jaltelgt,SHV-E300L
+Samsung,Galaxy S4,jalteskt,SHV-E300S
+Samsung,Galaxy S4,jflte,GT-I9505
+Samsung,Galaxy S4,jflte,GT-I9508
+Samsung,Galaxy S4,jflte,GT-I9508C
+Samsung,Galaxy S4,jflteMetroPCS,SGH-M919N
+Samsung,Galaxy S4,jflteaio,SAMSUNG-SGH-I337Z
+Samsung,Galaxy S4,jflteatt,SAMSUNG-SGH-I337
+Samsung,Galaxy S4,jfltecan,SGH-I337M
+Samsung,Galaxy S4,jfltecan,SGH-M919V
+Samsung,Galaxy S4,jfltecri,SCH-R970C
+Samsung,Galaxy S4,jfltecsp,SCH-R970X
+Samsung,Galaxy S4,jfltelra,SCH-I545L
+Samsung,Galaxy S4,jflterefreshspr,SPH-L720T
+Samsung,Galaxy S4,jfltespr,SPH-L720
+Samsung,Galaxy S4,jfltetfnatt,SM-S975L
+Samsung,Galaxy S4,jfltetfntmo,SGH-S970G
+Samsung,Galaxy S4,jfltetmo,SGH-M919
+Samsung,Galaxy S4,jflteusc,SCH-R970
+Samsung,Galaxy S4,jfltevzw,SCH-I545
+Samsung,Galaxy S4,jfltevzwpp,SCH-I545PP
+Samsung,Galaxy S4,jftdd,GT-I9507
+Samsung,Galaxy S4,jftdd,GT-I9507V
+Samsung,Galaxy S4,jfvelte,GT-I9515
+Samsung,Galaxy S4,jfvelte,GT-I9515L
+Samsung,Galaxy S4,jfwifi,GT-I9505X
+Samsung,Galaxy S4,jsglte,GT-I9508V
+Samsung,Galaxy S4,ks01lte,GT-I9506
+Samsung,Galaxy S4,ks01ltektt,SHV-E330K
+Samsung,Galaxy S4,ks01ltelgt,SHV-E330L
+Samsung,Galaxy S4 Active,jactivelte,GT-I9295
+Samsung,Galaxy S4 Active,jactivelteatt,SAMSUNG-SGH-I537
+Samsung,Galaxy S4 Active,jactivelteatt,SGH-I537
+Samsung,Galaxy S4 Active,jactivelteskt,SHV-E470S
+Samsung,Galaxy S4 Duos,ja3gchnduos,GT-I9502
+Samsung,Galaxy S4 Google Play Edition,jgedlte,GT-I9505G
+Samsung,Galaxy S4 LTE-A,ks01lteskt,SHV-E330S
+Samsung,Galaxy S4 Mini,serrano3g,GT-I9190
+Samsung,Galaxy S4 Mini,serranods,GT-I9192
+Samsung,Galaxy S4 Mini,serranolte,GT-I9195
+Samsung,Galaxy S4 Mini,serranolte,GT-I9195L
+Samsung,Galaxy S4 Mini,serranolte,GT-I9195T
+Samsung,Galaxy S4 Mini,serranolte,GT-I9195X
+Samsung,Galaxy S4 Mini,serranolte,GT-I9197
+Samsung,Galaxy S4 Mini,serranoltebmc,SGH-I257M
+Samsung,Galaxy S4 Mini,serranoltektt,SHV-E370K
+Samsung,Galaxy S4 Mini,serranoltekx,SHV-E370D
+Samsung,Galaxy S4 Mini,serranoltelra,SCH-I435L
+Samsung,Galaxy S4 Mini,serranoltespr,SPH-L520
+Samsung,Galaxy S4 Mini,serranolteusc,SCH-R890
+Samsung,Galaxy S4 Mini,serranoltevzw,SCH-I435
+Samsung,Galaxy S4 Mini,serranove3g,GT-I9192I
+Samsung,Galaxy S4 Mini,serranovelte,GT-I9195I
+Samsung,Galaxy S4 Mini,serranovolteatt,SAMSUNG-SGH-I257
+Samsung,Galaxy S4 Zoom,mproject3g,SM-C101
+Samsung,Galaxy S4 Zoom,mprojectlteatt,SAMSUNG-SM-C105A
+Samsung,Galaxy S4 Zoom,mprojectltektt,SM-C105K
+Samsung,Galaxy S4 Zoom,mprojectltelgt,SM-C105L
+Samsung,Galaxy S4 Zoom,mprojectlteskt,SM-C105S
+Samsung,Galaxy S4 Zoom,mprojectqlte,SM-C105
+Samsung,Galaxy S5,SC-04F,SC-04F
+Samsung,Galaxy S5,SCL23,SCL23
+Samsung,Galaxy S5,k3g,SM-G900H
+Samsung,Galaxy S5,klte,SM-G9008W
+Samsung,Galaxy S5,klte,SM-G9009W
+Samsung,Galaxy S5,klte,SM-G900F
+Samsung,Galaxy S5,klte,SM-G900FQ
+Samsung,Galaxy S5,klte,SM-G900I
+Samsung,Galaxy S5,klte,SM-G900M
+Samsung,Galaxy S5,klte,SM-G900MD
+Samsung,Galaxy S5,klteMetroPCS,SM-G900T1
+Samsung,Galaxy S5,klteMetroPCS,SM-G900T4
+Samsung,Galaxy S5,klteacg,SM-G900R7
+Samsung,Galaxy S5,klteaio,SAMSUNG-SM-G900AZ
+Samsung,Galaxy S5,klteatt,SAMSUNG-SM-G900A
+Samsung,Galaxy S5,kltecan,SM-G900W8
+Samsung,Galaxy S5,klteduoszn,SM-G9006W
+Samsung,Galaxy S5,kltektt,SM-G900K
+Samsung,Galaxy S5,kltelgt,SM-G900L
+Samsung,Galaxy S5,kltelra,SM-G900R6
+Samsung,Galaxy S5,klteskt,SM-G900S
+Samsung,Galaxy S5,kltespr,SM-G900P
+Samsung,Galaxy S5,kltetfnvzw,SM-S903VL
+Samsung,Galaxy S5,kltetmo,SM-G900T
+Samsung,Galaxy S5,kltetmo,SM-G900T3
+Samsung,Galaxy S5,klteusc,SM-G900R4
+Samsung,Galaxy S5,kltevzw,SM-G900V
+Samsung,Galaxy S5,kwifi,SM-G900X
+Samsung,Galaxy S5,lentisltektt,SM-G906K
+Samsung,Galaxy S5,lentisltelgt,SM-G906L
+Samsung,Galaxy S5,lentislteskt,SM-G906S
+Samsung,Galaxy S5 Active,SC-02G,SC-02G
+Samsung,Galaxy S5 Active,kactiveltekx,SM-G870F0
+Samsung,Galaxy S5 Active,klteactive,SM-G870F
+Samsung,Galaxy S5 Active,klteattactive,SAMSUNG-SM-G870A
+Samsung,Galaxy S5 Active,kltecanactive,SM-G870W
+Samsung,Galaxy S5 Dual SIM,klte,SM-G900FD
+Samsung,Galaxy S5 Google Play Edition,kgedlte,SM-G900FG
+Samsung,Galaxy S5 K Sport,kltesprsports,SM-G860P
+Samsung,Galaxy S5 LTE-A,kccat6,SM-G901F
+Samsung,Galaxy S5 Mini,kmini3g,SM-G800H
+Samsung,Galaxy S5 Mini,kminilte,SM-G800F
+Samsung,Galaxy S5 Mini,kminilte,SM-G800Y
+Samsung,Galaxy S5 Mini,kminilteusc,SM-G800R4
+Samsung,Galaxy S5 Neo,s5neolte,SM-G903F
+Samsung,Galaxy S5 Neo,s5neolte,SM-G903M
+Samsung,Galaxy S5 Neo,s5neoltecan,SM-G903W
+Samsung,Galaxy S5 mini,kmini3g,SM-G800HQ
+Samsung,Galaxy S5 mini,kminilte,SM-G800M
+Samsung,Galaxy S5 mini,kminilteatt,SAMSUNG-SM-G800A
+Samsung,Galaxy S5 mini,kminiwifi,SM-G800X
+Samsung,Galaxy S5 mini LTE,kminilte,SM-G800Y
+Samsung,Galaxy S6,SC-05G,SC-05G
+Samsung,Galaxy S6,zeroflte,SM-G920F
+Samsung,Galaxy S6,zeroflte,SM-G920I
+Samsung,Galaxy S6,zeroflte,SM-G920X
+Samsung,Galaxy S6,zeroflteacg,SM-G920R7
+Samsung,Galaxy S6,zeroflteaio,SAMSUNG-SM-G920AZ
+Samsung,Galaxy S6,zeroflteatt,SAMSUNG-SM-G920A
+Samsung,Galaxy S6,zerofltebmc,SM-G920W8
+Samsung,Galaxy S6,zerofltechn,SM-G9200
+Samsung,Galaxy S6,zerofltechn,SM-G9208
+Samsung,Galaxy S6,zerofltectc,SM-G9209
+Samsung,Galaxy S6,zerofltektt,SM-G920K
+Samsung,Galaxy S6,zerofltelgt,SM-G920L
+Samsung,Galaxy S6,zerofltelra,SM-G920R6
+Samsung,Galaxy S6,zerofltemtr,SM-G920T1
+Samsung,Galaxy S6,zeroflteskt,SM-G920S
+Samsung,Galaxy S6,zerofltespr,SM-G920P
+Samsung,Galaxy S6,zerofltetfnvzw,SM-S906L
+Samsung,Galaxy S6,zerofltetfnvzw,SM-S907VL
+Samsung,Galaxy S6,zerofltetmo,SM-G920T
+Samsung,Galaxy S6,zeroflteusc,SM-G920R4
+Samsung,Galaxy S6,zerofltevzw,SM-G920V
+Samsung,Galaxy S6 Active,marinelteatt,SAMSUNG-SM-G890A
+Samsung,Galaxy S6 Edge,404SC,404SC
+Samsung,Galaxy S6 Edge,SC-04G,SC-04G
+Samsung,Galaxy S6 Edge,SCV31,SCV31
+Samsung,Galaxy S6 Edge,zerolte,SM-G925F
+Samsung,Galaxy S6 Edge,zerolte,SM-G925I
+Samsung,Galaxy S6 Edge,zerolte,SM-G925X
+Samsung,Galaxy S6 Edge,zerolteacg,SM-G925R7
+Samsung,Galaxy S6 Edge,zerolteatt,SAMSUNG-SM-G925A
+Samsung,Galaxy S6 Edge,zeroltebmc,SM-G925W8
+Samsung,Galaxy S6 Edge,zeroltechn,SM-G9250
+Samsung,Galaxy S6 Edge,zeroltektt,SM-G925K
+Samsung,Galaxy S6 Edge,zeroltelgt,SM-G925L
+Samsung,Galaxy S6 Edge,zeroltelra,SM-G925R6
+Samsung,Galaxy S6 Edge,zerolteskt,SM-G925S
+Samsung,Galaxy S6 Edge,zeroltespr,SM-G925P
+Samsung,Galaxy S6 Edge,zeroltetmo,SM-G925T
+Samsung,Galaxy S6 Edge,zerolteusc,SM-G925R4
+Samsung,Galaxy S6 Edge,zeroltevzw,SM-G925V
+Samsung,Galaxy S6 Edge+,zenlte,SM-G9287
+Samsung,Galaxy S6 Edge+,zenlte,SM-G9287C
+Samsung,Galaxy S6 Edge+,zenlte,SM-G928C
+Samsung,Galaxy S6 Edge+,zenlte,SM-G928F
+Samsung,Galaxy S6 Edge+,zenlte,SM-G928G
+Samsung,Galaxy S6 Edge+,zenlte,SM-G928I
+Samsung,Galaxy S6 Edge+,zenlte,SM-G928X
+Samsung,Galaxy S6 Edge+,zenlteatt,SAMSUNG-SM-G928A
+Samsung,Galaxy S6 Edge+,zenltebmc,SM-G928W8
+Samsung,Galaxy S6 Edge+,zenltechn,SM-G9280
+Samsung,Galaxy S6 Edge+,zenltektt,SM-G928K
+Samsung,Galaxy S6 Edge+,zenltekx,SM-G928N0
+Samsung,Galaxy S6 Edge+,zenltelgt,SM-G928L
+Samsung,Galaxy S6 Edge+,zenlteskt,SM-G928S
+Samsung,Galaxy S6 Edge+,zenltespr,SM-G928P
+Samsung,Galaxy S6 Edge+,zenltetmo,SM-G928T
+Samsung,Galaxy S6 Edge+,zenlteusc,SM-G928R4
+Samsung,Galaxy S6 Edge+,zenltevzw,SM-G928V
+Samsung,Galaxy S7,herolte,SM-G930F
+Samsung,Galaxy S7,herolte,SM-G930X
+Samsung,Galaxy S7,heroltebmc,SM-G930W8
+Samsung,Galaxy S7,heroltektt,SM-G930K
+Samsung,Galaxy S7,heroltelgt,SM-G930L
+Samsung,Galaxy S7,herolteskt,SM-G930S
+Samsung,Galaxy S7,heroqlteacg,SM-G930R7
+Samsung,Galaxy S7,heroqlteaio,SAMSUNG-SM-G930AZ
+Samsung,Galaxy S7,heroqlteatt,SAMSUNG-SM-G930A
+Samsung,Galaxy S7,heroqltecctvzw,SM-G930VC
+Samsung,Galaxy S7,heroqltechn,SM-G9300
+Samsung,Galaxy S7,heroqltechn,SM-G9308
+Samsung,Galaxy S7,heroqltelra,SM-G930R6
+Samsung,Galaxy S7,heroqltemtr,SM-G930T1
+Samsung,Galaxy S7,heroqltespr,SM-G930P
+Samsung,Galaxy S7,heroqltetfnvzw,SM-G930VL
+Samsung,Galaxy S7,heroqltetmo,SM-G930T
+Samsung,Galaxy S7,heroqlteue,SM-G930U
+Samsung,Galaxy S7,heroqlteusc,SM-G930R4
+Samsung,Galaxy S7,heroqltevzw,SM-G930V
+Samsung,Galaxy S7 Active,poseidonlteatt,SAMSUNG-SM-G891A
+Samsung,Galaxy S7 Edge,SC-02H,SC-02H
+Samsung,Galaxy S7 Edge,SCV33,SCV33
+Samsung,Galaxy S7 Edge,hero2lte,SM-G935F
+Samsung,Galaxy S7 Edge,hero2lte,SM-G935X
+Samsung,Galaxy S7 Edge,hero2ltebmc,SM-G935W8
+Samsung,Galaxy S7 Edge,hero2ltektt,SM-G935K
+Samsung,Galaxy S7 Edge,hero2ltelgt,SM-G935L
+Samsung,Galaxy S7 Edge,hero2lteskt,SM-G935S
+Samsung,Galaxy S7 Edge,hero2qlteatt,SAMSUNG-SM-G935A
+Samsung,Galaxy S7 Edge,hero2qltecctvzw,SM-G935VC
+Samsung,Galaxy S7 Edge,hero2qltechn,SM-G9350
+Samsung,Galaxy S7 Edge,hero2qltespr,SM-G935P
+Samsung,Galaxy S7 Edge,hero2qltetmo,SM-G935T
+Samsung,Galaxy S7 Edge,hero2qlteue,SM-G935U
+Samsung,Galaxy S7 Edge,hero2qlteusc,SM-G935R4
+Samsung,Galaxy S7 Edge,hero2qltevzw,SM-G935V
+Samsung,Galaxy S8,SC-02J,SC-02J
+Samsung,Galaxy S8,SCV36,SCV36
+Samsung,Galaxy S8,dreamlte,SM-G950F
+Samsung,Galaxy S8,dreamlteks,SM-G950N
+Samsung,Galaxy S8,dreamqltecan,SM-G950W
+Samsung,Galaxy S8,dreamqltechn,SM-G9500
+Samsung,Galaxy S8,dreamqltecmcc,SM-G9508
+Samsung,Galaxy S8,dreamqltesq,SM-G950U
+Samsung,Galaxy S8,dreamqlteue,SM-G950U1
+Samsung,Galaxy S8 Active,cruiserlteatt,SM-G892A
+Samsung,Galaxy S8 Active,cruiserltesq,SM-G892U
+Samsung,Galaxy S8+,SC-03J,SC-03J
+Samsung,Galaxy S8+,SCV35,SCV35
+Samsung,Galaxy S8+,dream2lte,SM-G955F
+Samsung,Galaxy S8+,dream2lteks,SM-G955N
+Samsung,Galaxy S8+,dream2qltecan,SM-G955W
+Samsung,Galaxy S8+,dream2qltechn,SM-G9550
+Samsung,Galaxy S8+,dream2qltesq,SM-G955U
+Samsung,Galaxy S8+,dream2qlteue,SM-G955U1
+Samsung,Galaxy Spica,GT-I5700,GT-I5700
+Samsung,Galaxy Spica,GT-I5700,GT-I5700L
+Samsung,Galaxy Spica,GT-I5700,GT-I5700R
+Samsung,Galaxy Spica,GT-I5700L,GT-I5700L
+Samsung,Galaxy Spica,spica,GT-I5700
+Samsung,Galaxy Spica,spica,GT-I5700L
+Samsung,Galaxy Spica,spica,GT-I5700R
+Samsung,Galaxy Spica,spica,GT-i5700
+Samsung,Galaxy Star,mint,GT-S5282
+Samsung,Galaxy Star,mintss,GT-S5280
+Samsung,Galaxy Star Plus,logan2g,GT-S7262
+Samsung,Galaxy Star Trios,mintts,GT-S5283B
+Samsung,Galaxy Star2 Plus,higgs2g,SM-G350E
+Samsung,Galaxy Stellar,jaspervzw,SCH-I200
+Samsung,Galaxy Stellar,jaspervzw,SCH-I200PP
+Samsung,Galaxy Stratosphere2,aegis2vzw,SCH-I415
+Samsung,Galaxy Style Duos,aruba3gduosctc,SCH-I829
+Samsung,Galaxy TAB3 Lite,goyairis3g,SM-T116IR
+Samsung,Galaxy Tab,GT-P1000,GT-P1000
+Samsung,Galaxy Tab,GT-P1000L,GT-P1000L
+Samsung,Galaxy Tab,GT-P1000M,GT-P1000M
+Samsung,Galaxy Tab,GT-P1000N,GT-P1000N
+Samsung,Galaxy Tab,GT-P1000R,GT-P1000R
+Samsung,Galaxy Tab,GT-P1000T,GT-P1000T
+Samsung,Galaxy Tab,GT-P1010,GT-P1010
+Samsung,Galaxy Tab,GT-P1013,GT-P1013
+Samsung,Galaxy Tab,SC-01C,SC-01C
+Samsung,Galaxy Tab,SCH-I800,SCH-I800
+Samsung,Galaxy Tab,SGH-T849,SGH-T849
+Samsung,Galaxy Tab,SHW-M180K,SHW-M180K
+Samsung,Galaxy Tab,SHW-M180L,SHW-M180L
+Samsung,Galaxy Tab,SHW-M180S,SHW-M180S
+Samsung,Galaxy Tab,SHW-M180W,SHW-M180W
+Samsung,Galaxy Tab,SMT-i9100,SMT-i9100
+Samsung,Galaxy Tab 10.1,GT-P7500,GT-P7500
+Samsung,Galaxy Tab 10.1,GT-P7500D,GT-P7500D
+Samsung,Galaxy Tab 10.1,GT-P7503,GT-P7503
+Samsung,Galaxy Tab 10.1,GT-P7510,GT-P7510
+Samsung,Galaxy Tab 10.1,SC-01D,SC-01D
+Samsung,Galaxy Tab 10.1,SCH-I905,SCH-I905
+Samsung,Galaxy Tab 10.1,SGH-T859,SGH-T859
+Samsung,Galaxy Tab 10.1,SHW-M300W,SHW-M300W
+Samsung,Galaxy Tab 10.1,SHW-M380K,SHW-M380K
+Samsung,Galaxy Tab 10.1,SHW-M380S,SHW-M380S
+Samsung,Galaxy Tab 10.1,SHW-M380W,SHW-M380W
+Samsung,Galaxy Tab 10.1 N,GT-P7501,GT-P7501
+Samsung,Galaxy Tab 10.1 N,GT-P7511,GT-P7511
+Samsung,Galaxy Tab 10.1 v,p3,GT-P7100
+Samsung,Galaxy Tab 3 Lite,goyairis3g,SM-T116IR
+Samsung,Galaxy Tab 3V 7.0,goyave3g5M,SM-T116NY
+Samsung,Galaxy Tab 4 8.0,milletwifi,SM-T330X
+Samsung,Galaxy Tab 4 8.0,milletwifikx,SM-T330
+Samsung,Galaxy Tab 4 Active,rubenslte,SM-T365
+Samsung,Galaxy Tab 4 Active,rubenslte,SM-T365Y
+Samsung,Galaxy Tab 7.0,SPH-P100,SPH-P100
+Samsung,Galaxy Tab 7.0 Plus,GT-P6200,GT-P6200
+Samsung,Galaxy Tab 7.0 Plus,GT-P6200L,GT-P6200L
+Samsung,Galaxy Tab 7.0 Plus,GT-P6201,GT-P6201
+Samsung,Galaxy Tab 7.0 Plus,GT-P6210,GT-P6210
+Samsung,Galaxy Tab 7.0 Plus,GT-P6211,GT-P6211
+Samsung,Galaxy Tab 7.0 Plus,SC-02D,SC-02D
+Samsung,Galaxy Tab 7.0 Plus,SGH-T869,SGH-T869
+Samsung,Galaxy Tab 7.0 Plus,SHW-M430W,SHW-M430W
+Samsung,Galaxy Tab 7.7,GT-P6800,GT-P6800
+Samsung,Galaxy Tab 7.7,GT-P6810,GT-P6810
+Samsung,Galaxy Tab 7.7,SCH-I815,SCH-I815
+Samsung,Galaxy Tab 7.7 Plus,SC-01E,SC-01E
+Samsung,Galaxy Tab 8.9,GT-P7300,GT-P7300
+Samsung,Galaxy Tab 8.9,GT-P7310,GT-P7310
+Samsung,Galaxy Tab 8.9,GT-P7320,GT-P7320
+Samsung,Galaxy Tab 8.9,SCH-P739,SCH-P739
+Samsung,Galaxy Tab 8.9,SGH-I957,SAMSUNG-SGH-I957
+Samsung,Galaxy Tab 8.9,SGH-I957D,SAMSUNG-SGH-I957D
+Samsung,Galaxy Tab 8.9,SGH-I957D,SGH-I957D
+Samsung,Galaxy Tab 8.9,SGH-I957M,SAMSUNG-SGH-I957M
+Samsung,Galaxy Tab 8.9,SGH-I957M,SGH-I957M
+Samsung,Galaxy Tab 8.9,SGH-I957R,SAMSUNG-SGH-I957R
+Samsung,Galaxy Tab 8.9,SGH-I957R,SGH-I957R
+Samsung,Galaxy Tab 8.9,SHV-E140K,SHV-E140K
+Samsung,Galaxy Tab 8.9,SHV-E140L,SHV-E140L
+Samsung,Galaxy Tab 8.9,SHV-E140S,SHV-E140S
+Samsung,Galaxy Tab 8.9,SHW-M305W,SHW-M305W
+Samsung,Galaxy Tab A (2017),gta2slte,SM-T385
+Samsung,Galaxy Tab A (2017),gta2sltektt,SM-T385K
+Samsung,Galaxy Tab A (2017),gta2sltelgt,SM-T385L
+Samsung,Galaxy Tab A (2017),gta2slteskt,SM-T385S
+Samsung,Galaxy Tab A (2017),gta2swifi,SM-T380
+Samsung,Galaxy Tab A 10.1,gtanotexlwifikx,SM-P580
+Samsung,Galaxy Tab A 10.1,gtaxllte,SM-T585
+Samsung,Galaxy Tab A 10.1,gtaxllte,SM-T585M
+Samsung,Galaxy Tab A 10.1,gtaxllte,SM-T587
+Samsung,Galaxy Tab A 10.1,gtaxlltechn,SM-T585C
+Samsung,Galaxy Tab A 10.1,gtaxlltekx,SM-T585N0
+Samsung,Galaxy Tab A 10.1,gtaxlwifi,SM-T580
+Samsung,Galaxy Tab A 10.1,gtaxlwifi,SM-T580X
+Samsung,Galaxy Tab A 10.1,gtaxlwifichn,SM-T580
+Samsung,Galaxy Tab A 10.1,gtaxlwifichn,SM-T580X
+Samsung,Galaxy Tab A 10.1(2016),gtanotexllte,SM-P585
+Samsung,Galaxy Tab A 10.1(2016),gtanotexllte,SM-P585Y
+Samsung,Galaxy Tab A 7.0,gtexslte,SM-T285
+Samsung,Galaxy Tab A 7.0,gtexslte,SM-T285M
+Samsung,Galaxy Tab A 7.0,gtexslte,SM-T287
+Samsung,Galaxy Tab A 7.0,gtexslteswa,SM-T285YD
+Samsung,Galaxy Tab A 7.0,gtexswifi,SM-T280
+Samsung,Galaxy Tab A 8.0,gt58lte,SM-T355
+Samsung,Galaxy Tab A 8.0,gt58lte,SM-T355Y
+Samsung,Galaxy Tab A 8.0,gt58ltechn,SM-T355C
+Samsung,Galaxy Tab A 8.0,gt58ltetmo,SM-T357T
+Samsung,Galaxy Tab A 8.0,gt58wifi,SM-T350
+Samsung,Galaxy Tab A 8.0,gt58wifi,SM-T350X
+Samsung,Galaxy Tab A 8.0,gt58wifichn,SM-T350
+Samsung,Galaxy Tab A 8.0,gt58wifichn,SM-T350X
+Samsung,Galaxy Tab A 8.0,gt5note8lte,SM-P355
+Samsung,Galaxy Tab A 8.0,gt5note8lte,SM-P355M
+Samsung,Galaxy Tab A 8.0,gt5note8ltechn,SM-P355C
+Samsung,Galaxy Tab A 8.0,gt5note8ltechn,SM-P355Y
+Samsung,Galaxy Tab A 8.0,gt5note8wifi,SM-P350
+Samsung,Galaxy Tab A 8.0,gt5note8wifichn,SM-P350
+Samsung,Galaxy Tab A 9.7,gt510lte,SM-T555
+Samsung,Galaxy Tab A 9.7,gt510ltechn,SM-T555C
+Samsung,Galaxy Tab A 9.7,gt510wifi,SM-T550
+Samsung,Galaxy Tab A 9.7,gt510wifi,SM-T550X
+Samsung,Galaxy Tab A 9.7,gt510wifichn,SM-T550
+Samsung,Galaxy Tab A 9.7,gt510wifichn,SM-T550X
+Samsung,Galaxy Tab A 9.7,gt5note10lte,SM-P555
+Samsung,Galaxy Tab A 9.7,gt5note10lte,SM-P555M
+Samsung,Galaxy Tab A 9.7,gt5note10ltechn,SM-P555C
+Samsung,Galaxy Tab A 9.7,gt5note10ltehktw,SM-P555Y
+Samsung,Galaxy Tab A 9.7,gt5note10ltektt,SM-P555K
+Samsung,Galaxy Tab A 9.7,gt5note10ltelgt,SM-P555L
+Samsung,Galaxy Tab A 9.7,gt5note10lteskt,SM-P555S
+Samsung,Galaxy Tab A 9.7,gt5note10wifi,SM-P550
+Samsung,Galaxy Tab A 9.7,gt5note10wifichn,SM-P550
+Samsung,Galaxy Tab A S 8.0,gt58ltebmc,SM-T357W
+Samsung,Galaxy Tab A2 8.0,gta2slte,SM-T385
+Samsung,Galaxy Tab A2 8.0,gta2slte,SM-T385M
+Samsung,Galaxy Tab A2 8.0,gta2sltechn,SM-T385C
+Samsung,Galaxy Tab A2 8.0,gta2swifichn,SM-T380C
+Samsung,Galaxy Tab Active2,gtactive2lte,SM-T395
+Samsung,Galaxy Tab Active2,gtactive2ltechn,SM-T395C
+Samsung,Galaxy Tab Active2,gtactive2ltekx,SM-T395N
+Samsung,Galaxy Tab Active2,gtactive2wifi,SM-T390
+Samsung,Galaxy Tab E 8.0,gteslteatt,SAMSUNG-SM-T377A
+Samsung,Galaxy Tab E 8.0,gtesltebmc,SM-T377W
+Samsung,Galaxy Tab E 8.0,gtesltelgt,SM-T375L
+Samsung,Galaxy Tab E 8.0,gteslteskt,SM-T375S
+Samsung,Galaxy Tab E 8.0,gtesltetmo,SM-T377T
+Samsung,Galaxy Tab E 8.0,gtesltetw,SM-T3777
+Samsung,Galaxy Tab E 8.0,gtesltevzw,SM-T377V
+Samsung,Galaxy Tab E 8.0,gtesqltespr,SM-T377P
+Samsung,Galaxy Tab E 8.0,gtesqlteusc,SM-T377R4
+Samsung,Galaxy Tab E 9.6,gtel3g,SM-T561
+Samsung,Galaxy Tab E 9.6,gtel3g,SM-T561M
+Samsung,Galaxy Tab E 9.6,gtel3g,SM-T561Y
+Samsung,Galaxy Tab E 9.6,gtel3g,SM-T562
+Samsung,Galaxy Tab E 9.6,gtelltevzw,SM-T567V
+Samsung,Galaxy Tab E 9.6,gtelwifi,SM-T560
+Samsung,Galaxy Tab E 9.6,gtelwifichn,SM-T560
+Samsung,Galaxy Tab E 9.6,gtelwifiue,SM-T560NU
+Samsung,Galaxy Tab E8.0,gtesveltevzw,SM-T378V
+Samsung,Galaxy Tab Plus 7.0,goyave3gsea,SM-T116BU
+Samsung,Galaxy Tab Pro 10.1,picassolte,SM-T525
+Samsung,Galaxy Tab Pro 10.1,picassowifi,SM-T520
+Samsung,Galaxy Tab Pro 10.1 Chef Collection,picassowificc,SM-T520CC
+Samsung,Galaxy Tab Pro 12.2,v2lte,SM-T905
+Samsung,Galaxy Tab Pro 12.2,v2wifi,SM-T900
+Samsung,Galaxy Tab Pro 12.2,v2wifi,SM-T900X
+Samsung,Galaxy Tab Pro 8.4,mondrianlte,SM-T325
+Samsung,Galaxy Tab Pro 8.4,mondrianwifi,SM-T320
+Samsung,Galaxy Tab Pro 8.4,mondrianwifi,SM-T320X
+Samsung,Galaxy Tab Pro 8.4,mondrianwifikx,SM-T320
+Samsung,Galaxy Tab Pro 8.4,mondrianwifiue,SM-T320
+Samsung,Galaxy Tab Pro 8.4,mondrianwifiue,SM-T320NU
+Samsung,Galaxy Tab Q,q7,SM-T2519
+Samsung,Galaxy Tab S 10.5,chagallwifi,SM-T800
+Samsung,Galaxy Tab S 8.4,SC-03G,SC-03G
+Samsung,Galaxy Tab S 8.4,klimtlte,SM-T705
+Samsung,Galaxy Tab S 8.4,klimtlte,SM-T705C
+Samsung,Galaxy Tab S 8.4,klimtlte,SM-T705Y
+Samsung,Galaxy Tab S 8.4,klimtltevzw,SM-T707V
+Samsung,Galaxy Tab S 8.4,klimtwifi,SM-T700
+Samsung,Galaxy Tab S2 8.0,gts210lte,SM-T815
+Samsung,Galaxy Tab S2 8.0,gts28lte,SM-T715
+Samsung,Galaxy Tab S2 8.0,gts28lte,SM-T715Y
+Samsung,Galaxy Tab S2 8.0,gts28ltechn,SM-T715C
+Samsung,Galaxy Tab S2 8.0,gts28ltekx,SM-T715N0
+Samsung,Galaxy Tab S2 8.0,gts28velte,SM-T719
+Samsung,Galaxy Tab S2 8.0,gts28velte,SM-T719Y
+Samsung,Galaxy Tab S2 8.0,gts28veltechn,SM-T719C
+Samsung,Galaxy Tab S2 8.0,gts28vewifi,SM-T713
+Samsung,Galaxy Tab S2 8.0,gts28vewifichn,SM-T713
+Samsung,Galaxy Tab S2 8.0,gts28wifi,SM-T710
+Samsung,Galaxy Tab S2 8.0,gts28wifi,SM-T710X
+Samsung,Galaxy Tab S2 8.0,gts28wifichn,SM-T710
+Samsung,Galaxy Tab S2 9.7,gts210lte,SM-T815C
+Samsung,Galaxy Tab S2 9.7,gts210lte,SM-T815Y
+Samsung,Galaxy Tab S2 9.7,gts210lte,SM-T817
+Samsung,Galaxy Tab S2 9.7,gts210lteatt,SAMSUNG-SM-T817A
+Samsung,Galaxy Tab S2 9.7,gts210ltecan,SM-T817W
+Samsung,Galaxy Tab S2 9.7,gts210ltekx,SM-T815N0
+Samsung,Galaxy Tab S2 9.7,gts210ltespr,SM-T817P
+Samsung,Galaxy Tab S2 9.7,gts210ltetmo,SM-T817T
+Samsung,Galaxy Tab S2 9.7,gts210lteusc,SM-T817R4
+Samsung,Galaxy Tab S2 9.7,gts210ltevzw,SM-T817V
+Samsung,Galaxy Tab S2 9.7,gts210velte,SM-T818
+Samsung,Galaxy Tab S2 9.7,gts210velte,SM-T819
+Samsung,Galaxy Tab S2 9.7,gts210velte,SM-T819Y
+Samsung,Galaxy Tab S2 9.7,gts210velteatt,SAMSUNG-SM-T818A
+Samsung,Galaxy Tab S2 9.7,gts210veltecan,SM-T818W
+Samsung,Galaxy Tab S2 9.7,gts210veltechn,SM-T819C
+Samsung,Galaxy Tab S2 9.7,gts210veltetmo,SM-T818T
+Samsung,Galaxy Tab S2 9.7,gts210vewifi,SM-T813
+Samsung,Galaxy Tab S2 9.7,gts210vewifichn,SM-T813
+Samsung,Galaxy Tab S2 9.7,gts210wifi,SM-T810
+Samsung,Galaxy Tab S2 9.7,gts210wifi,SM-T810X
+Samsung,Galaxy Tab S3,gts3llte,SM-T825
+Samsung,Galaxy Tab S3,gts3llte,SM-T825C
+Samsung,Galaxy Tab S3,gts3llte,SM-T825X
+Samsung,Galaxy Tab S3,gts3llte,SM-T827
+Samsung,Galaxy Tab S3,gts3lltekx,SM-T825N0
+Samsung,Galaxy Tab S3,gts3llteusc,SM-T827R4
+Samsung,Galaxy Tab S3,gts3lltevzw,SM-T827V
+Samsung,Galaxy Tab S3,gts3lwifi,SM-T820
+Samsung,Galaxy Tab S3,gts3lwifi,SM-T820X
+Samsung,Galaxy Tab S3,gts3lwifichn,SM-T820
+Samsung,Galaxy Tab2 10.1,espresso10att,SAMSUNG-SGH-I497
+Samsung,Galaxy Tab2 10.1,espresso10can,SGH-I497
+Samsung,Galaxy Tab2 10.1,espresso10rf,GT-P5100
+Samsung,Galaxy Tab2 10.1,espresso10spr,SPH-P500
+Samsung,Galaxy Tab2 10.1,espresso10tmo,SGH-T779
+Samsung,Galaxy Tab2 10.1,espresso10vzw,SCH-I915
+Samsung,Galaxy Tab2 10.1,espresso10wifi,GT-P5110
+Samsung,Galaxy Tab2 10.1,espresso10wifi,GT-P5113
+Samsung,Galaxy Tab2 7.0,espressorf,GT-P3100
+Samsung,Galaxy Tab2 7.0,espressorf,GT-P3100B
+Samsung,Galaxy Tab2 7.0,espressorf,GT-P3105
+Samsung,Galaxy Tab2 7.0,espressovzw,SCH-I705
+Samsung,Galaxy Tab2 7.0,espressovzw,SCH-i705
+Samsung,Galaxy Tab2 7.0,espressowifi,GT-P3110
+Samsung,Galaxy Tab2 7.0,espressowifi,GT-P3113
+Samsung,Galaxy Tab3,lt01wifikx,SM-T310
+Samsung,Galaxy Tab3 10.1,santos103g,GT-P5200
+Samsung,Galaxy Tab3 10.1,santos10lte,GT-P5220
+Samsung,Galaxy Tab3 10.1,santos10wifi,GT-P5210
+Samsung,Galaxy Tab3 10.1,santos10wifi,GT-P5210XD1
+Samsung,Galaxy Tab3 7.0,lt023g,SM-T211
+Samsung,Galaxy Tab3 7.0,lt023g,SM-T212
+Samsung,Galaxy Tab3 7.0,lt023gdtv,SM-T211M
+Samsung,Galaxy Tab3 7.0,lt02lte,SM-T215
+Samsung,Galaxy Tab3 7.0,lt02lteatt,SAMSUNG-SM-T217A
+Samsung,Galaxy Tab3 7.0,lt02ltespr,SM-T217S
+Samsung,Galaxy Tab3 7.0,lt02ltetmo,SM-T217T
+Samsung,Galaxy Tab3 7.0,lt02wifi,SM-T210
+Samsung,Galaxy Tab3 7.0,lt02wifi,SM-T210R
+Samsung,Galaxy Tab3 7.0,lt02wifilgt,SM-T210L
+Samsung,Galaxy Tab3 8.0,lt013g,SM-T311
+Samsung,Galaxy Tab3 8.0,lt013g,SM-T312
+Samsung,Galaxy Tab3 8.0,lt01lte,SM-T315
+Samsung,Galaxy Tab3 8.0,lt01lte,SM-T315T
+Samsung,Galaxy Tab3 8.0,lt01wifi,SM-T310
+Samsung,Galaxy Tab3 8.0,lt01wifi,SM-T310X
+Samsung,Galaxy Tab3 8.0,lt02lduwifi,SM-T210X
+Samsung,Galaxy Tab3 Kids,lt02kidswifi,SM-T2105
+Samsung,Galaxy Tab3 Lite,goya3g,SM-T111
+Samsung,Galaxy Tab3 Lite,goya3g,SM-T111M
+Samsung,Galaxy Tab3 Lite,goyawifi,SM-T110
+Samsung,Galaxy Tab3 Lite 7.0,goyave3g,SM-T116NQ
+Samsung,Galaxy Tab3 Lite 7.0,goyavewifi,SM-T113
+Samsung,Galaxy Tab3 VE 7.0,goyave3g,SM-T116
+Samsung,Galaxy Tab3V 7.0,goyave3gsea,SM-T116NU
+Samsung,Galaxy Tab3V 7.0,goyavewifixtc,SM-T113NU
+Samsung,Galaxy Tab4,matissewifigoogle,SM-T530NN
+Samsung,Galaxy Tab4 10.0,matisse3g,SM-T531
+Samsung,Galaxy Tab4 10.0,matisselte,SM-T535
+Samsung,Galaxy Tab4 10.0,matisselteatt,SAMSUNG-SM-T537A
+Samsung,Galaxy Tab4 10.0,matisselteusc,SM-T537R4
+Samsung,Galaxy Tab4 10.0,matisseltevzw,SM-T537V
+Samsung,Galaxy Tab4 10.1,matisse10wifikx,SM-T536
+Samsung,Galaxy Tab4 10.1,matissevewifi,SM-T533
+Samsung,Galaxy Tab4 10.1,matissewifi,SM-T530
+Samsung,Galaxy Tab4 10.1,matissewifi,SM-T530X
+Samsung,Galaxy Tab4 10.1,matissewifikx,SM-T530
+Samsung,Galaxy Tab4 10.1,matissewifiue,SM-T530NU
+Samsung,Galaxy Tab4 7.0,403SC,403SC
+Samsung,Galaxy Tab4 7.0,degas2wifi,SM-T230NW
+Samsung,Galaxy Tab4 7.0,degas2wifibmwchn,SM-T230NW
+Samsung,Galaxy Tab4 7.0,degas3g,SM-T231
+Samsung,Galaxy Tab4 7.0,degas3g,SM-T232
+Samsung,Galaxy Tab4 7.0,degaslte,SM-T235
+Samsung,Galaxy Tab4 7.0,degaslte,SM-T235Y
+Samsung,Galaxy Tab4 7.0,degasltespr,SM-T237P
+Samsung,Galaxy Tab4 7.0,degasltevzw,SM-T237V
+Samsung,Galaxy Tab4 7.0,degasvelte,SM-T239
+Samsung,Galaxy Tab4 7.0,degasvelte,SM-T2397
+Samsung,Galaxy Tab4 7.0,degasvelte,SM-T239M
+Samsung,Galaxy Tab4 7.0,degasveltechn,SM-T239C
+Samsung,Galaxy Tab4 7.0,degaswifi,SM-T230
+Samsung,Galaxy Tab4 7.0,degaswifi,SM-T230NY
+Samsung,Galaxy Tab4 7.0,degaswifi,SM-T230X
+Samsung,Galaxy Tab4 7.0,degaswifibmwzc,SM-T230NY
+Samsung,Galaxy Tab4 7.0,degaswifidtv,SM-T230NT
+Samsung,Galaxy Tab4 7.0,degaswifiopenbnn,SM-T230NU
+Samsung,Galaxy Tab4 7.0,degaswifiue,SM-T230NU
+Samsung,Galaxy Tab4 8.0,millet3g,SM-T331
+Samsung,Galaxy Tab4 8.0,milletlte,SM-T335
+Samsung,Galaxy Tab4 8.0,milletlteatt,SAMSUNG-SM-T337A
+Samsung,Galaxy Tab4 8.0,milletltektt,SM-T335K
+Samsung,Galaxy Tab4 8.0,milletltelgt,SM-T335L
+Samsung,Galaxy Tab4 8.0,milletltetmo,SM-T337T
+Samsung,Galaxy Tab4 8.0,milletltevzw,SM-T337V
+Samsung,Galaxy Tab4 8.0,milletwifi,SM-T330
+Samsung,Galaxy Tab4 8.0,milletwifiue,SM-T330NU
+Samsung,Galaxy Tab4 Active,rubenslte,SM-T365
+Samsung,Galaxy Tab4 Active,rubenslte,SM-T365M
+Samsung,Galaxy Tab4 Active,rubensltekx,SM-T365F0
+Samsung,Galaxy Tab4 Active,rubenswifi,SM-T360
+Samsung,Galaxy Tab4 Active,rubenswifichn,SM-T360
+Samsung,Galaxy Tab4 Nook 10.1,matissewifiopenbnn,SM-T530NU
+Samsung,Galaxy TabA Plus 10.1,gtanotexllte,SM-P585M
+Samsung,Galaxy TabA Plus 10.1,gtanotexllte,SM-P587
+Samsung,Galaxy TabA Plus 10.1,gtanotexlltechn,SM-P588C
+Samsung,Galaxy TabA Plus 10.1,gtanotexlltekx,SM-P585N0
+Samsung,Galaxy TabA Plus 10.1,gtanotexlwifichn,SM-P583
+Samsung,Galaxy TabA Plus 10.1,gtaxlqltespr,SM-T587P
+Samsung,Galaxy TabA Plus10.1,gtanotexlwifikx,SM-P580X
+Samsung,Galaxy TabE 8.0,gtesltektt,SM-T378K
+Samsung,Galaxy TabE 8.0,gtesltelgt,SM-T378L
+Samsung,Galaxy TabE 8.0,gteslteskt,SM-T378S
+Samsung,Galaxy TabS 10.5,SCT21,SCT21
+Samsung,Galaxy TabS 10.5,chagallhltektt,SM-T805K
+Samsung,Galaxy TabS 10.5,chagallhltelgt,SM-T805L
+Samsung,Galaxy TabS 10.5,chagallhlteskt,SM-T805S
+Samsung,Galaxy TabS 10.5,chagalllte,SM-T805
+Samsung,Galaxy TabS 10.5,chagalllte,SM-T805M
+Samsung,Galaxy TabS 10.5,chagalllte,SM-T805Y
+Samsung,Galaxy TabS 10.5,chagalllte,SM-T807
+Samsung,Galaxy TabS 10.5,chagalllteatt,SAMSUNG-SM-T807A
+Samsung,Galaxy TabS 10.5,chagallltecan,SM-T805W
+Samsung,Galaxy TabS 10.5,chagallltespr,SM-T807P
+Samsung,Galaxy TabS 10.5,chagallltetmo,SM-T807T
+Samsung,Galaxy TabS 10.5,chagalllteusc,SM-T807R4
+Samsung,Galaxy TabS 10.5,chagallltevzw,SM-T807V
+Samsung,Galaxy TabS 10.5,chagallwifi,SM-T800
+Samsung,Galaxy TabS 10.5,chagallwifi,SM-T800X
+Samsung,Galaxy TabS 10.5,chagallwifikx,SM-T800
+Samsung,Galaxy TabS 8.4,klimtlte,SM-T705
+Samsung,Galaxy TabS 8.4,klimtlte,SM-T705M
+Samsung,Galaxy TabS 8.4,klimtlteatt,SAMSUNG-SM-T707A
+Samsung,Galaxy TabS 8.4,klimtltecan,SM-T705W
+Samsung,Galaxy TabS 8.4,klimtwifi,SM-T700
+Samsung,Galaxy TabS 8.4,klimtwifikx,SM-T700
+Samsung,Galaxy TabS2 9.7,gts210veltevzw,SM-T818V
+Samsung,Galaxy TabS3,gts3llte,SM-T825
+Samsung,Galaxy TabS3,gts3llte,SM-T825Y
+Samsung,Galaxy TabS3,gts3lltechn,SM-T825C
+Samsung,Galaxy Tap Pro 10.1,picassolte,SM-T525
+Samsung,Galaxy Tap Pro 8.4,mondrianwifi,SM-T320
+Samsung,Galaxy Trend,kyleve,GT-S7392
+Samsung,Galaxy Trend,kyleve,GT-S7392L
+Samsung,Galaxy Trend,kyleve3gcmcc,GT-S7568I
+Samsung,Galaxy Trend Duos,kyleichn,GT-S7562i
+Samsung,Galaxy Trend Duos,kylepluschn,GT-S7572
+Samsung,Galaxy Trend Duos,kyleve,GT-S7390
+Samsung,Galaxy Trend Duos,kyleve,GT-S7392
+Samsung,Galaxy Trend Duos,kyleve,GT-S7562C
+Samsung,Galaxy Trend Lite,kylevess,GT-S7390
+Samsung,Galaxy Trend Lite,kylevess,GT-S7390L
+Samsung,Galaxy Trend Plus,kylepro,GT-S7580
+Samsung,Galaxy Trend Plus,kylepro,GT-S7580E
+Samsung,Galaxy Trend Plus,kylepro,GT-S7580L
+Samsung,Galaxy Trend Plus,kylepro,GT-S7583T
+Samsung,Galaxy Trend2,garda3gcmcc,GT-S7898
+Samsung,Galaxy Trend2,gardave3gcmcc,GT-S7898I
+Samsung,Galaxy Trend2,kyleplusctc,SCH-I739
+Samsung,Galaxy Trend3,cs023g,SM-G3502U
+Samsung,Galaxy Trend3,cs02cmcc,SM-G3508
+Samsung,Galaxy Trend3,cs02ctc,SM-G3509
+Samsung,Galaxy Trend3,cs02ve,SM-G3508I
+Samsung,Galaxy Trend3,cs02ve3g,SM-G3502C
+Samsung,Galaxy Trend3,cs02ve3g,SM-G3502I
+Samsung,Galaxy Trend3,cs02ve3g,SM-G3508J
+Samsung,Galaxy Trend3,cs02ve3g,SM-G3509I
+Samsung,Galaxy U,SHW-M130L,SHW-M130L
+Samsung,Galaxy Victory,goghspr,SPH-L300
+Samsung,Galaxy Victory,goghvmu,SPH-L300
+Samsung,Galaxy View,gvlte,SM-T677
+Samsung,Galaxy View,gvlteatt,SAMSUNG-SM-T677A
+Samsung,Galaxy View,gvltevzw,SM-T677V
+Samsung,Galaxy View,gvltexsp,SM-T677
+Samsung,Galaxy View,gvwifijpn,SM-T670
+Samsung,Galaxy View,gvwifiue,SM-T670
+Samsung,Galaxy W,GT-I8150,GT-I8150
+Samsung,Galaxy W,GT-I8150B,GT-I8150B
+Samsung,Galaxy W,GT-I8150T,GT-I8150T
+Samsung,Galaxy W,SGH-T679M,SGH-T679M
+Samsung,Galaxy W,q7lteskt,SM-T255S
+Samsung,Galaxy Wide,on7nlteskt,SM-G600S
+Samsung,Galaxy Wide2,j7popelteskt,SM-J727S
+Samsung,Galaxy Win,delos3gcmcc,GT-I8558
+Samsung,Galaxy Win,delos3gduosctc,SCH-I869
+Samsung,Galaxy Win,delos3geur,GT-I8552
+Samsung,Galaxy Win,delos3geur,GT-I8552B
+Samsung,Galaxy Win,delos3gss,GT-I8550E
+Samsung,Galaxy Win,delosltelgt,SHV-E500L
+Samsung,Galaxy Win,deloslteskt,SHV-E500S
+Samsung,Galaxy Win Duos,delos3gchn,GT-I8552
+Samsung,Galaxy Win Pro,wilcox3g,SM-G3818
+Samsung,Galaxy Win Pro,wilcoxctc,SM-G3819
+Samsung,Galaxy Win Pro,wilcoxctc,SM-G3819D
+Samsung,Galaxy Win Pro,wilcoxds,SM-G3812
+Samsung,Galaxy Win2,coreprimeltedtv,SM-G360BT
+Samsung,Galaxy Xcover,GT-S5690,GT-S5690
+Samsung,Galaxy Xcover,GT-S5690L,GT-S5690L
+Samsung,Galaxy Xcover,GT-S5690M,GT-S5690M
+Samsung,Galaxy Xcover,GT-S5690R,GT-S5690R
+Samsung,Galaxy Xcover2,skomer,GT-S7710
+Samsung,Galaxy Xcover2,skomer,GT-S7710L
+Samsung,Galaxy Xcover3,xcover3lte,SM-G388F
+Samsung,Galaxy Xcover3,xcover3velte,SM-G389F
+Samsung,Galaxy Xcover4,xcover4lte,SM-G390F
+Samsung,Galaxy Xcover4,xcover4lte,SM-G390Y
+Samsung,Galaxy Xcover4,xcover4ltecan,SM-G390W
+Samsung,Galaxy Y,GT-S5360,GT-S5360
+Samsung,Galaxy Y,GT-S5360B,GT-S5360B
+Samsung,Galaxy Y,GT-S5360L,GT-S5360L
+Samsung,Galaxy Y,GT-S5360T,GT-S5360T
+Samsung,Galaxy Y,GT-S5363,GT-S5363
+Samsung,Galaxy Y,GT-S5368,GT-S5368
+Samsung,Galaxy Y,GT-S5369,GT-S5369
+Samsung,Galaxy Y,SCH-I509,SCH-I509
+Samsung,Galaxy Y,SCH-i509,SCH-i509
+Samsung,Galaxy Y Duos,GT-S6102,GT-S6102
+Samsung,Galaxy Y Duos,GT-S6102B,GT-S6102B
+Samsung,Galaxy Y Duos,GT-S6102E,GT-S6102E
+Samsung,Galaxy Y Plus,coriplusds,GT-S5303
+Samsung,Galaxy Y Plus,coriplusds,GT-S5303B
+Samsung,Galaxy Y Pop,GT-S6108,GT-S6108
+Samsung,Galaxy Y Pro,GT-B5510,GT-B5510
+Samsung,Galaxy Y Pro,GT-B5510B,GT-B5510B
+Samsung,Galaxy Y Pro,GT-B5510L,GT-B5510L
+Samsung,Galaxy Y Pro Duos,GT-B5512,GT-B5512
+Samsung,Galaxy Y Pro Duos,GT-B5512B,GT-B5512B
+Samsung,Galaxy Y TV,GT-S5367,GT-S5367
+Samsung,Galaxy Young,roy,GT-S6312
+Samsung,Galaxy Young,roydtv,GT-S6313T
+Samsung,Galaxy Young,royss,GT-S6310
+Samsung,Galaxy Young,royss,GT-S6310B
+Samsung,Galaxy Young,royss,GT-S6310L
+Samsung,Galaxy Young,royss,GT-S6310T
+Samsung,Galaxy Young,royssdtv,GT-S6313T
+Samsung,Galaxy Young,royssnfc,GT-S6310N
+Samsung,Galaxy Young2,young23g,SM-G130H
+Samsung,Galaxy Young2,young23g,SM-G130M
+Samsung,Galaxy Young2,young23g,SM-G130U
+Samsung,Galaxy Young2,young23gdtv,SM-G130BT
+Samsung,Galaxy Young2,young2ds2g,SM-G130E
+Samsung,Galaxy Young2,young2nfc3g,SM-G130HN
+Samsung,Galaxy Young2 Pro,young2ve3g,SM-G130BU
+Samsung,Galaxy player 70 Plus,YP-GB70D,YP-GB70D
+Samsung,Galaxy view,gvltektt,SM-T677NK
+Samsung,Galaxy view,gvltelgt,SM-T677NL
+Samsung,Galaxy win,delos3gss,GT-I8550L
+Samsung,Galaxy-A9(2016),a9xltechn,SM-A9000
+Samsung,Garda,gardalteMetroPCS,SGH-T399N
+Samsung,Garda,gardaltetmo,SGH-T399
+Samsung,Gear Live,sprat,Gear Live
+Samsung,Gem,SCH-I100,SCH-I100
+Samsung,Grand Prime Plus,grandpplte,SM-G532F
+Samsung,Grand Prime Plus,grandpplte,SM-G532G
+Samsung,Grand Prime Plus,grandppltedtv,SM-G532MT
+Samsung,Hennessy,hennessy3gduosctc,SCH-W789
+Samsung,Homesync,spcwifi,GT-B9150
+Samsung,Homesync,spcwifiany,GT-B9150
+Samsung,IceTouch,gokey,YP-GH1
+Samsung,Illusion,SCH-I110,SCH-I110
+Samsung,Infuse,SGH-I997,SAMSUNG-SGH-I997
+Samsung,Infuse,SGH-I997R,SAMSUNG-SGH-I997R
+Samsung,J1 Mini Prime,j1minivelte,SM-J106F
+Samsung,Moment,SPH-M900,SPH-M900
+Samsung,Montblanc,montblanc3gctc,SM-W2014
+Samsung,Nexus 10,manta,Nexus 10
+Samsung,Nexus S,crespo,Nexus S
+Samsung,Nexus S,crespo4g,Nexus S 4G
+Samsung,ProXpress M4580,fiber-athena,samsung-printer-tablet
+Samsung,Replenish,SPH-M580,SPH-M580
+Samsung,Replenish,SPH-M580BST,SPH-M580BST
+Samsung,Repp,SCH-R680,SCH-R680
+Samsung,Roy VE DTV,royssvedtv,GT-S6293T
+Samsung,Roy VE DTV,royvedtv,GT-S6293T
+Samsung,Rugby Smart,SGH-I847,SAMSUNG-SGH-I847
+Samsung,SM G9298,venenoltechn,SM-G9298
+Samsung,SM-G9198,philippeltechn,SM-G9198
+Samsung,SM-W2018,kellyltechn,SM-W2018
+Samsung,SM-W2018,kellyltechn,SM-W2018X
+Samsung,Sidekick,SGH-T839,SGH-T839
+Samsung,Transfix,SCH-R730,SCH-R730
+Samsung,Transform,SPH-M920,SPH-M920
+Samsung,Transform Ultra,SPH-M930,SPH-M930
+Samsung,Transform Ultra,SPH-M930BST,SPH-M930BST
+Samsung,VinsQ,SPH-M910,SPH-M910
+Samsung,VinsQ(M910),SPH-M910,SPH-M910
+Samsung,W2016,royceltectc,SM-W2016
+Samsung,W2017,veyronltectc,SM-W2017
+Samsung,olleh,ik1,SMT-E5015
+Sansui,ETAB M9021G,ETAB_M9021G,ETAB_M9021G
+Sansui,ETAB S7042G,S7042G,ETAB_S7042G
+Sansui,Fun,Sansui_Fun,Sansui Fun
+Sansui,Go,S401,Go
+Sansui,Sansui Play,Play,Sansui Play
+Sansui,Switch,SansuiSwitch,Sansui_Switch
+Sansui,"Tab 7""",ETAB_I7043G,ETAB I7043G
+Sansui,"Tab 7""",ETAB_I7043G,ETAB_I7043G
+Sansui,"Tab 7""",ETAB_I7043G_VP3,ETAB_I7043G_VP3
+Sanyo,55CE6139M1,CEM1,CEM1
+Sanyo,Benesse,31TL04,31TL04
+Sanyo,Benesse,40TL04,40TL04
+Sanyo,Benesse,41EA04,41EA04
+Sanyo,CEA1,CEA1,CEA1
+Sanyo,CEA3,CEA3,CEA3
+Sanyo,CEH1,CEH1,CEH1
+Sanyo,CER2,CER2,CER2
+Sanyo,CER3,CER3,CER3
+Schok,mini_SM7216,SM7216,SM7216
+Seatel,T8,seatel_T8,Seatel T8
+Seemahale Telecoms,ST5000,ST5000,ST5000
+Senseit,A109,SENSEIT_A109,SENSEIT_A109
+Senseit,L301,SENSEIT-L301,SENSEIT L301
+Senseit,SENSEIT_A247,SENSEIT_A247,SENSEIT A247
+Senwa,LS5,Telcel_LS5,LS5
+Senwa,Telcel_LS50,Telcel_LS50,LS50
+Senwa,Telcel_LS55,Telcel_LS55,LS55
+Sharp,,SH7218T,SH7218T
+Sharp,,SH8268U,SH8268U
+Sharp,,SH8288U,SH8288U
+Sharp,,SH8298U,SH8298U
+Sharp,,msm7627_surf,SH8118U
+Sharp,306SH,SG306SH,306SH
+Sharp,401SH,SG401SH,401SH
+Sharp,507SH,eve_sprout,507SH
+Sharp,A01SH,A01SH,A01SH
+Sharp,A1,TSL,FS8002
+Sharp,ADS1,ADS1,SHARP-ADS1
+Sharp,AN-NP40,an_np40,AN-NP40
+Sharp,AQUOS CRYSTAL 2,SG403SH,403SH
+Sharp,AQUOS CRYSTAL X,SG402SH,402SH
+Sharp,AQUOS Compact SH-02H,SH-02H,SH-02H
+Sharp,AQUOS EVER SH-02J,SH-02J,SH-02J
+Sharp,AQUOS EVER SH-04G,SH-04G,SH-04G
+Sharp,AQUOS K SHF31,SHF31,SHF31
+Sharp,AQUOS K SHF32,SHF32,SHF32
+Sharp,AQUOS K SHF33,SHF33,SHF33
+Sharp,AQUOS L SHV37,FSP_u,SHV37_u
+Sharp,AQUOS L2,SH-L02,SH-L02
+Sharp,AQUOS M1,MS1,FS8001
+Sharp,AQUOS P1,P1X,P1X
+Sharp,AQUOS PAD  SHT22,SHT22,SHT22
+Sharp,AQUOS PAD SH-05G,SH-05G,SH-05G
+Sharp,AQUOS PAD SH-06F,SH-06F,SH-06F
+Sharp,AQUOS PAD SH-08E,SH-08E,SH-08E
+Sharp,AQUOS PAD SHT21,SHT21,SHT21
+Sharp,AQUOS PHONE  SERIE SHL22,SHL22,SHL22
+Sharp,AQUOS PHONE  SERIE SHL23,SHL23,SHL23
+Sharp,AQUOS PHONE  SERIE mini SHL24,SHL24,SHL24
+Sharp,AQUOS PHONE CL IS17SH,SHI17,IS17SH
+Sharp,AQUOS PHONE EX SH-02F,SH-02F,SH-02F
+Sharp,AQUOS PHONE EX SH-04E,SH04E,SH-04E
+Sharp,AQUOS PHONE IS11SH,SHI11,IS11SH
+Sharp,AQUOS PHONE IS12SH,SHI12,IS12SH
+Sharp,AQUOS PHONE IS13SH,SHI13,IS13SH
+Sharp,AQUOS PHONE IS14SH,SHI14,IS14SH
+Sharp,AQUOS PHONE SERIE ISW16SH,SHI16,ISW16SH
+Sharp,AQUOS PHONE SERIE SHL21,SHL21,SHL21
+Sharp,AQUOS PHONE SH-01D,SH01D,SH-01D
+Sharp,AQUOS PHONE SH-06D,SH06D,SH-06D
+Sharp,AQUOS PHONE SH-12C,SH12C,SH-12C
+Sharp,AQUOS PHONE SH90B,SH90B,SH90B
+Sharp,AQUOS PHONE SL IS15SH,SHI15,IS15SH
+Sharp,AQUOS PHONE SoftBank  102SH II,SBM102SH2,SBM102SH2
+Sharp,AQUOS PHONE SoftBank 006SH,SBM006SH,SBM006SH
+Sharp,AQUOS PHONE SoftBank 102SH,SBM102SH,SBM102SH
+Sharp,AQUOS PHONE SoftBank 103SH,SBM103SH,SBM103SH
+Sharp,AQUOS PHONE SoftBank 104SH,SBM104SH,SBM104SH
+Sharp,AQUOS PHONE THE HYBRID SoftBank 007SH,SBM007SH,SBM007SH
+Sharp,AQUOS PHONE THE HYBRID SoftBank 007SH J,SBM007SHJ,SBM007SHJ
+Sharp,AQUOS PHONE THE HYBRID SoftBank 101SH,SBM101SH,SBM101SH
+Sharp,AQUOS PHONE THE PREMIUM SoftBank 009SH,SBM009SH,SBM009SH
+Sharp,AQUOS PHONE WX05SH,WX05SH,WX05SH
+Sharp,AQUOS PHONE Xx 206SH,SBM206SH,SBM206SH
+Sharp,AQUOS PHONE Xx 302SH,SBM302SH,SBM302SH
+Sharp,AQUOS PHONE Xx SoftBank 106SH,SBM106SH,SBM106SH
+Sharp,AQUOS PHONE Xx mini 303SH,SBM303SH,SBM303SH
+Sharp,AQUOS PHONE ZETA  SH-01F,SH-01F,SH-01F
+Sharp,AQUOS PHONE ZETA SH-02E,SH02E,SH-02E
+Sharp,AQUOS PHONE ZETA SH-06E,SH-06E,SH-06E
+Sharp,AQUOS PHONE ZETA SH-09D,SH09D,SH-09D
+Sharp,AQUOS PHONE es WX04SH,WX04SH,WX04SH
+Sharp,AQUOS PHONE f SH-13C,SH13C,SH-13C
+Sharp,AQUOS PHONE si SH-01E,SH01E,SH-01E
+Sharp,AQUOS PHONE si SH-07E,SH-07E,SH-07E
+Sharp,AQUOS PHONE slider SH-02D,SH02D,SH-02D
+Sharp,AQUOS PHONE ss 205SH,SBM205SH,SBM205SH
+Sharp,AQUOS PHONE st SH-07D,SH07D,SH-07D
+Sharp,AQUOS PHONE sv SH-10D,SH10D,SH-10D
+Sharp,AQUOS R,SG605SH,605SH
+Sharp,AQUOS R SH-03J,SH-03J,SH-03J
+Sharp,AQUOS R SHV39,HUR,SHV39
+Sharp,AQUOS R compact 701SH,SG701SH,701SH
+Sharp,AQUOS R compact SH-M06,SH-M06,SH-M06
+Sharp,AQUOS R compact SHV41,JWT,SHV41
+Sharp,AQUOS S3mini (SG1),SG1,FS8018
+Sharp,AQUOS SERIE SHL25,SHL25,SHL25
+Sharp,AQUOS SERIE SHV32,SHV32,SHV32
+Sharp,AQUOS SERIE SHV34,SHV34,SHV34
+Sharp,AQUOS SERIE mini SHV31,SHV31,SHV31
+Sharp,AQUOS SERIE mini SHV33,SHV33,SHV33
+Sharp,AQUOS SERIE mini SHV38,GTQ,SHV38
+Sharp,AQUOS SH-M01,SH-M01,SH-M01
+Sharp,AQUOS SH-M02,SH-M02,SH-M02
+Sharp,AQUOS SH-M02-EVA20,SH-M02-EVA20,SH-M02-EVA20
+Sharp,AQUOS SH-RM02,SH-RM02,SH-RM02
+Sharp,AQUOS U SHV35,SHV35,SHV35
+Sharp,AQUOS U SHV37,FSP,SHV37
+Sharp,AQUOS Xx,SG404SH,404SH
+Sharp,AQUOS Xx 3,SG506SH,506SH
+Sharp,AQUOS Xx 304SH,SG304SH,304SH
+Sharp,AQUOS Xx2,SG502SH,502SH
+Sharp,AQUOS Xx2 mini,SG503SH,503SH
+Sharp,AQUOS Xx3 mini,SG603SH,603SH
+Sharp,AQUOS ZETA SH-01G,SH-01G,SH-01G
+Sharp,AQUOS ZETA SH-01H,SH-01H,SH-01H
+Sharp,AQUOS ZETA SH-03G,SH-03G,SH-03G
+Sharp,AQUOS ZETA SH-04F,SH-04F,SH-04F
+Sharp,AQUOS ZETA SH-04H,SH-04H,SH-04H
+Sharp,AQUOS ea,SG606SH,606SH
+Sharp,AQUOS mini SH-M03,SH-M03,SH-M03
+Sharp,AQUOS sense,KXU_u,SHV40_u
+Sharp,AQUOS sense SH-01K,SH-01K,SH-01K
+Sharp,AQUOS sense SHV40,KXU,SHV40
+Sharp,AQUOS sense lite (SH-M05),SH-M05,SH-M05
+Sharp,AQUOS \xe3\x82\xb1\xe3\x83\xbc\xe3\x82\xbf\xe3\x82\xa4 SH-06G,SH-06G,SH-06G
+Sharp,Android One S1,kaleido_sprout,S1
+Sharp,BASIO2 SHV36,SHV36,SHV36
+Sharp,C1,MS1,FS8001
+Sharp,DM009SH,DM009SH,DM009SH
+Sharp,DM010SH,DM010SH,DM010SH
+Sharp,DM011SH,DM011SH,DM011SH
+Sharp,DM012SH,DM012SH,DM012SH
+Sharp,DM013SH,DM013SH,DM013SH
+Sharp,DM016SH,DM016SH,DM016SH
+Sharp,Disney Mobile DM014SH,DM014SH,DM014SH
+Sharp,Disney Mobile on docomo DM-01H,DM-01H,DM-01H
+Sharp,Disney Mobile on docomo DM-01J,DM-01J,DM-01J
+Sharp,Disney Mobile on docomo SH-02G,SH-02G,SH-02G
+Sharp,Disney Mobile on docomo SH-05F,SH-05F,SH-05F
+Sharp,EB-A71GJ,EB-A71GJ,EB-A71GJ
+Sharp,EB-WX1GJ/EB-W51GJ,Galapagos,EB-W51GJ
+Sharp,EB-WX1GJ/EB-W51GJ,Galapagos,EB-WX1GJ
+Sharp,FS8014,SE3,FS8014
+Sharp,GALAPAGOS SoftBank 003SH,SBM003SH,SBM003SH
+Sharp,GALAPAGOS SoftBank 005SH,SBM005SH,SBM005SH
+Sharp,HC-16TT1,HCTT1,HCTT1
+Sharp,INFOBAR A01,SHX11,INFOBAR A01
+Sharp,INFOBAR C01,SHX12,INFOBAR C01
+Sharp,IS01,SHI01,IS01
+Sharp,IS03,SHI03,IS03
+Sharp,IS05,SHI05,IS05
+Sharp,LC-**UH30U,sharp_2k15_us_android,LC-Ux30US
+Sharp,LC-40SF466T,Lc_40foc466t,LC_40FOC466T
+Sharp,LC-42LE860H,LC-42LE860H,LC-42LE860H
+Sharp,LC-42LE860M,LC-42LE860M,LC-42LE860M
+Sharp,LC-45SF460T,Lc_45foc460t,LC_45FOC460T
+Sharp,LC-50LE570X,LC-xxLE570X,LC-xxLE570X
+Sharp,LC-50LE860H,LC-50LE860H,LC-50LE860H
+Sharp,LC-50LE860M,LC-50LE860M,LC-50LE860M
+Sharp,LC-50UE1H,LC-50UE1H,LC-50UE1H
+Sharp,LC-50UE1M,LC-50UE1M,LC-50UE1M
+Sharp,LC-55LE860H,LC-55LE860H,LC-55LE860H
+Sharp,LC-55LE860M,LC-55LE860M,LC-55LE860M
+Sharp,LC-58UE1H,LC-58UE1H,LC-58UE1H
+Sharp,LC-58UE1M,LC-58UE1M,LC-58UE1M
+Sharp,LC-A11A,a11a,LC-A11A
+Sharp,LC-A1H,a1h,LC-A1H
+Sharp,LC-LE580T,lc_le580t,LC-LE580T
+Sharp,LC-LE580X,lc_le580x,LC-LE580X
+Sharp,LC-LX565H,lx565h,LC-LX565H
+Sharp,LC-S3H-01,lc_s3h01,LC-S3H-01
+Sharp,LC-S4H/LC-S45H/LC-S50H,lc_xxcae5h,LC-xxCAE5H
+Sharp,LC-SU666T/LC-SU766T,lc_xxbel6t,LC-xxBEL6T
+Sharp,LC-U35T,lc_u35t,LC-U35T
+Sharp,LC-UA6800T/4T-C**AM1T,lc_theut,AQUOS-4KTVT17
+Sharp,LC-UA6800X,lc_theux,AQUOS-4KTVX17
+Sharp,LC-US5/LC-UH5/4T-C**AJ1/4T-C70AU1,lc_sunuj,AQUOS-4KTVJ17
+Sharp,LC-XU35T,lc_xu35t,LC-XU35T
+Sharp,LC-XU930X_830X,lc_xu930x_830x,LC-XU930X_830X
+Sharp,"LC-xxUA50H,LC-xxUF50H,LC-xxUD50H",lc_xxbel8h_b,LC-xxBEL8H-B
+Sharp,LC-xxUE630X,lc_ue630x,LC-UE630X
+Sharp,LCD-40SF465A,Lcd_40foc465a,LCD_40FOC465A
+Sharp,"LCD-40SF466A, LCD-40TX3000A, LCD-40MX3000A, LCD-40DS3000A, LCD-40X508A",Lcd_40foc466a,LCD_40FOC466A
+Sharp,LCD-40SF468A,Lcd_40foc468a,LCD_40FOC468A
+Sharp,"LCD-40X418H1A, LCD-40X418H2A, LCD-40X418H3A",LCD_40X418FOCH1A,LCD_40X418FOCH1A
+Sharp,LCD-45SF460A,Lcd_45foc46a,LCD_45FOC46A
+Sharp,LCD-45SF470A,cv6a648_base,LCD_xxSFFOC470A
+Sharp,LCD-45SF475A,Lcd_xxsffoc475a,LCD_xxSFFOC475A
+Sharp,LCD-45T45A/LCD-45T46A/LCD-45T47A,Lcd_foc36a,LCD_FOC36A
+Sharp,LCD-45TX3000A,Lcd_45foc3000a,LCD_45FOC3000A
+Sharp,"LCD-45X418H1A, LCD-45X418H2A, LCD-45X418H3A",LCD_45X418FOCH1A,LCD_45X418FOCH1A
+Sharp,LCD-50MY4000A/TX4000A/50SU470A,Lcd_50foc4000a,LCD_50FOC4000A
+Sharp,LCD-60SU470A,cv6a648_4K_base,LCD_xxSUFOC470A
+Sharp,LCD-60SU475A,Lcd_xxsufoc475a,LCD_xxSUFOC475A
+Sharp,LCD-LX460A,lx460a,LCD-LX460A
+Sharp,LCD-LX560A,lx560a,LCD-LX560A
+Sharp,LCD-LX565A,lx565ab,LCD-LX565A-B
+Sharp,LCD-LX565A,msd818sharp,LCD-LX565A
+Sharp,LCD-S3A,lcd_s3a01,LCD-S3A-01
+Sharp,LCD-SU460A/LCD-SU465A,lcd_xxcae5a_c,LCD-xxCAE5A-C
+Sharp,LCD-SU560A,lcd_xxcae5a,LCD-xxCAE5A
+Sharp,LCD-SU870A,lcd_xxbel8a_b,LCD-xxBEL8A-B
+Sharp,LCD-TX5000A,lcd_xxcae5a_d,LCD-xxCAE5A-D
+Sharp,LCD-UF30A,lcd_uf30a,LCD-UF30A
+Sharp,LCD-V3A,v3a,LCD-V3A
+Sharp,LCD-xxBEL6A,lcd_xxbel6a,LCD-xxBEL6A
+Sharp,LCD-xxBEL8A,lcd_xxbel8a,LCD-xxBEL8A
+Sharp,LCD-xxMY8009A,lcd_xxbel7a_d,LCD-xxBEL7A-D
+Sharp,LCD-xxSU670A/xxMY6100A/xxSU675A/xxSU775A/xxSU875A,lcd_xxdem6a,LCD-xxDEM6A
+Sharp,LCD-xxSU671A,Lcd_xxsufoc5a,LCD_xxSUFOC5A
+Sharp,LCD-xxSU775A;LCD-xxMY7100A,lcd_xxdem7a,LCD-xxDEM7A
+Sharp,LCD-xxSU875A;LCD-xxSU675A;LCD-xxMY8100A,lcd_xxdem8a,LCD-xxDEM8A
+Sharp,"LCD-xxSX970A,LCD-xxMY9100A",lcd_xxdem9a,LCD-xxDEM9A
+Sharp,"LCD-xxX818A,LCD-xxMY818A",lcd_xxdemxa,LCD-xxDEMXA
+Sharp,LC_50FOC45H,Lc_50foc45h,LC_50FOC45H
+Sharp,LYNX 3D SH-03C,SH03C,SH-03C
+Sharp,LYNX SH-10B,SH10B,SH-10B
+Sharp,Media Tablet,EB-L76G-B,EB-L76G-B
+Sharp,PANTONE 5 SoftBank 107SH,SBM107SH,SBM107SH
+Sharp,PANTONE 6 SoftBank 200SH,SBM200SH,SBM200SH
+Sharp,PN-B501/PN-B401,PN_B_series,PN_B_series
+Sharp,PN-B501/PN-B401,PN_B_series_w,PN_B_series
+Sharp,Q-pot.Phone SH-04D,SH04D,SH-04D
+Sharp,RW107,RW107,RW107
+Sharp,RZ-E302,rk3188_10P_A,RZ-E302
+Sharp,S3,rome_sprout,S3-SH
+Sharp,SBM204SH,SBM204SH,SBM204SH
+Sharp,SC-S01,scallop,SC-S01
+Sharp,SH-01E Vivienne Westwood,SH01EVW,SH-01EVW
+Sharp,SH-01F DRAGON QUEST,SH-01FDQ,SH-01FDQ
+Sharp,SH-03F,SH03F,SH-03F
+Sharp,SH-03H,SH-03H,SH-03H
+Sharp,SH-05E,SH05E,SH-05E
+Sharp,SH-06D NERV,SH06DNERV,SH-06DNERV
+Sharp,SH-H01,VZJ,SH-H01
+Sharp,SH-M04,SH-M04,SH-M04
+Sharp,SH80F,SH80F,SH80F
+Sharp,SH8118U,msm7627,SH8118U
+Sharp,SH8128U,msm7627,SH8128U
+Sharp,SH8188U,SH8188U,SH8188U
+Sharp,SH825wi,SH825Wi,SH825Wi
+Sharp,SHARP AQUOS S2,SS2,FS8010
+Sharp,SHARP AQUOS S2 Plus,SAT,FS8008
+Sharp,SHARP AQUOS S2 Plus,SAT,FS8016
+Sharp,SHARP R1S,SK3,FS8028
+Sharp,Sharp A Click,AH3,IF9003
+Sharp,Sharp Pi,AG3,IF9007
+Sharp,Sharp R1,SE3_TH,FS8014
+Sharp,Sharp R1,SE3_VN,FS8014
+Sharp,SoftBank 007SH KT,SBM007SHK,SBM007SHK
+Sharp,SoftBank 107SH B,SBM107SHB,SBM107SHB
+Sharp,SoftBank 305SH,SG305SH,305SH
+Sharp,SoftBank AQUOS PHONE Xx 203SH,SBM203SH,SBM203SH
+Sharp,Star Wars mobile,SW001SH,SW001SH
+Sharp,X1,nasa_sprout,X1
+Sharp,Yahoo! Phone SoftBank 009SH Y,SBM009SHY,SBM009SHY
+Sharp,Z2,TSP,FS8002
+Sharp,Z3,VN3N,FS8009
+Sharp,lcd_xxbel7a_c,lcd_xxbel7a_c,LCD-xxBEL7A-C
+Sharp,z3,VN3N,FS8009
+Sharp,\xe3\x82\xb7\xe3\x83\xb3\xe3\x83\x97\xe3\x83\xab\xe3\x82\xb9\xe3\x83\x9e\xe3\x83\x9b\xef\xbc\x93,SG509SH,509SH
+Sharp,\xe3\x83\xad\xe3\x83\x9c\xe3\x83\x9b\xe3\x83\xb3,SR01MW,SR01MW
+Sharp,\xe3\x83\xad\xe3\x83\x9c\xe3\x83\x9b\xe3\x83\xb3,SR02MW,SR02MW
+Shelby,ZA555,ZA555,ZA555
+SiAL,Bic camera,Si01BB,Si01BB
+SiAL,Si01BE,Si01BE,Si01BE
+Sico,PLUS2,Plus2,Plus2
+Sico,PLUS2 4G,Plus2_4G,Plus2 4G
+Sico SmartPhone,SSR1-5-8M,GBC_bravo,SSR1-5-8M
+Sico SmartPhone,SSR1-5-8M,GBC_bravo,sico pro
+Sigma Mobile,X-TREME PQ24,X-treme_PQ24,X-treme_PQ24
+Sigma Mobile,X-TREME PQ28,X-treme_PQ28,X-treme_PQ28
+Silent Circle,Blackphone 2,BP2,Blackphone 2
+Simbans,PicassoTab,PicassoTab,PicassoTab
+Siragon,SP-5000,SP-5000,Siragon SP-5000
+Sirin,LABS SOLARIN,solarin,SOLARIN
+Sirin,LABS SOLARIN,solarin,Solarin
+Sky Devices,ELITE 4.0S,Elite_4_0S_GT_Tigo,Elite_4.0S
+Sky Devices,PLATINUM 4.0,Platinum_40,Platinum 4.0
+Sky Devices,PLATINUM 4.0,Platinum_4_0,Platinum 4.0
+Sky Devices,PLATINUM 4.0+,Platinum_4_0Plus,Platinum_4_0Plus
+Sky Devices,PLATINUM 5.0M,Platinum_5_0M,Platinum_5.0M
+Sky Devices,SKY 5.0LM,SKY_50LM,SKY 5.0LM
+Sky Devices,SKY 5.0Pro II,SKY_50Pro_II,SKY 5.0Pro II
+SkyLife,UHD2,IC1110,IC1110
+SkyLife,skylife LTE TV,DMTS17SS,DMT_1621
+Skyworth,Asia,globe_ap,globe
+Skyworth,Europe,globe_eu,globe
+Skyworth,North America,globe_na,globe
+Skyworth,South America,globe_sa,globe
+Smailo,Smailo 2GO,Smailo_2GO,Smailo_2GO
+Smartab,SRF79,SRF79,SRF79
+Smartab,ST1009X,ST1009X,ST1009X
+Smartab,ST700,ST700,ST700
+Smartab,ST7150,ST7150,ST7150
+Smartab,STJR700,STJR700,STJR700
+Smartab,STJR76,STJR76,STJR76
+Smartfren,A16C3H,A16C3H,Andromax A16C3H
+Smartfren,A26C4H,A26C4H,Andromax A26C4H
+Smartfren,AD688G,AD688G,Smartfren Andromax AD688G
+Smartfren,AD689G,AD689G,Smartfren Andromax AD689G
+Smartfren,Andromax AD682H,AD682H,Smartfren Andromax AD682H
+Smartfren,Andromax AD687G,AD687G,Andromax AD687G
+Smartfren,Andromax C46B2G,HS8916QC,Andromax C46B2G
+Smartfren,AndromaxNC36B1H,NC36B1H,Smartfren Andromax NC36B1H
+Smartfren,B16C2G,MSM8909QC,Andromax B16C2G
+Smartfren,B16C2H,B16C2H,Andromax B16C2H
+Smartfren,B26D2H,B26D2H,Andromax B26D2H
+Smartfren,C2LEAD688G,C2LEAD688G,Smartfren Andromax AD688G
+Smartfren,EG680,eg680,EG680
+Smartfren,G36C1G,HS8916QC,Andromax G36C1G
+Smartfren,G36C1H,G36C1H,Andromax G36C1H
+Smartfren,I46D1G,HS8916QC,Andromax I46D1G
+Smartfren,NC36B1G,HS8610QC,Smartfren Andromax NC36B1G
+Smartfren,NEWAD688G,NEWAD688G,Smartfren Andromax AD688G
+Smartron,Srtphone,rimo02a,T5524
+Smartron,tphone,rimo01a,T5511
+Sonimtech,Ex-Handy 09,XP6700Z1,Ex-Handy 09
+Sonimtech,Smart-Ex 01,XP7700Z1,Smart-Ex 01
+Sonimtech,XP6,XP6700,Ex-Handy 209
+Sonimtech,XP6,XP6700,XP6700
+Sonimtech,XP7,XP7700,Smart-Ex 201
+Sonimtech,XP7,XP7700,XP7700
+Sonimtech,XP7,XP7700Z1,Smart-Ex 01
+Sonimtech,XP7700Z1,XP7700Z1,Smart-Ex 01
+Sonimtech,XP7705,XP7705,XP7700
+Sony,,C5503,C5503
+Sony,,C6616,C6616
+Sony,,SGP312,SGP312
+Sony,,ST21i,ST21i
+Sony,,ST23i,ST23i
+Sony,,ST26i,ST26i
+Sony,,nbx02,Sony Tablet P
+Sony,BRAVIA 2015,SVP-DTV15,BRAVIA 2015
+Sony,BRAVIA 4K 2015,SVP-DTV15,BRAVIA 2015
+Sony,BRAVIA 4K 2015,SVP-DTV15,BRAVIA 4K 2015
+Sony,BRAVIA 4K GB,BRAVIA_ATV2,BRAVIA 4K GB
+Sony,BRAVIA Smart Stick,NSZGU1,NSZ-GU1
+Sony,Ericsson Live with Walkman,WT19a,WT19a
+Sony,Ericsson Live with Walkman,WT19i,WT19i
+Sony,Internet TV,asura,Internet TV
+Sony,Internet TV,eagle,Internet TV Box
+Sony,NSZGS7,NSZGS7,NSZ-GS7/GX70
+Sony,NW-F800,icx1227,WALKMAN
+Sony,NW-F880 Series,icx1237,WALKMAN
+Sony,NW-Z1000,icx1216,NW-Z1000Series
+Sony,NW-ZX1,icx1240,WALKMAN
+Sony,NW-ZX2,icx1265,WALKMAN
+Sony,NWZ-Z1000,icx1216,NWZ-Z1000Series
+Sony,NWZ-ZX1,icx1240,WALKMAN
+Sony,SmartWatch 3,tetra,SmartWatch 3
+Sony,Smartphone Z Ultra Google Play edition,C6806,C6806_GPe
+Sony,Tablet P,nbx02,Sony Tablet P
+Sony,Tablet S,nbx03,Sony Tablet S
+Sony,Xperia  E1 dual,D2114,D2114
+Sony,Xperia  M,C1905,C1905
+Sony,Xperia A,SO-04E,SO-04E
+Sony,Xperia A2,SO-04F,SO-04F
+Sony,Xperia A4,SO-04G,SO-04G
+Sony,Xperia C,C2304,C2304
+Sony,Xperia C,C2305,C2305
+Sony,Xperia C3,D2533,D2533
+Sony,Xperia C3 Dual,D2502,D2502
+Sony,Xperia C5 Ultra,E5506,E5506
+Sony,Xperia C5 Ultra,E5553,E5553
+Sony,Xperia C5 Ultra Dual,E5533,E5533
+Sony,Xperia C5 Ultra Dual,E5563,E5563
+Sony,Xperia E,C1504,C1504
+Sony,Xperia E,C1505,C1505
+Sony,Xperia E dual,C1604,C1604
+Sony,Xperia E dual,C1605,C1605
+Sony,Xperia E1,D2004,D2004
+Sony,Xperia E1,D2005,D2005
+Sony,Xperia E1,D2114,D2114
+Sony,Xperia E1 Dual,D2104,D2104
+Sony,Xperia E1 Dual,D2105,D2105
+Sony,Xperia E1 dual,D2104,D2104
+Sony,Xperia E1 dual,D2105,D2105
+Sony,Xperia E3,D2202,D2202
+Sony,Xperia E3,D2203,D2203
+Sony,Xperia E3,D2206,D2206
+Sony,Xperia E3,D2243,D2243
+Sony,Xperia E3 Dual,D2212,D2212
+Sony,Xperia E4g,E2053,E2053
+Sony,Xperia E4g Dual,E2033,E2033
+Sony,Xperia E4g Dual,E2043,E2043
+Sony,Xperia E5,F3311,F3311
+Sony,Xperia E5,F3313,F3313
+Sony,Xperia Go,ST27a,ST27a
+Sony,Xperia Go,ST27i,ST27i
+Sony,Xperia Hello,G1209,G1209
+Sony,Xperia J,ST26a,ST26a
+Sony,Xperia J,ST26i,ST26i
+Sony,Xperia J1 Compact,D5788,D5788
+Sony,Xperia L,C2104,C2104
+Sony,Xperia L,C2105,C2105
+Sony,Xperia L1,G3311,G3311
+Sony,Xperia L1,G3312,G3312
+Sony,Xperia L1,G3313,G3313
+Sony,Xperia M,C1904,C1904
+Sony,Xperia M,C1905,C1905
+Sony,Xperia M Dual,C2005,C2005
+Sony,Xperia M dual,C2004,C2004
+Sony,Xperia M dual,C2005,C2005
+Sony,Xperia M2,D2303,D2303
+Sony,Xperia M2,D2305,D2305
+Sony,Xperia M2,D2306,D2306
+Sony,Xperia M2 Aqua,D2403,D2403
+Sony,Xperia M2 Aqua,D2406,D2406
+Sony,Xperia M2 Dual,D2302,D2302
+Sony,Xperia M2 dual,D2302,D2302
+Sony,Xperia M5,E5603,E5603
+Sony,Xperia M5,E5606,E5606
+Sony,Xperia M5,E5653,E5653
+Sony,Xperia M5 Dual,E5633,E5633
+Sony,Xperia M5 Dual,E5643,E5643
+Sony,Xperia M5 Dual,E5663,E5663
+Sony,Xperia Miro,ST23i,ST23i
+Sony,Xperia P,LT22i,LT22i
+Sony,Xperia PLAY,R800a,R800a
+Sony,Xperia PLAY,R800i,R800i
+Sony,Xperia R1,G2199,G2199
+Sony,Xperia R1 Plus,G2299,G2299
+Sony,Xperia S,LT26i,LT26i
+Sony,Xperia SL,LT26ii,LT26ii
+Sony,Xperia SP,C5302,C5302
+Sony,Xperia SP,C5303,C5303
+Sony,Xperia SP,C5306,C5306
+Sony,Xperia SP,M35h,M35h
+Sony,Xperia SP,M35t,M35t
+Sony,Xperia T,LT30a,LT30a
+Sony,Xperia T,LT30p,LT30p
+Sony,Xperia T2 Ultra,D5303,D5303
+Sony,Xperia T2 Ultra,D5306,D5306
+Sony,Xperia T2 Ultra,D5316,D5316
+Sony,Xperia T2 Ultra,D5316N,D5316N
+Sony,Xperia T2 Ultra,D5322,D5322
+Sony,Xperia T2 Ultra dual,D5322,D5322
+Sony,Xperia T3,D5102,D5102
+Sony,Xperia T3,D5103,D5103
+Sony,Xperia T3,D5106,D5106
+Sony,Xperia TX,LT29i,LT29i
+Sony,Xperia Tablet S,txs03,SGPT12
+Sony,Xperia Tablet S,txs03,SGPT13
+Sony,Xperia Tablet Z,SGP311,SGP311
+Sony,Xperia Tablet Z,SGP312,SGP312
+Sony,Xperia Tablet Z,SGP321,SGP321
+Sony,Xperia Tablet Z,SGP351,SGP351
+Sony,Xperia Tipo,ST21i,ST21i
+Sony,Xperia Tipo,ST21i2,ST21i2
+Sony,Xperia Touch,G1109,G1109
+Sony,Xperia U,ST25a,ST25a
+Sony,Xperia U,ST25i,ST25i
+Sony,Xperia V,LT25i,LT25i
+Sony,Xperia X,F5121,F5121
+Sony,Xperia X,F5122,F5122
+Sony,Xperia X,suzu,F5121
+Sony,Xperia X Compact,F5321,F5321
+Sony,Xperia X Compact,SO-02J,SO-02J
+Sony,Xperia X Performance,502SO,502SO
+Sony,Xperia X Performance,F8131,F8131
+Sony,Xperia X Performance,F8132,F8132
+Sony,Xperia X Performance,SO-04H,SO-04H
+Sony,Xperia X Performance,SOV33,SOV33
+Sony,Xperia XA,F3111,F3111
+Sony,Xperia XA,F3112,F3112
+Sony,Xperia XA,F3113,F3113
+Sony,Xperia XA,F3115,F3115
+Sony,Xperia XA,F3116,F3116
+Sony,Xperia XA Ultra,F3211,F3211
+Sony,Xperia XA Ultra,F3212,F3212
+Sony,Xperia XA Ultra,F3213,F3213
+Sony,Xperia XA Ultra,F3215,F3215
+Sony,Xperia XA Ultra,F3216,F3216
+Sony,Xperia XA1,G3112,G3112
+Sony,Xperia XA1,G3116,G3116
+Sony,Xperia XA1,G3121,G3121
+Sony,Xperia XA1,G3123,G3123
+Sony,Xperia XA1,G3125,G3125
+Sony,Xperia XA1 Plus,G3412,G3412
+Sony,Xperia XA1 Plus,G3416,G3416
+Sony,Xperia XA1 Plus,G3421,G3421
+Sony,Xperia XA1 Plus,G3423,G3423
+Sony,Xperia XA1 Plus,G3426,G3426
+Sony,Xperia XA1 Ultra,G3212,G3212
+Sony,Xperia XA1 Ultra,G3221,G3221
+Sony,Xperia XA1 Ultra,G3223,G3223
+Sony,Xperia XA1 Ultra,G3226,G3226
+Sony,Xperia XZ,601SO,601SO
+Sony,Xperia XZ,F8331,F8331
+Sony,Xperia XZ,F8332,F8332
+Sony,Xperia XZ,SO-01J,SO-01J
+Sony,Xperia XZ,SOV34,SOV34
+Sony,Xperia XZ Premium,G8141,G8141
+Sony,Xperia XZ Premium,G8142,G8142
+Sony,Xperia XZ Premium,G8188,G8188
+Sony,Xperia XZ Premium,SO-04J,SO-04J
+Sony,Xperia XZ1,701SO,701SO
+Sony,Xperia XZ1,G8341,G8341
+Sony,Xperia XZ1,G8342,G8342
+Sony,Xperia XZ1,G8343,G8343
+Sony,Xperia XZ1,SO-01K,SO-01K
+Sony,Xperia XZ1,SOV36,SOV36
+Sony,Xperia XZ1 Compact,G8441,G8441
+Sony,Xperia XZ1 Compact,SO-02K,SO-02K
+Sony,Xperia XZs,602SO,602SO
+Sony,Xperia XZs,G8231,G8231
+Sony,Xperia XZs,G8232,G8232
+Sony,Xperia XZs,SO-03J,SO-03J
+Sony,Xperia XZs,SOV35,SOV35
+Sony,Xperia Z,C6602,C6602
+Sony,Xperia Z,C6603,C6603
+Sony,Xperia Z,C6606,C6606
+Sony,Xperia Z,C6616,C6616
+Sony,Xperia Z,L36h,L36h
+Sony,Xperia Z,SO-02E,SO-02E
+Sony,Xperia Z Ultra,C6802,C6802
+Sony,Xperia Z Ultra,C6806,C6806
+Sony,Xperia Z Ultra,C6833,C6833
+Sony,Xperia Z Ultra,C6843,C6843
+Sony,Xperia Z Ultra,SGP412,SGP412
+Sony,Xperia Z Ultra,SOL24,SOL24
+Sony,Xperia Z Ultra,XL39h,XL39h
+Sony,Xperia Z1,C6902,C6902
+Sony,Xperia Z1,C6903,C6903
+Sony,Xperia Z1,C6906,C6906
+Sony,Xperia Z1,C6916,C6916
+Sony,Xperia Z1,C6943,C6943
+Sony,Xperia Z1,L39h,L39h
+Sony,Xperia Z1,L39t,L39t
+Sony,Xperia Z1,L39u,L39u
+Sony,Xperia Z1,SO-01F,SO-01F
+Sony,Xperia Z1,SOL23,SOL23
+Sony,Xperia Z1 Compact,D5503,D5503
+Sony,Xperia Z1 Compact,M51w,M51w
+Sony,Xperia Z1f,SO-02F,SO-02F
+Sony,Xperia Z2,D6502,D6502
+Sony,Xperia Z2,D6503,D6503
+Sony,Xperia Z2,D6543,D6543
+Sony,Xperia Z2,SO-03F,SO-03F
+Sony,Xperia Z2 Tablet,SGP511,SGP511
+Sony,Xperia Z2 Tablet,SGP512,SGP512
+Sony,Xperia Z2 Tablet,SGP521,SGP521
+Sony,Xperia Z2 Tablet,SGP551,SGP551
+Sony,Xperia Z2 Tablet,SGP561,SGP561
+Sony,Xperia Z2 Tablet,SO-05F,SO-05F
+Sony,Xperia Z2 Tablet,SOT21,SOT21
+Sony,Xperia Z2a,D6563,D6563
+Sony,Xperia Z3,401SO,401SO
+Sony,Xperia Z3,D6603,D6603
+Sony,Xperia Z3,D6616,D6616
+Sony,Xperia Z3,D6643,D6643
+Sony,Xperia Z3,D6646,D6646
+Sony,Xperia Z3,D6653,D6653
+Sony,Xperia Z3,SO-01G,SO-01G
+Sony,Xperia Z3,SOL26,SOL26
+Sony,Xperia Z3,leo,D6603
+Sony,Xperia Z3 Compact,D5803,D5803
+Sony,Xperia Z3 Compact,D5833,D5833
+Sony,Xperia Z3 Compact,SO-02G,SO-02G
+Sony,Xperia Z3 Compact,aries,D5803
+Sony,Xperia Z3 Dual,D6633,D6633
+Sony,Xperia Z3 Dual,D6683,D6683
+Sony,Xperia Z3 Tablet Compact,SGP611,SGP611
+Sony,Xperia Z3 Tablet Compact,SGP612,SGP612
+Sony,Xperia Z3 Tablet Compact,SGP621,SGP621
+Sony,Xperia Z3 Tablet Compact,SGP641,SGP641
+Sony,Xperia Z3+,E6553,E6553
+Sony,Xperia Z3+ Dual,E6533,E6533
+Sony,Xperia Z3v,D6708,D6708
+Sony,Xperia Z4,402SO,402SO
+Sony,Xperia Z4,SO-03G,SO-03G
+Sony,Xperia Z4,SOV31,SOV31
+Sony,Xperia Z4 Tablet,SGP712,SGP712
+Sony,Xperia Z4 Tablet,SGP771,SGP771
+Sony,Xperia Z4 Tablet,SO-05G,SO-05G
+Sony,Xperia Z4 Tablet,SOT31,SOT31
+Sony,Xperia Z4v,E6508,E6508
+Sony,Xperia Z5,501SO,501SO
+Sony,Xperia Z5,E6603,E6603
+Sony,Xperia Z5,E6653,E6653
+Sony,Xperia Z5,SO-01H,SO-01H
+Sony,Xperia Z5,SOV32,SOV32
+Sony,Xperia Z5 Compact,E5803,E5803
+Sony,Xperia Z5 Compact,E5823,E5823
+Sony,Xperia Z5 Compact,SO-02H,SO-02H
+Sony,Xperia Z5 Premium,E6853,E6853
+Sony,Xperia Z5 Premium,E6883,E6883
+Sony,Xperia Z5 Premium,SO-03H,SO-03H
+Sony,Xperia Z5 Premium Dual,E6833,E6833
+Sony,Xperia Z5 dual,E6633,E6633
+Sony,Xperia Z5 dual,E6683,E6683
+Sony,Xperia ZL,C6502,C6502
+Sony,Xperia ZL,C6503,C6503
+Sony,Xperia ZL,C6506,C6506
+Sony,Xperia ZL,L35h,L35h
+Sony,Xperia ZL2,SOL25,SOL25
+Sony,Xperia ZR,C5306,C5306
+Sony,Xperia ZR,C5502,C5502
+Sony,Xperia ZR,C5503,C5503
+Sony,Xperia acro HD,SO-03D,SO-03D
+Sony,Xperia acro S,LT26w,LT26w
+Sony,Xperia active,ST17i,ST17i
+Sony,Xperia arc S,LT18i,LT18i
+Sony,Xperia go,ST27i,ST27i
+Sony,Xperia ion,LT28h,LT28h
+Sony,Xperia ion,LT28i,LT28i
+Sony,Xperia mini pro,SK17a,SK17a
+Sony,Xperia miro,ST23a,ST23a
+Sony,Xperia miro,ST23i,ST23i
+Sony,Xperia neo L,MT25i,MT25i
+Sony,Xperia pro,MK16i,MK16i
+Sony,Xperia ray,ST18i,ST18i
+Sony,Xperia sola,MT27i,MT27i
+Sony,Xperia tipo,ST21a,ST21a
+Sony,Xperia tipo dual,ST21a2,ST21a2
+Sony,Xperia\xe2\x84\xa2 C4,E5303,E5303
+Sony,Xperia\xe2\x84\xa2 C4,E5306,E5306
+Sony,Xperia\xe2\x84\xa2 C4,E5353,E5353
+Sony,Xperia\xe2\x84\xa2 C4 Dual,E5333,E5333
+Sony,Xperia\xe2\x84\xa2 C4 Dual,E5343,E5343
+Sony,Xperia\xe2\x84\xa2 C4 Dual,E5363,E5363
+Sony,Xperia\xe2\x84\xa2 E4,E2104,E2104
+Sony,Xperia\xe2\x84\xa2 E4,E2105,E2105
+Sony,Xperia\xe2\x84\xa2 E4 Dual,E2115,E2115
+Sony,Xperia\xe2\x84\xa2 E4 Dual,E2124,E2124
+Sony,Xperia\xe2\x84\xa2 E4g,E2003,E2003
+Sony,Xperia\xe2\x84\xa2 E4g,E2006,E2006
+Sony,Xperia\xe2\x84\xa2 M4 Aqua,E2303,E2303
+Sony,Xperia\xe2\x84\xa2 M4 Aqua,E2306,E2306
+Sony,Xperia\xe2\x84\xa2 M4 Aqua,E2353,E2353
+Sony,Xperia\xe2\x84\xa2 M4 Aqua Dual,E2312,E2312
+Sony,Xperia\xe2\x84\xa2 M4 Aqua Dual,E2333,E2333
+Sony,Xperia\xe2\x84\xa2 M4 Aqua Dual,E2363,E2363
+Sony Ericsson,,LT15a,LT15a
+Sony Ericsson,,LT18i,LT18i
+Sony Ericsson,,LT22i,LT22i
+Sony Ericsson,,LT26i,LT26i
+Sony Ericsson,,LT28h,LT28h
+Sony Ericsson,,LT28i,LT28i
+Sony Ericsson,,MK16a,MK16a
+Sony Ericsson,,MK16i,MK16i
+Sony Ericsson,,MT11i,MT11i
+Sony Ericsson,,MT15i,MT15i
+Sony Ericsson,,MT27i,MT27i
+Sony Ericsson,,R800x,R800x
+Sony Ericsson,,SK17i,SK17i
+Sony Ericsson,,ST15i,ST15i
+Sony Ericsson,,ST17i,ST17i
+Sony Ericsson,,ST18i,ST18i
+Sony Ericsson,,WT18i,WT18i
+Sony Ericsson,,WT19a,WT19a
+Sony Ericsson,,WT19i,WT19i
+Sony Ericsson,Live with Walkman,WT19a,WT19a
+Sony Ericsson,Live with Walkman,WT19i,WT19i
+Sony Ericsson,Live with Walkman(TM),WT19a,WT19a
+Sony Ericsson,X10 Xperia Mini,robyn,E10i
+Sony Ericsson,Xperia AX,SO-01E,SO-01E
+Sony Ericsson,Xperia Acro,IS11S,IS11S
+Sony Ericsson,Xperia Acro,SO-02C,SO-02C
+Sony Ericsson,Xperia Arc,LT15i,LT15i
+Sony Ericsson,Xperia Arc,SO-01C,SO-01C
+Sony Ericsson,Xperia C,S39h,S39h
+Sony Ericsson,Xperia GX,SO-04D,SO-04D
+Sony Ericsson,Xperia Go,ST27a,ST27a
+Sony Ericsson,Xperia Go,ST27i,ST27i
+Sony Ericsson,Xperia J,ST26i,ST26i
+Sony Ericsson,Xperia Neo,MT15i,MT15i
+Sony Ericsson,Xperia P,LT22i,LT22i
+Sony Ericsson,Xperia PLAY,R800a,R800a
+Sony Ericsson,Xperia PLAY,R800at,R800at
+Sony Ericsson,Xperia PLAY,R800i,R800i
+Sony Ericsson,Xperia PLAY,R800x,R800x
+Sony Ericsson,Xperia PLAY,SO-01D,SO-01D
+Sony Ericsson,Xperia Play,R800i,R800i
+Sony Ericsson,Xperia Play,Zeus,Zeus
+Sony Ericsson,Xperia S,LT26i,LT26i
+Sony Ericsson,Xperia S,SO-02D,SO-02D
+Sony Ericsson,Xperia SL,LT26ii,LT26ii
+Sony Ericsson,Xperia SP,M35c,M35c
+Sony Ericsson,Xperia SX,SO-05D,SO-05D
+Sony Ericsson,Xperia T,LT30a,LT30a
+Sony Ericsson,Xperia T,LT30at,LT30at
+Sony Ericsson,Xperia T,LT30p,LT30p
+Sony Ericsson,Xperia TX,LT29i,LT29i
+Sony Ericsson,Xperia Tablet Z,SGP311,SGP311
+Sony Ericsson,Xperia Tablet Z,SGP321,SGP321
+Sony Ericsson,Xperia Tablet Z,SGP341,SGP341
+Sony Ericsson,Xperia Tablet Z,SO-03E,SO-03E
+Sony Ericsson,Xperia U,ST25i,ST25i
+Sony Ericsson,Xperia UL,SOL22,SOL22
+Sony Ericsson,Xperia V,LT25c,LT25c
+Sony Ericsson,Xperia V,LT25i,LT25i
+Sony Ericsson,Xperia VL,SOL21,SOL21
+Sony Ericsson,Xperia X10,SO-01B,SO-01B
+Sony Ericsson,Xperia X10,SonyEricssonSO-01B,SO-01B
+Sony Ericsson,Xperia X10,SonyEricssonX10iv,X10i
+Sony Ericsson,Xperia X10,X10a,X10a
+Sony Ericsson,Xperia X10,X10i,X10i
+Sony Ericsson,Xperia X10 Mini,E10i,E10i
+Sony Ericsson,Xperia X10 Mini,SonyEricssonE10i,E10i
+Sony Ericsson,Xperia X10 Mini Pro,U20i,U20i
+Sony Ericsson,Xperia X10 mini,SonyEricssonE10a,E10a
+Sony Ericsson,Xperia X10 mini pro,SonyEricssonU20a,U20a
+Sony Ericsson,Xperia X8,E15i,E15i
+Sony Ericsson,Xperia Z,SO-02E,SO-02E
+Sony Ericsson,Xperia Z Ultra,C6806,C6806
+Sony Ericsson,Xperia Z1,C6903,C6903
+Sony Ericsson,Xperia Z1,C6906,C6906
+Sony Ericsson,Xperia Z1,C6943,C6943
+Sony Ericsson,Xperia acro HD,IS12S,IS12S
+Sony Ericsson,Xperia acro S,LT26w,LT26w
+Sony Ericsson,Xperia active,ST17i,ST17i
+Sony Ericsson,Xperia arc,LT15a,LT15a
+Sony Ericsson,Xperia arc,LT15i,LT15i
+Sony Ericsson,Xperia arc S,LT18a,LT18a
+Sony Ericsson,Xperia arc S,LT18i,LT18i
+Sony Ericsson,Xperia go,ST27i,ST27i
+Sony Ericsson,Xperia ion,LT28at,LT28at
+Sony Ericsson,Xperia ion,LT28h,LT28h
+Sony Ericsson,Xperia ion,LT28i,LT28i
+Sony Ericsson,Xperia live,WT19a,WT19a
+Sony Ericsson,Xperia mini,S51SE,S51SE
+Sony Ericsson,Xperia mini,ST15a,ST15a
+Sony Ericsson,Xperia mini,ST15i,ST15i
+Sony Ericsson,Xperia mini pro,SK17a,SK17a
+Sony Ericsson,Xperia mini pro,SK17i,SK17i
+Sony Ericsson,Xperia miro,ST23i,ST23i
+Sony Ericsson,Xperia neo,MT15a,MT15a
+Sony Ericsson,Xperia neo,MT15i,MT15i
+Sony Ericsson,Xperia neo L,MT25i,MT25i
+Sony Ericsson,Xperia neo V,MT11a,MT11a
+Sony Ericsson,Xperia neo V,MT11i,MT11i
+Sony Ericsson,Xperia pro,MK16a,MK16a
+Sony Ericsson,Xperia pro,MK16i,MK16i
+Sony Ericsson,Xperia ray,SO-03C,SO-03C
+Sony Ericsson,Xperia ray,ST18a,ST18a
+Sony Ericsson,Xperia ray,ST18i,ST18i
+Sony Ericsson,Xperia sola,MT27i,MT27i
+Sony Ericsson,Xperia tipo,ST21i,ST21i
+Sony Ericsson,Xperia tipo dual,ST21i2,ST21i2
+Sophix_Digix,TAB-750_G,TAB-750_G,TAB-750_G
+Sourcing Creation,Connect 451,Connect451,Connect 451
+Sourcing Creation,Connect 504,Q9,Connect504
+Sourcing Creation,Connect502,Connect502,Connect502
+Sourcing Creation,Connect502,MT502,Connect502
+Sourcing Creation,Connect551,Connect551,Connect551
+Sourcing Creation,Key\'TAB 1001,MB979T9,Smarttab_9701
+Sourcing Creation,ST1003S,T1882R,Smart_TAB_1003s
+Sourcing Creation,Smart TAB 1005,M16Q1C,SmartTab1005
+Sourcing Creation,Smart Tab 1004XS,SmartTab_1004_XS,SmartTab_1004_XS
+Sourcing Creation,Smart\' Tab 1006,M16Q1A,SmartTab1006
+Sourcing Creation,SmartTab_8004,T814,SmartTab_8004
+Sourcing Creation,Web\'Pad_1002_02,Webpad_1002_02,Webpad_1002_02
+Sourcing Creation,Wooze I 5,Wooze_I5,Wooze_I5
+Sourcing Creation,Wooze I 5.5 Gris,Wooze_I55,Wooze_I55
+Sourcing Creation,Wooze L,Wooze_L,Wooze_L
+Sourcing Creation,Wooze XL,Wooze_XL,Wooze_XL
+Sourcing Creation,WoozeI45,WoozeI45,WoozeI45
+Sourcing Creation,sp401,sp401,sp401
+Sourcing Creation,webpad_7005,MB709Q5,Webpad_7005
+Southern Telecom,A1000/P1003/P1010,A1000,A1000/P1003/P1010
+Southern Telecom,A400,A400,A400
+Southern Telecom,A5,A5,A5
+Southern Telecom,A500,Polaroid_Phone,a500
+Southern Telecom,A600,A600,A600
+Southern Telecom,Emerson EM756,EM756,EM756
+Southern Telecom,M10,ST1009,M10
+Southern Telecom,M10,ST1009,M10/Q1010
+Southern Telecom,M11H/Q1100,M11H,M11H/Q1100
+Southern Telecom,Nook Tablet 7\xe2\x80\x9d,st16c7bnn,BNTV450
+Southern Telecom,P709/P716,P709,P709/P716
+Southern Telecom,P7100,P7100,P7100
+Southern Telecom,P909,P909,P909
+Southern Telecom,PDT9000,PDT9000,PDT9000
+Southern Telecom,Polaroid L10/P1000,L10,L10
+Southern Telecom,Polaroid M11,M11,M11
+Southern Telecom,Polaroid P700/A700,P700,P700/A700
+Southern Telecom,Polaroid P902/A900,P902,P902/A900
+Southern Telecom,Polaroid Power P600,P600,P600
+Southern Telecom,Polaroid Snap S50,S50,S50
+Southern Telecom,Polaroid Snap S55,S55,S55
+Southern Telecom,Polaroid Snap S60,S60,S60
+Southern Telecom,ST1009,ST1009,ST1009
+Southern Telecom,ST13,ST13,ST13
+Southern Telecom,ST706,P709,ST706
+Southern Telecom,Smartab ST10,ST10,ST10/ST10x
+Southern Telecom,Smartab ST7,ST7,ST7/ST7x
+Southern Telecom,Streamachine,X13,X13
+Southern Telecom,a4,a4,a4
+SpectraPrecision,Ranger 5 Handheld,workhorse_wifi,Ranger5
+SpectraPrecision,Ranger 8 Handheld,pelican,Ranger8
+SpectraPrecision,Ranger 8 Handheld,pelican_wifi,Ranger8
+SpectraPrecision,Spectra Ranger 5,workhorse,Ranger5
+Spectralink,8744,thor_6dq,8744
+Spectralink,PIVOT 8741/8753,thor_6dq,8741
+Spectralink,PIVOT 8741/8753,thor_6dq,8742
+Spectralink,PIVOT 8741/8753,thor_6dq,8753
+Spice,Dream Uno,Mi-498_sprout,Spice Mi-498
+Spice,Dream Uno,Mi-498_sprout,Spice Mi-498H
+Spice,F301,Spice_F301,Spice F301
+Spice,F305,Spice-F305,Spice F305
+Spice,K601,Spice_K601,Spice K601
+Spice,Smart Flo Mi-449,SpiceMi449,SpiceMi-449
+Spice,Smart Flo Mi-449,hongyu72_wet_jb3,SpiceMi-449
+Spice,Spice F302,Spice_F302,Spice F302
+Spice,Spice V801,Spice_V801,Spice V801
+Spice,Stellar Mi-438,Spice,MI-438
+Spice,Stellar Mi-506,SpiceMi506,Spice Mi-506
+Spice,Victor5,Spice,Xlife-Victor5
+Spice,Xlife-441Q,Spice,Xlife-415
+Spice,Xlife-441Q,Spice,Xlife-441Q
+Spice,Xlife-450Q,Spice,Xlife-450Q
+Spice,Xlife-514Q,Spice,Xlife-514Q
+Spice,Xlife-M44Q,Spice,Xlife-M44Q
+Spice,Xlife-Proton 5 pro,Spice,Xlife-Proton5 Pro
+Sprint,AQT100,NKJ_AQT100,AQT100
+Sprint,AQT82,NKSA_AQT82,AQT82
+Sprint,HTC Bolt,htc_acawhl,2PYB2
+Sprint,Slate 8 Tablet,NKS_AQT80,AQT80
+StarMobile,UP Prime,UP_Prime,UP Prime
+StarMobile,UP Selfie,UP_Selfie,UP_Selfie
+Starlight,I STAR PLUS,I_STAR_PLUS,I_STAR_PLUS
+Storex,eZee\'Tab7Q11-M,Tab7Q11,Tab7Q11
+Storex,eZeeTab10D12-S,eZeeTab10D12-S,eZeeTab10D12-S
+Storex,eZeeTab7D15-M,eZeeTab7D15-M,eZeeTab7D15-M
+Storex,eZee\xe2\x80\x99Tab7D14-S,STOREX7526,NID_7010
+Stream,B1,B1,B1
+Stream,B2s,B2s,B2s
+Stream,FIXION,HS8937QC,FIXION
+Stream,Iron Pro,IRON_Pro,IRON Pro
+Stream,PERLA,PERLA,PERLA
+Stream,SHARK,SHARK,SHARK
+Sts-tottori,JR-500,JR-500,JR-500
+Sts-tottori,JR-P2000,JR-P2000,JR-P2000
+Sts-tottori,TAB-A03,TAB-A03,TAB-A03-SD
+Stylo,S551,STYLO_S551,STYLO S551
+Stylo,STYLOF1,STYLOF1,STYLO F1
+Stylo,STYLO_S61,STYLO_S61,STYLO SM61 MAGIC+
+Stylo,STYLO_S61,STYLO_S61,STYLO SV61 VECTOR+
+Stylo,VS5502,VS5502,VS5502
+Stylus,AT703,AT703,AT703
+Stylus,Comet_SP5002G,Comet_SP5002G,Comet_SP5002G
+Stylus,FUNDA,ETAB_I1041G,ETAB I1041G
+Stylus,FUNDA,ETAB_I7041G,ETAB_I7041G
+Stylus,IFS100,IFS100,IFS100
+Stylus,Rida SP5003G LTE,Rida_SP5003G_LTE,Rida_SP5003G_LTE
+Stylus,Sumo SP5201G LTE,Sumo_SP5201G_LTE,Sumo_SP5201G_LTE
+Stylus,Sumo_XL_SP5501G_LTE,Sumo_XL_SP5501G_LTE,Sumo_XL_SP5501G_LTE
+Stylus,Symbol SP4002G,Symbol_SP4002G,Symbol_SP4002G
+Sugar,Sugar,s9121,SUGAR
+Sumitomo Electric Industries,ST4173,ST4173,ST4173
+Sumitomo Electric Networks,,dhe1100,Hikari-iFrame/WDPF-703SE
+Swipe,Elite 4G,Elite_4G,Elite 4G
+Swipe,Razor,Swipe_Razor,Razor
+Swipe,Strike,Swipe_Strike,Strike
+Swisstone,swisstone SD 510,SD5103G,swisstone SD 510
+Swisstone,swisstone SD 530,SD5304G,swisstone SD 530
+Symphony,H300,H300,H300
+Symphony,H400,H400,H400
+Symphony,H58,H58,H58
+Symphony,INOVA,INOVA,INOVA
+Symphony,P6 PRO,P6_PRO,P6 PRO
+Symphony,P7,Symphony_P7,P7
+Symphony,P7 Pro,P7_PRO,Symphony P7 PRO
+Symphony,P8 PRO,P8_PRO,P8 PRO
+Symphony,P9,P9,P9
+Symphony,P9+,P9_Plus,P9 Plus
+Symphony,R100,R100,Symphony R100
+Symphony,R20,R20,R20
+Symphony,R30,R30,R30
+Symphony,Roar A50,Roar_A50_sprout,Roar_A50
+Symphony,SYMTAB25,SYMTAB25,SYMTAB25
+Symphony,SYMTAB60,SYMTAB60,SYMTAB60
+Symphony,Symphony_Z9,Z9,Symphony Z9
+Symphony,V100,V100,V100
+Symphony,V110,V110,V110
+Symphony,V120,V120,V120
+Symphony,V34,V34,V34
+Symphony,V47,V47,V47
+Symphony,V65,V65,V65
+Symphony,V75,V75,V75
+Symphony,V75m,V75m,V75m
+Symphony,V85,V85,V85
+Symphony,Z10,Z10,SYMPHONY Z10
+Symphony,ZVII,ZVII,ZVII
+Symphony,ZVIII,ZVIII,ZVIII
+Symphony,i10,i10,i10
+Symphony,i10 plus,i10_plus,i10 plus
+Symphony,i100,i100,i100
+Symphony,i20,i20,i20
+Symphony,i25,Symphonyi25,i25
+Symphony,i50,i50,i50
+Symphony,i60,i60,i60
+Symphony,i90,i90,i90
+Symphony,roarV95,roarV95,roarV95
+T-Mobile,Telekom_Puls,T-Tab,Telekom Puls
+TA71CA5_JP,"JP SA COUTO, S.A. _MG070A2T",TA71CA5_1,TA71CA5
+TAG Heuer,Connected,glacier,TAG Heuer
+TAG Heuer,Connected Modular 41,spectralite,TAG Heuer
+TAG Heuer,Connected Modular 45,anthracite,TAG Heuer
+TAG Heuer,Connected Modular 45 (China),anthracite,TAG Heuer
+TCL,L55E6700UDS,movo_la,movo_la
+TCL,LE50UHDE5692G,movo,movo
+TCL,Percee TV,tcl_sa,Percee TV
+TCL,South America,tcl,Percee TV
+TCT (Alcatel),,A556C,A556C
+TCT (Alcatel),,A919_gsm,TCL A919
+TCT (Alcatel),,ASB-D_T918,ASB-D T918
+TCT (Alcatel),,B-GriffinPlus_TD,ASB-D T918
+TCT (Alcatel),,BASE_Varia_gsm,BASE_Varia
+TCT (Alcatel),,E928_TD,TCL E928
+TCT (Alcatel),,Griffin_TD,TCL E928
+TCT (Alcatel),,MOVE_gsm,MOVE
+TCT (Alcatel),,MTC-962_gsm,MTC-962
+TCT (Alcatel),,Martini,one touch 906
+TCT (Alcatel),,MegaFon_SP-A10,MegaFon_SP-A10
+TCT (Alcatel),,ONE_TOUCH_928D_gsm,ALCATEL ONE TOUCH 928D
+TCT (Alcatel),,ONE_TOUCH_983A_gsm,ALCATEL_one_touch_983A
+TCT (Alcatel),,ONE_TOUCH_983M_gsm,ONE TOUCH 983M
+TCT (Alcatel),,OP070,OP070
+TCT (Alcatel),,OT-906,ALCATEL_one_touch_906
+TCT (Alcatel),,OT-906,ALCATEL_one_touch_906Y
+TCT (Alcatel),,OT-913D,ALCATEL_one_touch_913D
+TCT (Alcatel),,OT-976,ALCATEL_one_touch_976
+TCT (Alcatel),,OT-978,ALCATEL_one_touch_978
+TCT (Alcatel),,OT-979,ALCATEL_one_touch_979
+TCT (Alcatel),,OT-979,ALCATEL_one_touch_979_HelloKitty
+TCT (Alcatel),,OT-980A_gsm,Alcatel OT-980A
+TCT (Alcatel),,OT-980_gsm,Alcatel OT-980
+TCT (Alcatel),,OT-980_gsm,Alcatel OT-980A
+TCT (Alcatel),,OT-980_gsm,Alcatel OT-981A
+TCT (Alcatel),,OT-981A_gsm,Alcatel OT-981A
+TCT (Alcatel),,OT-981_gsm,Alcatel OT-981A
+TCT (Alcatel),,OT_918_gsm,ALCATEL OT 918
+TCT (Alcatel),,OT_919_HelloKitty_gsm,ALCATEL OT 919 HelloKitty
+TCT (Alcatel),,OT_919_gsm,ALCATEL OT 919
+TCT (Alcatel),,OT_990M_gsm,ALCATEL_OT_990M
+TCT (Alcatel),,RASPG3201_umts,RASPG3201
+TCT (Alcatel),,RPSPG3201_umts,RPSPG3201
+TCT (Alcatel),,SmartIII4,Vodafone 975N
+TCT (Alcatel),,T20,one touch T20
+TCT (Alcatel),,T60,onetouch T60
+TCT (Alcatel),,TCL-A909_A909_gsm,TCL A909
+TCT (Alcatel),,TCL-S806,TCL-S806
+TCT (Alcatel),,TCL_890D_gsm,TCL A890 2SIM
+TCT (Alcatel),,TCL_A510,TCL A510
+TCT (Alcatel),,TCL_A510,TCL_A510
+TCT (Alcatel),,TCL_A919_umts,TCL A919
+TCT (Alcatel),,TCL_A919_umts,TCL_W969
+TCT (Alcatel),,TCL_A966_gsm,TCL A966
+TCT (Alcatel),,TCL_A968,TCL A968
+TCT (Alcatel),,TCL_A980_gsm,TCL A980
+TCT (Alcatel),,TCL_A986_gsm,TCL A986
+TCT (Alcatel),,TCL_A988_gsm,TCL_A988
+TCT (Alcatel),,TCL_A998_gsm,TCL A998
+TCT (Alcatel),,TCL_C990_Plus_cdma,TCL C990+
+TCT (Alcatel),,TCL_D515_cdma,TCL D515
+TCT (Alcatel),,TCL_D662_cdma,TCL D662
+TCT (Alcatel),,TCL_S800_GSM,TCL S800
+TCT (Alcatel),,TCL_W939_gsm,TCL_W939
+TCT (Alcatel),,TCL_W969_gsm,TCL W969
+TCT (Alcatel),,Vancouver_gsm,Vancouver_Orange
+TCT (Alcatel),,mercury,I-L1
+TCT (Alcatel),,move_2_gsm,move 2
+TCT (Alcatel),,msm7627_ffa,Alcatel OT-980
+TCT (Alcatel),,msm7627_ffa,Alcatel OT-980A
+TCT (Alcatel),,one_touch_890D_gsm,ALCATEL one touch 890D
+TCT (Alcatel),,one_touch_890_gsm,ALCATEL_one_touch_890
+TCT (Alcatel),,one_touch_890_gsm,Vip_MiniDroid
+TCT (Alcatel),,one_touch_891_gsm,ALCATEL_one_touch_891
+TCT (Alcatel),,one_touch_908A_gsm,ALCATEL_one_touch_908A
+TCT (Alcatel),,one_touch_908F_gsm,ALCATEL_one_touch_908F
+TCT (Alcatel),,one_touch_908F_gsm,ALCATEL_one_touch_908F_Orange
+TCT (Alcatel),,one_touch_908F_gsm,Alcatel_one_touch_908F
+TCT (Alcatel),,one_touch_908F_gsm,Alcatel_one_touch_908F_Orange
+TCT (Alcatel),,one_touch_908M_gsm,ALCATEL_one_touch_908M
+TCT (Alcatel),,one_touch_908S_gsm,ALCATEL_one_touch_908S
+TCT (Alcatel),,one_touch_908_gsm,ALCATEL ONE TOUCH 908
+TCT (Alcatel),,one_touch_909A_gsm,ALCATEL_one_touch_909A
+TCT (Alcatel),,one_touch_909B_cdma,ALCATEL_one_touch_909B
+TCT (Alcatel),,one_touch_909B_cdma,USCC_ALCATEL_one_touch_909B
+TCT (Alcatel),,one_touch_909S_gsm,ALCATEL_one_touch_909S
+TCT (Alcatel),,one_touch_910A_gsm,ALCATEL_one_touch_910A
+TCT (Alcatel),,one_touch_910_gsm,ALCATEL_one_touch_910
+TCT (Alcatel),,one_touch_916A_gsm,ALCATEL ONE TOUCH 916A
+TCT (Alcatel),,one_touch_916D_gsm,ALCATEL ONE TOUCH 916D
+TCT (Alcatel),,one_touch_916_gsm,ALCATEL ONE TOUCH 916
+TCT (Alcatel),,one_touch_918M_gsm,ALCATEL_ONE_TOUCH_918M
+TCT (Alcatel),,one_touch_918M_umts,ALCATEL_one_touch_918M
+TCT (Alcatel),,one_touch_918N_umts,ALCATEL_one_touch_918N
+TCT (Alcatel),,one_touch_918_gsm,ALCATEL ONE TOUCH 918
+TCT (Alcatel),,one_touch_985_gsm,ALCATEL ONE TOUCH 985
+TCT (Alcatel),,one_touch_985_gsm,Telenor Smart
+TCT (Alcatel),,one_touch_988_cdma,ALCATEL_one_touch_988
+TCT (Alcatel),,one_touch_988_cdma,USCC_ALCATEL_one_touch_988
+TCT (Alcatel),,one_touch_990A_gsm,ALCATEL ONE TOUCH 990A
+TCT (Alcatel),,one_touch_990A_gsm,ALCATEL_one_touch_990A
+TCT (Alcatel),,one_touch_990C_cdma,ALCATEL one touch 990C
+TCT (Alcatel),,one_touch_990_gsm,ALCATEL ONE TOUCH 990
+TCT (Alcatel),,one_touch_990_gsm,Alcatel one touch 990 Orange
+TCT (Alcatel),,one_touch_990_gsm,Telenor_OneTouch
+TCT (Alcatel),,one_touch_991S_gsm,ALCATEL ONE TOUCH 991S
+TCT (Alcatel),,one_touch_993D_gsm,ALCATEL ONE TOUCH 993D
+TCT (Alcatel),,one_touch_995A_gsm,ALCATEL_one_touch_995A
+TCT (Alcatel),,one_touch_995C_cdma,one touch 995C+
+TCT (Alcatel),,one_touch_996_gsm,Orange_infinity_996
+TCT (Alcatel),\t ALCATEL ONETOUCH PIXI 3 (3.5),PIXI3_35,SoshPhone_mini
+TCT (Alcatel),\t ALCATEL ONETOUCH PIXI 3 (4.5),PIXI3_45_4G,5017X
+TCT (Alcatel),4013M,Pixi3-4,4013M
+TCT (Alcatel),4014A,Pixi3-4,4014A
+TCT (Alcatel),4014M,Pixi3-4,4014M
+TCT (Alcatel),4024X,PLAY_P1,4024X
+TCT (Alcatel),4047D,U5_3G,4047D
+TCT (Alcatel),4047G,U5_3G,4047G
+TCT (Alcatel),4047N,U5_3G,4047N
+TCT (Alcatel),4047X,U5_3G,4047X
+TCT (Alcatel),4055A,U3,4055A
+TCT (Alcatel),4055I,U3,4055I
+TCT (Alcatel),4055J,U3,4055J
+TCT (Alcatel),4055Q,U3,4055Q
+TCT (Alcatel),4055T,U3,4055T
+TCT (Alcatel),4055U,U3,4055U
+TCT (Alcatel),4060W,Pixi445,4060W
+TCT (Alcatel),4114E,Pixi3-4,4114E
+TCT (Alcatel),5011A,BUZZ6_55,5011A
+TCT (Alcatel),5017B,Pixi3454GSPR,5017B
+TCT (Alcatel),5023E,Pixi4PlusPower,5023E
+TCT (Alcatel),5023F,Pixi4PlusPower,5023F
+TCT (Alcatel),5027B,Pixi445SPR,5027B
+TCT (Alcatel),5038D,SOUL45_GSM,5038D
+TCT (Alcatel),5042T,ALTO45TMO,5042T
+TCT (Alcatel),5046S,Mickey6VZW,5046S
+TCT (Alcatel),5049S,Mickey6TVZW,5049S
+TCT (Alcatel),5049W,Mickey6TTMO,5049W
+TCT (Alcatel),5049Z,Mickey6TTMO,5049Z
+TCT (Alcatel),5051,POP45,5051
+TCT (Alcatel),5051A,POP45,5051A
+TCT (Alcatel),5051D,POP45,5051D
+TCT (Alcatel),5051J,POP45,5051J
+TCT (Alcatel),5051M,POP45,5051M
+TCT (Alcatel),5051T,POP45,5051T
+TCT (Alcatel),5051X,POP45,5051X
+TCT (Alcatel),5054A,Pop355,5054A
+TCT (Alcatel),5054D,Pop355,5054D
+TCT (Alcatel),5054S,Pop355,5054S
+TCT (Alcatel),5054T,Pop355,5054T
+TCT (Alcatel),5054W,Pop355,5054W
+TCT (Alcatel),5054X,Pop355,5054X
+TCT (Alcatel),5056,POP455C,5056
+TCT (Alcatel),5056A,POP455C,5056A
+TCT (Alcatel),5056D,POP455C,5056D
+TCT (Alcatel),5056E,POP455C,5056E
+TCT (Alcatel),5056E,POP455C,5056M
+TCT (Alcatel),5056G,POP455C,5056G
+TCT (Alcatel),5056I,POP455C,5056I
+TCT (Alcatel),5056N,POP455C,5056N
+TCT (Alcatel),5056T,POP455C,5056T
+TCT (Alcatel),5056U,POP455C,5056U
+TCT (Alcatel),5056W,POP455C,5056W
+TCT (Alcatel),5056X,POP455C,5056X
+TCT (Alcatel),5065A,Pop35,5065A
+TCT (Alcatel),5065D,Pop35,5065D
+TCT (Alcatel),5065N,Pop35,5065N
+TCT (Alcatel),5065W,Pop35,5065W
+TCT (Alcatel),5065X,Pop35,5065X
+TCT (Alcatel),5070D,P3-5_4G,5070D
+TCT (Alcatel),5080A,shine_lite,5080A
+TCT (Alcatel),5080F,shine_lite,5080F
+TCT (Alcatel),5080Q,shine_lite,5080Q
+TCT (Alcatel),5080U,shine_lite,5080U
+TCT (Alcatel),5080U,shine_lite,ALCATEL_5080U
+TCT (Alcatel),5085G,elsa6_amz,5085G
+TCT (Alcatel),5085O,elsa6_amz,5085O
+TCT (Alcatel),5098O,Pixi4-64GMEX,5098O
+TCT (Alcatel),5098O,Pixi4-6_4G_CKT,Alcatel_5098O
+TCT (Alcatel),5098O,Pixi4-6_4G_CKT,alcatel_5098O
+TCT (Alcatel),5098S,Pixi4-6_4G,5098S
+TCT (Alcatel),5154A,Pop355,5154A
+TCT (Alcatel),6010A,Miata_3G,6016A
+TCT (Alcatel),6014X,Miata_3G,6014X
+TCT (Alcatel),6016D,Miata_3G,6016D
+TCT (Alcatel),6016E,Miata_3G,6016E
+TCT (Alcatel),6016X,Miata_3G,6016X
+TCT (Alcatel),6037B,Eclipse,6037B
+TCT (Alcatel),6037K,Eclipse,6037K
+TCT (Alcatel),6037Y,Eclipse,6037Y
+TCT (Alcatel),6039A,idol347,6039A
+TCT (Alcatel),6039H,idol347,6039H
+TCT (Alcatel),6039J,idol347,6039J
+TCT (Alcatel),6039K,idol347,6039K
+TCT (Alcatel),6039S,idol347,6039S
+TCT (Alcatel),6039Y,idol347,6039Y
+TCT (Alcatel),6042D,CROSSAPAC,6042D
+TCT (Alcatel),6043A,DIABLOXPLUS,6043A
+TCT (Alcatel),6043D,DIABLOXPLUS,6043D
+TCT (Alcatel),6044D,I1-5_4G,6044D
+TCT (Alcatel),6055A,idol4,6055A
+TCT (Alcatel),6055B,idol4,6055B
+TCT (Alcatel),6055D,idol4,6055D
+TCT (Alcatel),6055K,idol4,6055K
+TCT (Alcatel),6055P,idol4,6055P
+TCT (Alcatel),6060X,simba6_global,6060X
+TCT (Alcatel),7040N,Yaris5TMO,7040N
+TCT (Alcatel),7040R,Yaris5TMO,7040R
+TCT (Alcatel),7040T,Yaris5TMO,7040T
+TCT (Alcatel),7045Y,RIO5,7045Y
+TCT (Alcatel),730U,Rio5C,J730U
+TCT (Alcatel),8030B,HERO2,8030B
+TCT (Alcatel),8030B,HERO2PLUS,8030B
+TCT (Alcatel),8030Y,HERO2,8030Y
+TCT (Alcatel),8050D,Pixi4-6_3G,8050D
+TCT (Alcatel),8050E,Pixi4-6_3G,8050E
+TCT (Alcatel),8050E,Pixi4-6_3G,T600M
+TCT (Alcatel),8050G,Pixi4-6_3G,8050G
+TCT (Alcatel),8050X,Pixi4-6_3G,8050X
+TCT (Alcatel),8053,Pixi3-7,8053
+TCT (Alcatel),8054,Pixi3-7,8054
+TCT (Alcatel),8055,Pixi3-7,8055
+TCT (Alcatel),8056,Pixi3-7,8056
+TCT (Alcatel),8057,Pixi3-7,8057
+TCT (Alcatel),8057,Pixi3-7,KR076
+TCT (Alcatel),8062,Pixi4-7_WIFI,8062
+TCT (Alcatel),8063,Pixi4-7_WIFI,8063
+TCT (Alcatel),8070,Pixi3-8_WIFI,8070
+TCT (Alcatel),8079,Pixi3-10_WiFi,8079
+TCT (Alcatel),8080,Pixi3-10_WiFi,8080
+TCT (Alcatel),8262,Pixi4-7_WIFI,8262
+TCT (Alcatel),9001D,Pixi4-6_4G,9001D
+TCT (Alcatel),9001I,Pixi4-6_4G,9001I
+TCT (Alcatel),9001X,Pixi4-6_4G,9001X
+TCT (Alcatel),9002A,Pixi3-7_3G,9002A
+TCT (Alcatel),9002A,Pixi3-7_3G,ALCATEL ONE TOUCH 9002A
+TCT (Alcatel),9002W,Pixi3-7_3G,9002W
+TCT (Alcatel),9002X,Pixi3-7_3G,9002X
+TCT (Alcatel),9003A,Pixi4-7_3G,9003A
+TCT (Alcatel),9003X,Pixi4-7_3G,9003X
+TCT (Alcatel),9005X,PIXO8_3G,9005X
+TCT (Alcatel),9006W,Pixi2-7_4G_TMO,9006W
+TCT (Alcatel),9007X,Pixi3-7_4G_EE,9007X
+TCT (Alcatel),9010X,Pixi3-10_3G,9010X
+TCT (Alcatel),9015B,Pixi4-7_4G_Bell,9015B
+TCT (Alcatel),9015B,Pixi4-7_4G_Bell,ALCATEL ONETOUCH POP 7 LTE
+TCT (Alcatel),9015B,Pixi4-7_4G_NA,9015B
+TCT (Alcatel),9015B,Pixi4-7_4G_Rogers,9015B
+TCT (Alcatel),9015B,Pixi4-7_4G_Telus,9015B
+TCT (Alcatel),9015J,PIXI4-7_4G,9015J
+TCT (Alcatel),9015Q,PIXI4-7_4G,9015Q
+TCT (Alcatel),9015U,PIXI4-7_4G,9015U
+TCT (Alcatel),9015W,Pixi4-7_4G_TMO,9015W
+TCT (Alcatel),9015W,Pixi4-7_4G_TMO,ALCATEL ONETOUCH POP 7 LTE
+TCT (Alcatel),9021A,Pop2-8_4G_Telus,9021A
+TCT (Alcatel),9024O,PIXI5-8_4G_Telus,9024O
+TCT (Alcatel),9024W,PIXI5-8_4G_TMO,9024W
+TCT (Alcatel),9025Q,POP4-7_4G,9025Q
+TCT (Alcatel),9030G,POP4-10_4G,9030G
+TCT (Alcatel),9030Q,POP4-10_4G,9030Q
+TCT (Alcatel),9203A,Pixi5-7_3G,9203A
+TCT (Alcatel),A3,mickey6,5046A
+TCT (Alcatel),A3,mickey6,5046D
+TCT (Alcatel),A3,mickey6,5046I
+TCT (Alcatel),A3,mickey6,5046J
+TCT (Alcatel),A3,mickey6,5046T
+TCT (Alcatel),A3,mickey6,5046U
+TCT (Alcatel),A3,mickey6,5046Y
+TCT (Alcatel),A3 10\'\',Pixi5-10_4G,9026T
+TCT (Alcatel),A3 10\'\',Pixi5-10_4G,9026X
+TCT (Alcatel),A3 PLUS,mickey6t,5049E
+TCT (Alcatel),A3 PLUS,mickey6t,5049G
+TCT (Alcatel),A3 XL,PIXI5-6_4G,9008A
+TCT (Alcatel),A3 XL,PIXI5-6_4G,9008D
+TCT (Alcatel),A3 XL,PIXI5-6_4G,9008I
+TCT (Alcatel),A3 XL,PIXI5-6_4G,9008J
+TCT (Alcatel),A3 XL,PIXI5-6_4G,9008N
+TCT (Alcatel),A3 XL,PIXI5-6_4G,9008T
+TCT (Alcatel),A3 XL,PIXI5-6_4G,9008U
+TCT (Alcatel),A3 XL,PIXI5-6_4G,9008X
+TCT (Alcatel),A3 XL,PIXI5-6_4G,9108A
+TCT (Alcatel),A3 XL,PIXI5-6_4G,TCLGalaG60(9108A)
+TCT (Alcatel),A30,MICKEY6US,5046G
+TCT (Alcatel),A30,Mickey6RW,A576RW
+TCT (Alcatel),A450TL,ALTO45_TF,A450TL
+TCT (Alcatel),A460T,PIXI3_4TF,A460T
+TCT (Alcatel),A464BG,Pixi3-35TF,A464BG
+TCT (Alcatel),A466BG,PIXI4_4TF,A466BG
+TCT (Alcatel),A5,ELSA6,5085A
+TCT (Alcatel),A5,ELSA6,5085B
+TCT (Alcatel),A5,ELSA6,5085D
+TCT (Alcatel),A5,ELSA6,5085H
+TCT (Alcatel),A5,ELSA6,5085I
+TCT (Alcatel),A5,ELSA6,5085J
+TCT (Alcatel),A5,ELSA6,5085N
+TCT (Alcatel),A5,ELSA6,5085Q
+TCT (Alcatel),A5,ELSA6,5085Y
+TCT (Alcatel),A520L,Alto4EVDO,A520L
+TCT (Alcatel),A521L,Alto4NA,A521L
+TCT (Alcatel),A570BL,Pop445,A570BL
+TCT (Alcatel),A571VL,Pixi445TFVZW,A571VL
+TCT (Alcatel),A572BG,Pop445,A572BG
+TCT (Alcatel),A573VC,Pixi445EVDO,A573VC
+TCT (Alcatel),A577VL,Mickey6TFEVDO,A577VL
+TCT (Alcatel),A621BL,Pop355,A621BL
+TCT (Alcatel),A621R,Pop355,A621R
+TCT (Alcatel),A622GL,Pixi3554GEVDO,A622GL
+TCT (Alcatel),A622VL,Pixi3554GEVDO,A622VL
+TCT (Alcatel),A7,ELSA6P,5090A
+TCT (Alcatel),A7,ELSA6P,5090I
+TCT (Alcatel),A7,ELSA6P,5090Y
+TCT (Alcatel),A7 XL,POP5-6_4G,7071A
+TCT (Alcatel),A7 XL,POP5-6_4G,7071D
+TCT (Alcatel),A846L,Alto5TF,A846L
+TCT (Alcatel),A851L,Viper_gsm,Alcatel 7030L
+TCT (Alcatel),A851L,Viper_gsm,Alcatel A851L
+TCT (Alcatel),ALCATEL 3C,A3A_XL_3G,5026A
+TCT (Alcatel),ALCATEL 3C,A3A_XL_3G,5026D
+TCT (Alcatel),ALCATEL 3C,A3A_XL_3G,5026J
+TCT (Alcatel),ALCATEL 4015T,Yaris35_GSM,ALCATEL 4015T
+TCT (Alcatel),ALCATEL A564C,Yaris5NA,ALCATEL A564C
+TCT (Alcatel),ALCATEL A564R,Yaris5NA,ALCATEL A564R
+TCT (Alcatel),ALCATEL ONE TOUCH 4005D,Beetle_Lite_Edge_GSM,ALCATEL ONE TOUCH 4005D
+TCT (Alcatel),ALCATEL ONE TOUCH 4005D,Beetle_Lite_Edge_GSM,ALCATEL_ONE_TOUCH_4005D
+TCT (Alcatel),ALCATEL ONE TOUCH 4010X,Beetle_Lite_GSM,ALCATEL ONE TOUCH 4010A
+TCT (Alcatel),ALCATEL ONE TOUCH 4010X,Beetle_Lite_GSM,ALCATEL ONE TOUCH 4010D
+TCT (Alcatel),ALCATEL ONE TOUCH 4010X,Beetle_Lite_GSM,ALCATEL ONE TOUCH 4010E
+TCT (Alcatel),ALCATEL ONE TOUCH 4010X,Beetle_Lite_GSM,ALCATEL ONE TOUCH 4010X
+TCT (Alcatel),ALCATEL ONE TOUCH 4010X,Beetle_Lite_GSM,TCL_J210
+TCT (Alcatel),ALCATEL ONE TOUCH 4010X,Beetle_Lite_GSM,Telenor Smart 2
+TCT (Alcatel),ALCATEL ONE TOUCH 4030X,Beetle_GSM,ALCATEL ONE TOUCH 4029A
+TCT (Alcatel),ALCATEL ONE TOUCH 4030X,Beetle_GSM,ALCATEL ONE TOUCH 4030D
+TCT (Alcatel),ALCATEL ONE TOUCH 4030X,Beetle_GSM,ALCATEL ONE TOUCH 4030E
+TCT (Alcatel),ALCATEL ONE TOUCH 4030X,Beetle_GSM,ALCATEL ONE TOUCH 4030X
+TCT (Alcatel),ALCATEL ONE TOUCH 4030X,Beetle_GSM,ALCATEL ONE TOUCH 4030Y
+TCT (Alcatel),ALCATEL ONE TOUCH 4030X,Beetle_GSM,ALCATEL ONE TOUCH 4030Y_orange
+TCT (Alcatel),ALCATEL ONE TOUCH 4030X,Beetle_GSM,Infinity POP
+TCT (Alcatel),ALCATEL ONE TOUCH 4030X,Beetle_GSM,Orange Runo
+TCT (Alcatel),ALCATEL ONE TOUCH 4037N,SOUL4NA,ALCATEL ONE TOUCH 4037N
+TCT (Alcatel),ALCATEL ONE TOUCH 4037N,SOUL4NA,ALCATEL ONE TOUCH 4037T
+TCT (Alcatel),ALCATEL ONE TOUCH 5020D,Megane_GSM,ALCATEL ONE TOUCH 5020A
+TCT (Alcatel),ALCATEL ONE TOUCH 5020D,Megane_GSM,ALCATEL ONE TOUCH 5020D
+TCT (Alcatel),ALCATEL ONE TOUCH 5020D,Megane_GSM,ALCATEL ONE TOUCH 5020E
+TCT (Alcatel),ALCATEL ONE TOUCH 5020D,Megane_GSM,ALCATEL ONE TOUCH 5020T
+TCT (Alcatel),ALCATEL ONE TOUCH 5020D,Megane_GSM,ALCATEL ONE TOUCH 5020W
+TCT (Alcatel),ALCATEL ONE TOUCH 5020D,Megane_GSM,ALCATEL ONE TOUCH 5020X
+TCT (Alcatel),ALCATEL ONE TOUCH 5020D,Megane_GSM,ALCATEL ONE TOUCH 5021E
+TCT (Alcatel),ALCATEL ONE TOUCH 5020D,Megane_GSM,ALCATEL_ONE_TOUCH_5020D_Orange
+TCT (Alcatel),ALCATEL ONE TOUCH 5020D,Megane_GSM,ALCATEL_ONE_TOUCH_5020X_Orange
+TCT (Alcatel),ALCATEL ONE TOUCH 5020D,Megane_GSM,AURUS III
+TCT (Alcatel),ALCATEL ONE TOUCH 5020D,Megane_GSM,MTC 972
+TCT (Alcatel),ALCATEL ONE TOUCH 5020D,Megane_GSM,Orange Kivo
+TCT (Alcatel),ALCATEL ONE TOUCH 5020D,Megane_GSM,Telenor Smart Pro 2
+TCT (Alcatel),ALCATEL ONE TOUCH 5020N,Megane,ALCATEL ONE TOUCH 5020N
+TCT (Alcatel),ALCATEL ONE TOUCH 5035D,Camry_GSM,ALCATEL ONE TOUCH 5035A
+TCT (Alcatel),ALCATEL ONE TOUCH 5035D,Camry_GSM,ALCATEL ONE TOUCH 5035D
+TCT (Alcatel),ALCATEL ONE TOUCH 5035D,Camry_GSM,ALCATEL ONE TOUCH 5035E
+TCT (Alcatel),ALCATEL ONE TOUCH 5035D,Camry_GSM,ALCATEL ONE TOUCH 5035X
+TCT (Alcatel),ALCATEL ONE TOUCH 5035D,Camry_GSM,TCL J610
+TCT (Alcatel),ALCATEL ONE TOUCH 5035D,Camry_GSM,TCL S810
+TCT (Alcatel),ALCATEL ONE TOUCH 5036A,YarisL_GSM,ALCATEL ONE TOUCH 5036A
+TCT (Alcatel),ALCATEL ONE TOUCH 5036D,YarisL_GSM,ALCATEL ONE TOUCH 5036D
+TCT (Alcatel),ALCATEL ONE TOUCH 5036D,YarisL_GSM,ONE TOUCH 5036X
+TCT (Alcatel),ALCATEL ONE TOUCH 5036F,YarisL_GSM,ALCATEL ONE TOUCH 5036F
+TCT (Alcatel),ALCATEL ONE TOUCH 5036X,YarisL_GSM,ALCATEL ONE TOUCH 5036X
+TCT (Alcatel),ALCATEL ONE TOUCH 5037E,YarisL_GSM,ALCATEL ONE TOUCH 5037E
+TCT (Alcatel),ALCATEL ONE TOUCH 601,Telsa,ALCATEL ONE TOUCH 6010
+TCT (Alcatel),ALCATEL ONE TOUCH 6010A,Telsa,ALCATEL ONE TOUCH 6010A
+TCT (Alcatel),ALCATEL ONE TOUCH 6010D,Telsa,ALCATEL ONE TOUCH 6010D
+TCT (Alcatel),ALCATEL ONE TOUCH 6010X,Telsa,ALCATEL ONE TOUCH 6010
+TCT (Alcatel),ALCATEL ONE TOUCH 6010X,Telsa,ALCATEL ONE TOUCH 6010D
+TCT (Alcatel),ALCATEL ONE TOUCH 6010X,Telsa,ALCATEL ONE TOUCH 6010X
+TCT (Alcatel),ALCATEL ONE TOUCH 6010X,Telsa,ALCATEL ONE TOUCH 6010X-orange
+TCT (Alcatel),ALCATEL ONE TOUCH 6010X,Telsa,TCL S520
+TCT (Alcatel),ALCATEL ONE TOUCH 6030A,Diablo,ALCATEL ONE TOUCH 6030A
+TCT (Alcatel),ALCATEL ONE TOUCH 6030D,Diablo,ALCATEL ONE TOUCH 6030D
+TCT (Alcatel),ALCATEL ONE TOUCH 6030N,Diablo,ALCATEL ONE TOUCH 6030N
+TCT (Alcatel),ALCATEL ONE TOUCH 6030X,Diablo,ALCATEL ONE TOUCH 6030A
+TCT (Alcatel),ALCATEL ONE TOUCH 6030X,Diablo,ALCATEL ONE TOUCH 6030D
+TCT (Alcatel),ALCATEL ONE TOUCH 6030X,Diablo,ALCATEL ONE TOUCH 6030X
+TCT (Alcatel),ALCATEL ONE TOUCH 6030X,Diablo,ALCATEL ONE TOUCH 6030X-orange
+TCT (Alcatel),ALCATEL ONE TOUCH 6030X,Diablo,ALCATEL_ONE_TOUCH_6030X_Orange
+TCT (Alcatel),ALCATEL ONE TOUCH 6030X,Diablo,Optimus_San_Remo
+TCT (Alcatel),ALCATEL ONE TOUCH 6030X,Diablo,TCL S820
+TCT (Alcatel),ALCATEL ONE TOUCH 6030X-orange,Diablo,ALCATEL ONE TOUCH 6030X-orange
+TCT (Alcatel),ALCATEL ONE TOUCH 6032,Alpha,ALCATEL ONE TOUCH 6032
+TCT (Alcatel),ALCATEL ONE TOUCH 6032A,Alpha,ALCATEL ONE TOUCH 6032A
+TCT (Alcatel),ALCATEL ONE TOUCH 6032X,Alpha,ALCATEL ONE TOUCH 6032X
+TCT (Alcatel),ALCATEL ONE TOUCH 6033A,DiabloHD,ALCATEL ONE TOUCH 6033A
+TCT (Alcatel),ALCATEL ONE TOUCH 6033M,DiabloHD,ALCATEL ONE TOUCH 6033M
+TCT (Alcatel),ALCATEL ONE TOUCH 6033X,DiabloHD,ALCATEL ONE TOUCH 6033M
+TCT (Alcatel),ALCATEL ONE TOUCH 6033X,DiabloHD,ALCATEL ONE TOUCH 6033X
+TCT (Alcatel),ALCATEL ONE TOUCH 6033X,DiabloHD,TCL S850
+TCT (Alcatel),ALCATEL ONE TOUCH 6037B,Eclipse,ALCATEL ONE TOUCH 6037B
+TCT (Alcatel),ALCATEL ONE TOUCH 6040A,DIABLOX,ALCATEL ONE TOUCH 6040A
+TCT (Alcatel),ALCATEL ONE TOUCH 6040D,DIABLOX,ALCATEL ONE TOUCH 6040D
+TCT (Alcatel),ALCATEL ONE TOUCH 6040D,DIABLOX,TCL S950
+TCT (Alcatel),ALCATEL ONE TOUCH 6040E,DIABLOX,ALCATEL ONE TOUCH 6040E
+TCT (Alcatel),ALCATEL ONE TOUCH 6040X,DIABLOX,ALCATEL ONE TOUCH 6040X
+TCT (Alcatel),ALCATEL ONE TOUCH 7024W,Rav4,ALCATEL ONE TOUCH 7024R
+TCT (Alcatel),ALCATEL ONE TOUCH 7024W,Rav4,ALCATEL ONE TOUCH 7024W
+TCT (Alcatel),ALCATEL ONE TOUCH 7024W,Rav4,ALCATEL ONE TOUCH FIERCE
+TCT (Alcatel),ALCATEL ONE TOUCH 7025D,Rav4,ALCATEL ONE TOUCH 7025D
+TCT (Alcatel),ALCATEL ONE TOUCH 7040A,YARISXL,ALCATEL ONE TOUCH 7040A
+TCT (Alcatel),ALCATEL ONE TOUCH 7040D,YARISXL,ALCATEL ONE TOUCH 7040D
+TCT (Alcatel),ALCATEL ONE TOUCH 7040E,YARISXL,ALCATEL ONE TOUCH 7040E
+TCT (Alcatel),ALCATEL ONE TOUCH 7040K,YARISXL,ALCATEL ONE TOUCH 7040K
+TCT (Alcatel),ALCATEL ONE TOUCH 7040X,YARISXL,ALCATEL ONE TOUCH 7040X
+TCT (Alcatel),ALCATEL ONE TOUCH 7041D,YARISXL,ALCATEL ONE TOUCH 7041D
+TCT (Alcatel),ALCATEL ONE TOUCH 7041X,YARISXL,ALCATEL ONE TOUCH 7041X
+TCT (Alcatel),ALCATEL ONE TOUCH 7042A,YARISXL,ALCATEL ONE TOUCH 7042A
+TCT (Alcatel),ALCATEL ONE TOUCH 7042D,YARISXL,ALCATEL ONE TOUCH 7042D
+TCT (Alcatel),ALCATEL ONE TOUCH 7042E,YARISXL,ALCATEL ONE TOUCH 7042E
+TCT (Alcatel),ALCATEL ONE TOUCH 7047D,YARIS_55,ALCATEL ONE TOUCH 7047D
+TCT (Alcatel),ALCATEL ONE TOUCH 7047E,YARIS_55,ALCATEL ONE TOUCH 7047E
+TCT (Alcatel),ALCATEL ONE TOUCH 7047X,YARIS_55,ALCATEL ONE TOUCH 7047X
+TCT (Alcatel),ALCATEL ONE TOUCH 8008D,Scribe5HD,ALCATEL ONE TOUCH 8008D
+TCT (Alcatel),ALCATEL ONE TOUCH 8008D,Scribe5HD,ALCATEL ONE TOUCH 8008X
+TCT (Alcatel),ALCATEL ONE TOUCH 8008D,Scribe5HD,Orange Infinity 8008X
+TCT (Alcatel),ALCATEL ONE TOUCH 8020A,SCRIBEPRO,ALCATEL ONE TOUCH 8020A
+TCT (Alcatel),ALCATEL ONE TOUCH 8020D,SCRIBEPRO,ALCATEL ONE TOUCH 8020D
+TCT (Alcatel),ALCATEL ONE TOUCH 8020E,SCRIBEPRO,ALCATEL ONE TOUCH 8020E
+TCT (Alcatel),ALCATEL ONE TOUCH 8020X,SCRIBEPRO,ALCATEL ONE TOUCH 8020X
+TCT (Alcatel),ALCATEL ONE TOUCH 903,one_touch_903A_gsm,ALCATEL_ONE_TOUCH_903
+TCT (Alcatel),ALCATEL ONE TOUCH 903,one_touch_903A_gsm,ALCATEL_one_touch_903
+TCT (Alcatel),ALCATEL ONE TOUCH 903,one_touch_903D_gsm,ALCATEL ONE TOUCH 903D
+TCT (Alcatel),ALCATEL ONE TOUCH 903,one_touch_903_gsm,ALCATEL ONE TOUCH 903
+TCT (Alcatel),ALCATEL ONE TOUCH 903,one_touch_903_gsm,ALCATEL_ONE_TOUCH_903
+TCT (Alcatel),ALCATEL ONE TOUCH 903A,one_touch_903A_gsm,ALCATEL ONE TOUCH 903A
+TCT (Alcatel),ALCATEL ONE TOUCH 903D,one_touch_903D_gsm,ALCATEL ONE TOUCH 903D
+TCT (Alcatel),ALCATEL ONE TOUCH 918,one_touch_918_gsm,ALCATEL ONE TOUCH 918
+TCT (Alcatel),ALCATEL ONE TOUCH 918,one_touch_918_gsm,ALCATEL one touch 918
+TCT (Alcatel),ALCATEL ONE TOUCH 918,one_touch_918_gsm,ALCATEL_one_touch_918
+TCT (Alcatel),ALCATEL ONE TOUCH 918,one_touch_918_gsm,Alcatel_one_touch_918_Orange
+TCT (Alcatel),ALCATEL ONE TOUCH 918A,one_touch_918A_gsm,ALCATEL ONE TOUCH 918A
+TCT (Alcatel),ALCATEL ONE TOUCH 918A,one_touch_918A_gsm,ALCATEL_one_touch_918A
+TCT (Alcatel),ALCATEL ONE TOUCH 918D,ONE_TOUCH_918D_umts,ALCATEL ONE TOUCH 918D
+TCT (Alcatel),ALCATEL ONE TOUCH 918D,one_touch_918D_gsm,ALCATEL ONE TOUCH 918D
+TCT (Alcatel),ALCATEL ONE TOUCH 918N,ONE_TOUCH_918N_umts,ALCATEL ONE TOUCH 918N
+TCT (Alcatel),ALCATEL ONE TOUCH 918N,one_touch_918N_gsm,ALCATEL ONE TOUCH 918N
+TCT (Alcatel),ALCATEL ONE TOUCH 918S,one_touch_918S_gsm,ALCATEL ONE TOUCH 918S
+TCT (Alcatel),ALCATEL ONE TOUCH 922,one_touch_922_gsm,ALCATEL ONE TOUCH 922
+TCT (Alcatel),ALCATEL ONE TOUCH 930D,OT-930,ALCATEL ONE TOUCH 930D
+TCT (Alcatel),ALCATEL ONE TOUCH 930D,OT-930,ALCATEL ONE TOUCH 930N
+TCT (Alcatel),ALCATEL ONE TOUCH 985,one_touch_985_gsm,ALCATEL ONE TOUCH 985
+TCT (Alcatel),ALCATEL ONE TOUCH 985,one_touch_985_gsm,ALCATEL_ONE_TOUCH_985
+TCT (Alcatel),ALCATEL ONE TOUCH 985,one_touch_985_gsm,ALCATEL_one_touch_985
+TCT (Alcatel),ALCATEL ONE TOUCH 985,one_touch_985_gsm,Telenor_One_Touch_C
+TCT (Alcatel),ALCATEL ONE TOUCH 985D,one_touch_985D_gsm,ALCATEL ONE TOUCH 985D
+TCT (Alcatel),ALCATEL ONE TOUCH 985N,one_touch_985N_gsm,ALCATEL ONE TOUCH 985N
+TCT (Alcatel),ALCATEL ONE TOUCH 991,ONE_TOUCH_991D_gsm,ALCATEL ONE TOUCH 991D
+TCT (Alcatel),ALCATEL ONE TOUCH 991,ONE_TOUCH_991_gsm,ALCATEL ONE TOUCH 991
+TCT (Alcatel),ALCATEL ONE TOUCH 991,ONE_TOUCH_991_gsm,ALCATEL_one_touch_991
+TCT (Alcatel),ALCATEL ONE TOUCH 991,ONE_TOUCH_991_gsm,Telenor_Smart_Pro
+TCT (Alcatel),ALCATEL ONE TOUCH 991,one_touch_991_gsm,ALCATEL ONE TOUCH 991
+TCT (Alcatel),ALCATEL ONE TOUCH 991A,ONE_TOUCH_991A_gsm,ALCATEL ONE TOUCH 991A
+TCT (Alcatel),ALCATEL ONE TOUCH 991D,ONE_TOUCH_991D_gsm,ALCATEL ONE TOUCH 991D
+TCT (Alcatel),ALCATEL ONE TOUCH 991D,one_touch_991D_gsm,ALCATEL ONE TOUCH 991D
+TCT (Alcatel),ALCATEL ONE TOUCH 991T,one_touch_991T_gsm,ALCATEL ONE TOUCH 991T
+TCT (Alcatel),ALCATEL ONE TOUCH 992D,Martell_lite_GSM,ALCATEL ONE TOUCH 992
+TCT (Alcatel),ALCATEL ONE TOUCH 992D,Martell_lite_GSM,ALCATEL ONE TOUCH 992D
+TCT (Alcatel),ALCATEL ONE TOUCH 992D,Martell_lite_GSM,TCL S500
+TCT (Alcatel),ALCATEL ONE TOUCH 992D,Martell_lite_GSM,TCL S600
+TCT (Alcatel),ALCATEL ONE TOUCH 995,one_touch_995_gsm,ALCATEL_one_touch_995
+TCT (Alcatel),ALCATEL ONE TOUCH 995,one_touch_995_gsm,Optimus_Madrid
+TCT (Alcatel),ALCATEL ONE TOUCH 995,one_touch_995_gsm,Telenor_Smart_HD
+TCT (Alcatel),ALCATEL ONE TOUCH 995A,one_touch_995_gsm,ALCATEL_one_touch_995A
+TCT (Alcatel),ALCATEL ONE TOUCH 997D,Martell_GSM,ALCATEL ONE TOUCH 997
+TCT (Alcatel),ALCATEL ONE TOUCH 997D,Martell_GSM,ALCATEL ONE TOUCH 997D
+TCT (Alcatel),ALCATEL ONE TOUCH 997D,Martell_GSM,BASE_Lutea_3
+TCT (Alcatel),ALCATEL ONE TOUCH 997D,Martell_GSM,TCL S710
+TCT (Alcatel),ALCATEL ONE TOUCH 997D,Martell_GSM,TCL S800
+TCT (Alcatel),ALCATEL ONE TOUCH D668,DANIEL,ALCATEL ONE TOUCH D668
+TCT (Alcatel),ALCATEL ONE TOUCH D668,DANIEL,TCL D668
+TCT (Alcatel),ALCATEL ONE TOUCH D668,DANIEL,TCL-D668
+TCT (Alcatel),ALCATEL ONE TOUCH Fierce,Rav4,ALCATEL ONE TOUCH 7024N
+TCT (Alcatel),ALCATEL ONE TOUCH Fierce,Rav4,ALCATEL ONE TOUCH 7024W
+TCT (Alcatel),ALCATEL ONE TOUCH Fierce,Rav4,ALCATEL ONE TOUCH Fierce
+TCT (Alcatel),ALCATEL ONE TOUCH P310A,POP7,ALCATEL ONE TOUCH P310A
+TCT (Alcatel),ALCATEL ONE TOUCH P320A,POP8,ALCATEL ONE TOUCH P320A
+TCT (Alcatel),ALCATEL ONE TOUCH P321,POP8,ALCATEL ONE TOUCH P321
+TCT (Alcatel),ALCATEL ONE TOUCH918N,one_touch_918_gsm,ALCATEL ONE TOUCH 918N
+TCT (Alcatel),ALCATEL ONETOUCH 4037R,SOUL4NA,ALCATEL ONE TOUCH 4037R
+TCT (Alcatel),ALCATEL ONETOUCH 4037R,SOUL4NA,ALCATEL ONETOUCH 4037R
+TCT (Alcatel),ALCATEL ONETOUCH 6032,Alpha,ALCATEL ONETOUCH 6032
+TCT (Alcatel),ALCATEL ONETOUCH 6032A,Alpha,ALCATEL ONETOUCH 6032A
+TCT (Alcatel),ALCATEL ONETOUCH 6032X,Alpha,ALCATEL ONETOUCH 6032X
+TCT (Alcatel),ALCATEL ONETOUCH 6043D,DIABLOXPLUS,ALCATEL ONETOUCH 6043D
+TCT (Alcatel),ALCATEL ONETOUCH Flash Plus,CROSS2,ALCATEL ONETOUCH Flash Plus
+TCT (Alcatel),ALCATEL ONETOUCH IDOL 3 (5.5),idol3,6045B
+TCT (Alcatel),ALCATEL ONETOUCH IDOL 3 (5.5),idol3,6045F
+TCT (Alcatel),ALCATEL ONETOUCH IDOL 3 (5.5),idol3,6045I
+TCT (Alcatel),ALCATEL ONETOUCH IDOL 3 (5.5),idol3,6045K
+TCT (Alcatel),ALCATEL ONETOUCH IDOL 3 (5.5),idol3,6045Y
+TCT (Alcatel),ALCATEL ONETOUCH IDOL 3 (5.5),idol3,TCL i806
+TCT (Alcatel),ALCATEL ONETOUCH P310A,POP7,ALCATEL ONE TOUCH P310A
+TCT (Alcatel),ALCATEL ONETOUCH P310A,POP7,ALCATEL ONETOUCH P310A
+TCT (Alcatel),ALCATEL ONETOUCH PIXI 3 (3.5),PIXI3_35,4009A
+TCT (Alcatel),ALCATEL ONETOUCH PIXI 3 (3.5),PIXI3_35,4009D
+TCT (Alcatel),ALCATEL ONETOUCH PIXI 3 (3.5),PIXI3_35,4009E
+TCT (Alcatel),ALCATEL ONETOUCH PIXI 3 (3.5),PIXI3_35,4009F
+TCT (Alcatel),ALCATEL ONETOUCH PIXI 3 (3.5),PIXI3_35,4009K
+TCT (Alcatel),ALCATEL ONETOUCH PIXI 3 (3.5),PIXI3_35,4009M
+TCT (Alcatel),ALCATEL ONETOUCH PIXI 3 (3.5),PIXI3_35,4009S
+TCT (Alcatel),ALCATEL ONETOUCH PIXI 3 (3.5),PIXI3_35,4009X
+TCT (Alcatel),ALCATEL ONETOUCH PIXI 3 (4.5),PIXI3_45_4G,5017A
+TCT (Alcatel),ALCATEL ONETOUCH PIXI 3 (4.5),PIXI3_45_4G,5017D
+TCT (Alcatel),ALCATEL ONETOUCH PIXI 3 (4.5),PIXI3_45_4G,5017E
+TCT (Alcatel),ALCATEL ONETOUCH PIXI 3 (4.5),PIXI3_45_4G,5019D
+TCT (Alcatel),ALCATEL ONETOUCH PIXI 4 (4),Pixi4-4,4034A
+TCT (Alcatel),ALCATEL ONETOUCH PIXI 4 (4),Pixi4-4,4034D
+TCT (Alcatel),ALCATEL ONETOUCH PIXI 4 (4),Pixi4-4,4034E
+TCT (Alcatel),ALCATEL ONETOUCH PIXI 4 (4),Pixi4-4,4034F
+TCT (Alcatel),ALCATEL ONETOUCH PIXI 4 (4),Pixi4-4,4034G
+TCT (Alcatel),ALCATEL ONETOUCH PIXI 4 (4),Pixi4-4,4034X
+TCT (Alcatel),ALCATEL ONETOUCH PIXI 4 (4),Pixi4-4,Alcatel_4034F
+TCT (Alcatel),ALCATEL ONETOUCH PIXI 4 (4),Pixi4-4,DIGICEL DL 1 lite
+TCT (Alcatel),ALCATEL ONETOUCH PIXI\xe2\x84\xa2 3 (4.5),PIXI3_45_4G,5017O
+TCT (Alcatel),ALCATEL ONETOUCH POP 3 (5),PIXI3-5,5015A
+TCT (Alcatel),ALCATEL ONETOUCH POP 3 (5),PIXI3-5,5015D
+TCT (Alcatel),ALCATEL ONETOUCH POP 3 (5),PIXI3-5,5015E
+TCT (Alcatel),ALCATEL ONETOUCH POP 3 (5),PIXI3-5,5015X
+TCT (Alcatel),ALCATEL ONETOUCH POP 3 (5),PIXI3-5,5016A
+TCT (Alcatel),ALCATEL ONETOUCH POP 3 (5),PIXI3-5,5016J
+TCT (Alcatel),ALCATEL ONETOUCH POP 3 (5),PIXI3-5,5116J
+TCT (Alcatel),ALCATEL ONETOUCH POP 3 (5.5),PIXI3-55,5025D
+TCT (Alcatel),ALCATEL ONETOUCH POP 3 (5.5),PIXI3-55,5025E
+TCT (Alcatel),ALCATEL ONETOUCH POP 3 (5.5),PIXI3-55,5025G
+TCT (Alcatel),ALCATEL ONETOUCH POP 3 (5.5),PIXI3-55,5025X
+TCT (Alcatel),ALCATEL ONETOUCH POP 3 (5.5),PIXI3-55,DIGICEL DL1000
+TCT (Alcatel),ALCATEL ONETOUCH POP 3 (5.5),PIXI3-55,S4035 3G
+TCT (Alcatel),ALCATEL ONETOUCH POP D3,SOUL4NA,ALCATEL ONETOUCH POP D3
+TCT (Alcatel),ALCATEL ONETOUCH Victory,7046T,Alcatel 7046T
+TCT (Alcatel),ALCATEL PIXI 4 (5),PIXI4_5_4G,5041D
+TCT (Alcatel),ALCATEL PIXI 4 (5),PIXI4_5_4G,5045A
+TCT (Alcatel),ALCATEL PIXI 4 (5),PIXI4_5_4G,5045D
+TCT (Alcatel),ALCATEL PIXI 4 (5),PIXI4_5_4G,5045F
+TCT (Alcatel),ALCATEL PIXI 4 (5),PIXI4_5_4G,5045G
+TCT (Alcatel),ALCATEL PIXI 4 (5),PIXI4_5_4G,5045I
+TCT (Alcatel),ALCATEL PIXI 4 (5),PIXI4_5_4G,5045J
+TCT (Alcatel),ALCATEL PIXI 4 (5),PIXI4_5_4G,5045T
+TCT (Alcatel),ALCATEL PIXI 4 (5),PIXI4_5_4G,5045X
+TCT (Alcatel),ALCATEL PIXI 4 (5),PIXI4_5_4G,5045Y
+TCT (Alcatel),ALCATEL PIXI 4 (5),PIXI4_5_4G,5145A
+TCT (Alcatel),ALCATEL PIXI 4 (5),PIXI4_5_4G,DIGICELDL1
+TCT (Alcatel),ALCATEL one touch 986+,OT986,ALCATEL one touch 986+
+TCT (Alcatel),ALCATEL one touch 990C+,one_touch_990C_Plus_cdma,ALCATEL one touch 990C+
+TCT (Alcatel),ALCATEL one touch J320,Iris,ALCATEL one touch J320
+TCT (Alcatel),ALCATEL_ 4034A,Pixi4-4,ALCATEL_4034A
+TCT (Alcatel),ALCATEL_6055K,idol4,ALCATEL_6055K
+TCT (Alcatel),ALCATEL_ONETOUCH_7053D,X1,7053D
+TCT (Alcatel),ALCATEL_ONETOUCH_7053D,X1,ALCATEL_ONETOUCH_7053D
+TCT (Alcatel),ALCATEL_ONE_TOUCH_4027A,Pixi3-45,ALCATEL ONE TOUCH 4027A
+TCT (Alcatel),ALCATEL_ONE_TOUCH_5037A,YarisL_GSM,ALCATEL ONE TOUCH 5037A
+TCT (Alcatel),ALCATEL_ONE_TOUCH_5037X,YarisL_GSM,ALCATEL ONE TOUCH 5037X
+TCT (Alcatel),ALCATEL_ONE_TOUCH_6010X_Orange,ONE_TOUCH_6010X_gsm,ALCATEL_ONE_TOUCH_6010X_Orange
+TCT (Alcatel),ALCATEL_ONE_TOUCH_6030X_Orange,ONE_TOUCH_6030X_gsm,ALCATEL_ONE_TOUCH_6030X_Orange
+TCT (Alcatel),ALCATEL_ONE_TOUCH_7047A,YARIS_55,ALCATEL ONE TOUCH 7047A
+TCT (Alcatel),ALCATEL_ONE_TOUCH_903,one_touch_903A_gsm,ALCATEL_ONE_TOUCH_903
+TCT (Alcatel),ALCATEL_ONE_TOUCH_903,one_touch_903_gsm,ALCATEL_ONE_TOUCH_903
+TCT (Alcatel),ALCATEL_ONE_TOUCH_991_Orange,one_touch_991_gsm,ALCATEL_ONE_TOUCH_991_Orange
+TCT (Alcatel),ALCATEL_ONE_TOUCH_P310X,POP7,ALCATEL ONE TOUCH P310X
+TCT (Alcatel),ALCATEL_ONE_TOUCH_P320X,POP8,ALCATEL ONE TOUCH P320X
+TCT (Alcatel),ALCATEL_one_touch_918D,one_touch_918D_umts,ALCATEL_one_touch_918D
+TCT (Alcatel),ALCATEL_one_touch_991,ONE_TOUCH_991A_gsm,ALCATEL_one_touch_991
+TCT (Alcatel),ALCATEL_one_touch_991,one_touch_991_gsm,ALCATEL_one_touch_991
+TCT (Alcatel),ALCATEL_one_touch_995,one_touch_995_gsm,ALCATEL_one_touch_995
+TCT (Alcatel),ALCATEL_one_touch_995,one_touch_995_gsm,RPSPE4301
+TCT (Alcatel),ALCATEL_one_touch_995,one_touch_995_gsm,Telenor_One_Touch_S
+TCT (Alcatel),ALCATEL_one_touch_995,one_touch_995_gsm,Telenor_Smart_HD
+TCT (Alcatel),ALCATEL_one_touch_995A,one_touch_995_gsm,ALCATEL_one_touch_995A
+TCT (Alcatel),ALCATEL_one_touch_995S,one_touch_995_gsm,ALCATEL_one_touch_995S
+TCT (Alcatel),ALOO 6032,Alpha,ALOO 6032
+TCT (Alcatel),AM-H100,EOS_lte,AM-H100
+TCT (Alcatel),ATEL ONE TOUCH 995,one_touch_995_gsm,ALCATEL_one_touch_995
+TCT (Alcatel),Alcatel 3V,A3A_XL_4G,5099A
+TCT (Alcatel),Alcatel 3V,A3A_XL_4G,5099D
+TCT (Alcatel),Alcatel 3V,A3A_XL_4G,5099U
+TCT (Alcatel),Alcatel 5,A5A_INFINI,5086A
+TCT (Alcatel),Alcatel 5,A5A_INFINI,5086D
+TCT (Alcatel),Alcatel Raven LTE,BUZZ6T4GTFUMTS,A574BL
+TCT (Alcatel),Alcatel one touch 985,one_touch_985A_gsm,ALCATEL_one_touch_985
+TCT (Alcatel),Alcatel9007T,Pixi3_7_4G,Alcatel9007T
+TCT (Alcatel),Alcatel_4060A,Pop445,Alcatel_4060A
+TCT (Alcatel),Alcatel_5044C,BUZZ6T4GCRICKET,Alcatel_5044C
+TCT (Alcatel),Alcatel_5045A,PIXI4_5_4G,Alcatel_5045A
+TCT (Alcatel),Alcatel_5054O,Pop355,Alcatel_5054O
+TCT (Alcatel),Alcatel_5056O,Pop355,Alcatel_5056O
+TCT (Alcatel),Alcatel_5085C,elsa6_na,Alcatel 5085C
+TCT (Alcatel),Alcatel_5098O,Pixi4-64GMEX,Alcatel_5098O
+TCT (Alcatel),Alcatel_6055U,idol4,Alcatel 6055U
+TCT (Alcatel),Alcatel_6055U,idol4,Alcatel_6055U
+TCT (Alcatel),Alcatel_6060C,simba6_cricket,Alcatel_6060C
+TCT (Alcatel),Alcatel_7049D,Lion-5,Alcatel_7049D
+TCT (Alcatel),Alcatel_9001X,Pixi4-6_4G,Alcatel_9001X
+TCT (Alcatel),Alcatel_9026S,Pixi5-10_4G,Alcatel 9026S
+TCT (Alcatel),Alcatel_one_touch_918_Orange,one_touch_918_gsm,Alcatel_one_touch_918_Orange
+TCT (Alcatel),Boost View 5.0,YARISXL,Boost View 5.0
+TCT (Alcatel),D819,HERO8,D819
+TCT (Alcatel),D820,HERO8,D820
+TCT (Alcatel),D820X,HERO8,D820X
+TCT (Alcatel),DL900,YARISXL,DL900
+TCT (Alcatel),DLGICELDL1 plus,POP455C,DIGICELDL1plus
+TCT (Alcatel),E500,X50D,E500
+TCT (Alcatel),ELEMENT5,BUZZ6T4GGOPHONE,Alcatel_5044R
+TCT (Alcatel),EVO7,EVO7,MTC 1065
+TCT (Alcatel),EVO7,EVO7,onetouch EVO7
+TCT (Alcatel),EVO7,EVO7,starTIM tab 7
+TCT (Alcatel),FL03,FLASH3,FL03
+TCT (Alcatel),Flash Plus 2,shine_plus,FL02
+TCT (Alcatel),Flash2_7049D,Lion-5,Flash2_7049D
+TCT (Alcatel),Go PLAY,alto5_sporty,7048A
+TCT (Alcatel),Go PLAY,alto5_sporty,7048S
+TCT (Alcatel),Go PLAY,alto5_sporty,7048W
+TCT (Alcatel),Go PLAY,alto5_sporty,7048X
+TCT (Alcatel),Hero2C,Hero2C,7055A
+TCT (Alcatel),I216A,PIXI7,I216A
+TCT (Alcatel),I216X,PIXI7,I216X
+TCT (Alcatel),I220,PIXI8,I220
+TCT (Alcatel),I221,PIXI8,I221
+TCT (Alcatel),IDOL 2 S,EOS4G,6050Y
+TCT (Alcatel),IDOL 2 S,EOS4G,ALCATEL ONE TOUCH 6050Y
+TCT (Alcatel),IDOL 2 S,EOS4G,Idol2S_Orange
+TCT (Alcatel),IDOL 2 S,EOS_lte,6050A
+TCT (Alcatel),IDOL 2 S,EOS_lte,6050F
+TCT (Alcatel),IDOL 2 S,EOS_lte,6050W
+TCT (Alcatel),IDOL 2 S,EOS_lte,6050Y
+TCT (Alcatel),IDOL 2 S,EOS_lte,ALCATEL ONE TOUCH 6050Y
+TCT (Alcatel),IDOL 2 S,EOS_lte,ALCATEL ONETOUCH 6050A
+TCT (Alcatel),IDOL 2 S,EOS_lte,OWN S5030
+TCT (Alcatel),IDOL 2 S,EOS_lte,TCL S830U
+TCT (Alcatel),IDOL 2 S,EOS_lte,TCL S838M
+TCT (Alcatel),IDOL 4S,idol4s,6070K
+TCT (Alcatel),IDOL 4S,idol4s,6070O
+TCT (Alcatel),IDOL 5,SIMBA6L,6058A
+TCT (Alcatel),IDOL 5,SIMBA6L,6058D
+TCT (Alcatel),IDOL 5,SIMBA6L,6058X
+TCT (Alcatel),IDOL 5S,IDOL5S,6060S
+TCT (Alcatel),Idol S,DiabloHD_LTE,ALCATEL ONE TOUCH 6035L
+TCT (Alcatel),Idol S,DiabloHD_LTE,BS472
+TCT (Alcatel),Idol S,DiabloHD_LTE,MTC 978
+TCT (Alcatel),Idol S,Diablo_LTE,ALCATEL ONE TOUCH 6034L
+TCT (Alcatel),Idol S,Diablo_LTE,ALCATEL ONE TOUCH 6034M
+TCT (Alcatel),Idol S,Diablo_LTE,ALCATEL ONE TOUCH 6034R
+TCT (Alcatel),Idol S,Diablo_LTE,ALCATEL ONE TOUCH 6034Y
+TCT (Alcatel),Idol S,Diablo_LTE,San Remo 4G
+TCT (Alcatel),Idol S,Diablo_LTE,TCL-S850L
+TCT (Alcatel),Idol X,DiabloHD_LTE,ALCATEL ONE TOUCH 6035R
+TCT (Alcatel),Idol2 MINI S,MIATA_lte,6036A
+TCT (Alcatel),Idol2 MINI S,MIATA_lte,6036X
+TCT (Alcatel),Idol2 MINI S,MIATA_lte,6036Y
+TCT (Alcatel),Juke-A554C,A554C,A554C
+TCT (Alcatel),LCATEL ONETOUCH PIXI 3 (4.5),PIXI3_45_4G,DIGICEL DL810
+TCT (Alcatel),M812C,M812,M812C
+TCT (Alcatel),MTC 960,MTC_960_gsm,MTC 960
+TCT (Alcatel),MTC 970,Beetle_GSM,MTC 970
+TCT (Alcatel),MTC975,Camry_GSM,MTC975
+TCT (Alcatel),MegaFon_SP-A10,one_touch_995_gsm,MegaFon_SP-A10
+TCT (Alcatel),Megafon Login,OT-930,MegaFon_SP-AI
+TCT (Alcatel),Mirage,feijao,5057M
+TCT (Alcatel),Moov2,move_2_gsm,move 2
+TCT (Alcatel),NeXT by Maxis (B1),VFD500,VFD 500
+TCT (Alcatel),NeXT by Maxis (M1),VFD700,Maxis VFD 700
+TCT (Alcatel),NeXT by Maxis (M1),VFD700,VFD 700
+TCT (Alcatel),NeXT by Maxis (M1),VFD700,VFD700
+TCT (Alcatel),Nitro,idol3,6045O
+TCT (Alcatel),No,Pixi445Cricket,Alcatel_4060O
+TCT (Alcatel),ONE TOUCH 4007X,Pixo_GSM,ONE TOUCH 4007A
+TCT (Alcatel),ONE TOUCH 4007X,Pixo_GSM,ONE TOUCH 4007D
+TCT (Alcatel),ONE TOUCH 4007X,Pixo_GSM,ONE TOUCH 4007E
+TCT (Alcatel),ONE TOUCH 4007X,Pixo_GSM,ONE TOUCH 4007X
+TCT (Alcatel),ONE TOUCH 4011X,BeetleliteJB,ONE TOUCH 4011X
+TCT (Alcatel),ONE TOUCH 4015X,Yaris35_GSM,4016D
+TCT (Alcatel),ONE TOUCH 4015X,Yaris35_GSM,ONE TOUCH 4015A
+TCT (Alcatel),ONE TOUCH 4015X,Yaris35_GSM,ONE TOUCH 4015D
+TCT (Alcatel),ONE TOUCH 4015X,Yaris35_GSM,ONE TOUCH 4015N
+TCT (Alcatel),ONE TOUCH 4015X,Yaris35_GSM,ONE TOUCH 4015X
+TCT (Alcatel),ONE TOUCH 4015X,Yaris35_GSM,ONE TOUCH 4015X-orange
+TCT (Alcatel),ONE TOUCH 4015X,Yaris35_GSM,ONE TOUCH 4016A
+TCT (Alcatel),ONE TOUCH 4015X,Yaris35_GSM,Orange Yomi
+TCT (Alcatel),ONE TOUCH 4033X,Yaris_M_GSM,4032A
+TCT (Alcatel),ONE TOUCH 4033X,Yaris_M_GSM,4032D
+TCT (Alcatel),ONE TOUCH 4033X,Yaris_M_GSM,4032E
+TCT (Alcatel),ONE TOUCH 4033X,Yaris_M_GSM,4032X
+TCT (Alcatel),ONE TOUCH 4033X,Yaris_M_GSM,4033L
+TCT (Alcatel),ONE TOUCH 4033X,Yaris_M_GSM,MS3B
+TCT (Alcatel),ONE TOUCH 4033X,Yaris_M_GSM,ONE TOUCH 4032A
+TCT (Alcatel),ONE TOUCH 4033X,Yaris_M_GSM,ONE TOUCH 4033A
+TCT (Alcatel),ONE TOUCH 4033X,Yaris_M_GSM,ONE TOUCH 4033D
+TCT (Alcatel),ONE TOUCH 4033X,Yaris_M_GSM,ONE TOUCH 4033E
+TCT (Alcatel),ONE TOUCH 4033X,Yaris_M_GSM,ONE TOUCH 4033X
+TCT (Alcatel),ONE TOUCH 4033X,Yaris_M_GSM,OWN S3010
+TCT (Alcatel),ONE TOUCH 4033X,Yaris_M_GSM,OWN S3010D
+TCT (Alcatel),ONE TOUCH 4033X,Yaris_M_GSM,TCLJ330
+TCT (Alcatel),ONE TOUCH 6012A,California_GSM,ONE TOUCH 6012A
+TCT (Alcatel),ONE TOUCH 6012D,California,ALCATEL ONE TOUCH 6012D
+TCT (Alcatel),ONE TOUCH 6012D,California,ALCATEL ONE TOUCH 6012X
+TCT (Alcatel),ONE TOUCH 6012D,California,Mobile Sosh
+TCT (Alcatel),ONE TOUCH 6012D,California,ONE TOUCH 6012A
+TCT (Alcatel),ONE TOUCH 6012D,California,ONE TOUCH 6012D
+TCT (Alcatel),ONE TOUCH 6012D,California,ONE TOUCH 6012E
+TCT (Alcatel),ONE TOUCH 6012D,California,ONE TOUCH 6012X
+TCT (Alcatel),ONE TOUCH 6012D,California,ONE TOUCH IDOL MINI
+TCT (Alcatel),ONE TOUCH 6012D,California,Orange Covo
+TCT (Alcatel),ONE TOUCH 6012D,California,Orange Hiro
+TCT (Alcatel),ONE TOUCH 6012X,California,ONE TOUCH 6012X
+TCT (Alcatel),ONE TOUCH 8020D,SCRIBEPRO,ONE TOUCH 8020D
+TCT (Alcatel),ONE TOUCH 983,ONE_TOUCH_983_gsm,ALCATEL_one_touch_983
+TCT (Alcatel),ONE TOUCH 983,ONE_TOUCH_983_gsm,ONE TOUCH 983
+TCT (Alcatel),ONE TOUCH 983,ONE_TOUCH_983_gsm,VALENCIA
+TCT (Alcatel),ONE TOUCH 983,one_touch_983_gsm,ALCATEL_one_touch_983
+TCT (Alcatel),ONE TOUCH C505C,ONE_TOUCH_C505C_cdma,ONE TOUCH C505C
+TCT (Alcatel),ONE TOUCH EVO7HD,E710,MTC 1078
+TCT (Alcatel),ONE TOUCH EVO7HD,E710,ONE TOUCH E710
+TCT (Alcatel),ONE TOUCH EVO7HD,E710,ONE TOUCH EVO7HD
+TCT (Alcatel),ONE TOUCH EVO8HD,E720,ONE TOUCH EVO7HD
+TCT (Alcatel),ONE TOUCH EVO8HD,E720,ONE TOUCH EVO8HD
+TCT (Alcatel),ONE TOUCH SCRIBE 5,Scribe5_gsm,ALCATEL ONE TOUCH 8000A
+TCT (Alcatel),ONE TOUCH SCRIBE 5,Scribe5_gsm,ALCATEL ONE TOUCH 8000D
+TCT (Alcatel),ONE TOUCH SCRIBE 5,Scribe5_gsm,TCL Y710
+TCT (Alcatel),ONE TOUCH T10,GR-TB7,GR-TB7
+TCT (Alcatel),ONE TOUCH TAB 7,T011,ONE TOUCH TAB 7
+TCT (Alcatel),ONE TOUCH TAB 7,T011,TCL TAB 7
+TCT (Alcatel),ONE TOUCH TAB 7HD,T016,ONE TOUCH TAB 7HD
+TCT (Alcatel),ONE TOUCH TAB 8HD,T021,ONE TOUCH TAB 8HD
+TCT (Alcatel),ONE TOUCH Ultra 960c,Alltel,ONE_TOUCH_960C
+TCT (Alcatel),ONE TOUCH Ultra 960c,ONE_TOUCH_960C,ADR3010
+TCT (Alcatel),ONE TOUCH Ultra 960c,ONE_TOUCH_960C,ONE TOUCH 960C
+TCT (Alcatel),ONE TOUCH Ultra 960c,RadioShack,ADR3010
+TCT (Alcatel),ONE TOUCH Ultra 960c,nTelos,ONE_TOUCH_960C
+TCT (Alcatel),ONE TOUCH Ultra 960c,vulcan,ONE_TOUCH_960C
+TCT (Alcatel),ONETOUCH PIXI 3 (8),pixi384g,9022S
+TCT (Alcatel),ONETOUCH PIXI 3 (8),pixi384g,9022X
+TCT (Alcatel),ONETOUCH PIXI 3 (8),pixi384g,Alcatel9022S
+TCT (Alcatel),ONETOUCH PIXI 3 (8),pixi384g,Alcatel_9022S
+TCT (Alcatel),ONETOUCH PIXI3(7),pixi37,9007A
+TCT (Alcatel),ONETOUCH PIXI3(7),pixi37,9007X
+TCT (Alcatel),ONE_TOUCH_P310A,POP7,ONE TOUCH P310A
+TCT (Alcatel),ONE_TOUCH_P310X,POP7,ALCATEL ONE TOUCH P310X
+TCT (Alcatel),OT-990C,OT-990C_cdma,OT-990C
+TCT (Alcatel),OWN S4010,Telsa,OWN S4010
+TCT (Alcatel),OWN S5010,DiabloHD,OWN S5010
+TCT (Alcatel),OWN_S4025,YARIS_55,OWN_S4025
+TCT (Alcatel),One Touch 890D,one_touch_890D_gsm,ALCATEL one touch 890D
+TCT (Alcatel),One Touch 906,one_touch_906_gsm,ALCATEL_one_touch_906Y
+TCT (Alcatel),One Touch 908,one_touch_908_gsm,ALCATEL ONE TOUCH 908
+TCT (Alcatel),One Touch 908,one_touch_908_gsm,ALCATEL_one_touch_908
+TCT (Alcatel),One Touch 908,one_touch_908_gsm,Alcatel_one_touch_908F_Orange
+TCT (Alcatel),One Touch 990,one_touch_990_gsm,ALCATEL ONE TOUCH 990
+TCT (Alcatel),One Touch 990,one_touch_990_gsm,ALCATEL one touch 990
+TCT (Alcatel),One Touch 990,one_touch_990_gsm,ALCATEL_one_touch_990
+TCT (Alcatel),One Touch 990,one_touch_990_gsm,Alcatel one touch 908F Orange
+TCT (Alcatel),One Touch 990,one_touch_990_gsm,Alcatel one touch 990 Orange
+TCT (Alcatel),One Touch 990,one_touch_990_gsm,Los Angeles
+TCT (Alcatel),One Touch 990,one_touch_990_gsm,TCL A990
+TCT (Alcatel),One Touch 990,one_touch_990_gsm,TCL ONE TOUCH 990
+TCT (Alcatel),One Touch 990,one_touch_990_gsm,Telenor_OneTouch
+TCT (Alcatel),One Touch 990,one_touch_990_gsm,Vodafone 958
+TCT (Alcatel),One Touch 990A,one_touch_990A_gsm,ALCATEL_one_touch_990A
+TCT (Alcatel),One Touch 990S,one_touch_990S_gsm,ALCATEL_one_touch_990S
+TCT (Alcatel),One Touch 990S,one_touch_990S_gsm,Alcatel one touch 990S
+TCT (Alcatel),P330X,Pop7_LTE,P330X
+TCT (Alcatel),P330X_orange,Pop7_LTE,P330X_orange
+TCT (Alcatel),P350X,POP8_LTE,P350X
+TCT (Alcatel),P360X,POP10,P360X
+TCT (Alcatel),P688L,Rio5C,TCL-P688L
+TCT (Alcatel),P688L,Rio5C,TOM007
+TCT (Alcatel),PIXI 4 (5),Pixi4-5,5010D
+TCT (Alcatel),PIXI 4 (5),Pixi4-5,5010E
+TCT (Alcatel),PIXI 4 (5),Pixi4-5,5010G
+TCT (Alcatel),PIXI 4 (5),Pixi4-5,5010S
+TCT (Alcatel),PIXI 4 (5),Pixi4-5,5010U
+TCT (Alcatel),PIXI 4 (5),Pixi4-5,5010X
+TCT (Alcatel),PIXI 5 HD,Mickey6CC,A576CC
+TCT (Alcatel),PIXI3(4),Pixi3-4,4003A
+TCT (Alcatel),PIXI3(4),Pixi3-4,4003J
+TCT (Alcatel),PIXI3(4),Pixi3-4,4013D
+TCT (Alcatel),PIXI3(4),Pixi3-4,4013E
+TCT (Alcatel),PIXI3(4),Pixi3-4,4013J
+TCT (Alcatel),PIXI3(4),Pixi3-4,4013K
+TCT (Alcatel),PIXI3(4),Pixi3-4,4013X
+TCT (Alcatel),PIXI3(4),Pixi3-4,4014E
+TCT (Alcatel),PIXI3(4),Pixi3-4,ONE_TOUCH_PIXI3
+TCT (Alcatel),PIXI3(4),Pixi3-4,ONE_TOUCH_PIXI3D
+TCT (Alcatel),PIXI3(4.5),Pixi3-45,4027A
+TCT (Alcatel),PIXI3(4.5),Pixi3-45,4027D
+TCT (Alcatel),PIXI3(4.5),Pixi3-45,4027N
+TCT (Alcatel),PIXI3(4.5),Pixi3-45,4027X
+TCT (Alcatel),PIXI3(4.5),Pixi3-45,4028A
+TCT (Alcatel),PIXI3(4.5),Pixi3-45,4028E
+TCT (Alcatel),PIXI3(4.5),Pixi3-45,4028J
+TCT (Alcatel),PIXI3(4.5),Pixi3-45,4028S
+TCT (Alcatel),PIXI4 (3.5),PIXI4-35,4017A
+TCT (Alcatel),PIXI4 (3.5),PIXI4-35,4017D
+TCT (Alcatel),PIXI4 (3.5),PIXI4-35,4017F
+TCT (Alcatel),PIXI4 (3.5),PIXI4-35,4017S
+TCT (Alcatel),PIXI4 (3.5),PIXI4-35,4017X
+TCT (Alcatel),PIXI\xe2\x84\xa24,Pixi445CAN,4060S
+TCT (Alcatel),PLAY_P1,PLAY_P1,4024D
+TCT (Alcatel),PLAY_P1,PLAY_P1,4024E
+TCT (Alcatel),POP 2,Alto45,5042A
+TCT (Alcatel),POP 2,Alto45,5042D
+TCT (Alcatel),POP 2,Alto45,5042X
+TCT (Alcatel),POP 2 (5),alto5,7043A
+TCT (Alcatel),POP 2 (5),alto5,7043K
+TCT (Alcatel),POP 2 (5),alto5,7043Y
+TCT (Alcatel),POP 2 (5),alto5_premium,7044A
+TCT (Alcatel),POP 2 (5),alto5_premium,7044X
+TCT (Alcatel),"POP 4 6"" 4G android",POP4-6_4G,7070I
+TCT (Alcatel),"POP 4 6"" 4G android",POP4-6_4G,7070Q
+TCT (Alcatel),"POP 4 6"" 4G android",POP4-6_4G,7070X
+TCT (Alcatel),POP 4S,shine_plus,5095I
+TCT (Alcatel),POP 4S,shine_plus,5095K
+TCT (Alcatel),POP 4S,shine_plus,5095Y
+TCT (Alcatel),POP S3,RIO4G_TF,ALCATEL A845L
+TCT (Alcatel),POP S3,RIO_4G,5050A
+TCT (Alcatel),POP S3,RIO_4G,5050S
+TCT (Alcatel),POP S3,RIO_4G,5050X
+TCT (Alcatel),POP S3,RIO_4G,5050Y
+TCT (Alcatel),POP S3,RIO_4G,ALCATEL ONETOUCH 5050X
+TCT (Alcatel),POP S3,RIO_4G,Siru
+TCT (Alcatel),POP S9,RIO6_lte,7050Y
+TCT (Alcatel),POP S9,RIO6_lte,ALCATEL A995L
+TCT (Alcatel),POP S9,RIO6_lte,STARXTREM II
+TCT (Alcatel),POP S9,RIO6_lte,Smartphone Android by SFR STARXTREM II
+TCT (Alcatel),POP2 (4),alto4,4045A
+TCT (Alcatel),POP2 (4),alto4_8g,4045A
+TCT (Alcatel),POP2 (4),alto4_8g,4045D
+TCT (Alcatel),POP2 (4),alto4_8g,4045L
+TCT (Alcatel),POP2 (4),alto4_8g,4045O
+TCT (Alcatel),POP2 (4),alto4_8g,4045X
+TCT (Alcatel),POP2 (4.5),alto45_latam_b28,5042G
+TCT (Alcatel),POP2 (4.5),alto45_latam_b28,5042W
+TCT (Alcatel),PandA_m14,YARIS_55,PandA_m14
+TCT (Alcatel),Pixi3-3.5 TF,Pixi3-35TF,A463BG
+TCT (Alcatel),Pixi3-4 TF,PIXI3_4TF,A460G
+TCT (Alcatel),Pixi4-4 3G Telus,PIXI4_4TF,A466T
+TCT (Alcatel),Pixo 7,PIXO7,I211
+TCT (Alcatel),Pixo 7,PIXO7,I212
+TCT (Alcatel),Pixo 7,PIXO7,I213
+TCT (Alcatel),Pop4,POP455C,Pop4
+TCT (Alcatel),S4035_4G,Pop355,S4035_4G
+TCT (Alcatel),SHINE LITE,shine_lite,5080D
+TCT (Alcatel),SHINE LITE,shine_lite,5080X
+TCT (Alcatel),SMART 4G 5.5 Enterprise,M812,SMART 4G 5.5 Enterprise
+TCT (Alcatel),SMART_ PLUS,PIXI4_55_3G,SMART_PLUS
+TCT (Alcatel),SOL PRIME,idol4s,T-1000
+TCT (Alcatel),SOL PRIME,idol4s_skt,T-1000
+TCT (Alcatel),SOLO Aspire M,PIXI3-5,SOLO Aspire M
+TCT (Alcatel),SOUL 4.5,SOUL45_GSM,5038X
+TCT (Alcatel),Smartphone Android by SFR STARADDICT II,one_touch_996_gsm,Smartphone Android by SFR STARADDICT II
+TCT (Alcatel),Smartphone Android by SFR STARADDICT II,one_touch_996_gsm,Smartphone_Android_by_SFR_STARADDICT_II
+TCT (Alcatel),Sol,idol3,AM-H200
+TCT (Alcatel),Soul 3.5,SOUL35,4018A
+TCT (Alcatel),Soul 3.5,SOUL35,4018D
+TCT (Alcatel),Soul 3.5,SOUL35,4018E
+TCT (Alcatel),Soul 3.5,SOUL35,4018F
+TCT (Alcatel),Soul 3.5,SOUL35,4018M
+TCT (Alcatel),Soul 3.5,SOUL35,4018X
+TCT (Alcatel),Soul 3.5,SOUL35,T4018
+TCT (Alcatel),Soul 4,SOUL4,4035A
+TCT (Alcatel),Soul 4,SOUL4,4035D
+TCT (Alcatel),Soul 4,SOUL4,4035X
+TCT (Alcatel),Soul 4,SOUL4,4035X_Orange
+TCT (Alcatel),Soul 4,SOUL4,4035Y
+TCT (Alcatel),Soul 4,SOUL4,4036E
+TCT (Alcatel),Soul 4.5,SOUL45_GSM,5038A
+TCT (Alcatel),Soul 4.5,SOUL45_GSM,5038E
+TCT (Alcatel),Soul 4.5,SOUL45_GSM,D45
+TCT (Alcatel),T10,T10,one touch T10
+TCT (Alcatel),T70,PIXO7,T70
+TCT (Alcatel),TAB 7 DUAL CORE,T015,TAB 7 DUAL CORE
+TCT (Alcatel),TAB 7 DUAL CORE,T017,TAB 7 DUAL CORE
+TCT (Alcatel),TCL 302U,Festa5_CU,TCL 302U
+TCT (Alcatel),TCL 520,shine_lite,TCL 520
+TCT (Alcatel),TCL 562,shine_plus,562
+TCT (Alcatel),TCL 580,idol4_mini,TCL 580
+TCT (Alcatel),TCL 736L,Rio5C,TCL-J736L
+TCT (Alcatel),TCL 738M,Rio5C,TCL J738M
+TCT (Alcatel),TCL 750,x1_plus,TCL 750
+TCT (Alcatel),TCL 950,idol4s_cn,TCL 950
+TCT (Alcatel),TCL A506,TCL_A506,TCL A506
+TCT (Alcatel),TCL A865,TCL_A865,TCL A865
+TCT (Alcatel),TCL A988,one_touch_993D_gsm,ALCATEL ONE TOUCH 993D
+TCT (Alcatel),TCL A988,one_touch_993_gsm,ALCATEL ONE TOUCH 993
+TCT (Alcatel),TCL A988,one_touch_993_gsm,MTC_968
+TCT (Alcatel),TCL C995,TCL_C995_cdma,TCL C995
+TCT (Alcatel),TCL D35,SOUL35,TCL D35
+TCT (Alcatel),TCL D40 DUAL,D40,TCL D40 DUAL
+TCT (Alcatel),TCL D55,YARIS_55,TCL D55
+TCT (Alcatel),TCL D662,TCL_D662_cdma,TCL D662
+TCT (Alcatel),TCL D706,EG502,TCL D706
+TCT (Alcatel),TCL D768,EG501,TCL D768
+TCT (Alcatel),TCL D920,TCL_D920,TCL D920
+TCT (Alcatel),TCL D920,TCL_D920,TCL-D920
+TCT (Alcatel),TCL DL750,SOUL4,DL750
+TCT (Alcatel),TCL H900M,HERO2,TCL H900M
+TCT (Alcatel),TCL J210C,TCL_J210C_cdma,TCL J210C
+TCT (Alcatel),TCL J210C,TCL_J210C_cdma,TCL-J210C
+TCT (Alcatel),TCL J300,Megane,ALCATEL ONE TOUCH 5020T
+TCT (Alcatel),TCL J300,Megane,TCL J300
+TCT (Alcatel),TCL J310,MeganeB,TCL J310
+TCT (Alcatel),TCL J320,Iris,TCL J320
+TCT (Alcatel),TCL J320C,Daniel_lite,TCL J320C
+TCT (Alcatel),TCL J320T,IrisTD,TCL J320T
+TCT (Alcatel),TCL J600T,Iris2TD,TCL J600T
+TCT (Alcatel),TCL J620,md501,TCL J620
+TCT (Alcatel),TCL J630,Iris2PlusUMTS,J630
+TCT (Alcatel),TCL J630T,Iris2PlusTD,TCL J630T
+TCT (Alcatel),TCL J720,YARISXL,TCL J720
+TCT (Alcatel),TCL J726T,YARISXL,TCL J726T
+TCT (Alcatel),TCL J900,Camry2,TCL J900
+TCT (Alcatel),TCL J900T,Camry2_TD,TCL J900T
+TCT (Alcatel),TCL J920,YARIS_55,TCL J920
+TCT (Alcatel),TCL J926T,YARIS_55,TCL J926T
+TCT (Alcatel),TCL J928,Prius,TCL J928
+TCT (Alcatel),TCL J929L,Diablo_LTE,TCL-J929L
+TCT (Alcatel),TCL J938M,RIO55_LTE,TCL J938M
+TCT (Alcatel),TCL M2M,CROSS2,TCL M2M
+TCT (Alcatel),TCL M2U,CROSS2,TCL M2U
+TCT (Alcatel),TCL P301C,Cooper_40,TCL P301C
+TCT (Alcatel),TCL P301M,TCL_P301M,TCL P301M
+TCT (Alcatel),TCL P302C,Cooper40,TCL P302C
+TCT (Alcatel),TCL P316L,Festa5_CT,TCL P316L
+TCT (Alcatel),TCL P331M,TCL_P331M,TCL P331M
+TCT (Alcatel),TCL P332U,TCL_P332U,TCL P332U
+TCT (Alcatel),TCL P360W,Focus5_CU,TCL P360W
+TCT (Alcatel),TCL P500M,Festa_L,TCL P500M
+TCT (Alcatel),TCL P502U,Festa5_CU,TCL P502U
+TCT (Alcatel),TCL P520L,Bora5_CT,TCL P520L
+TCT (Alcatel),TCL P606,Rav4_GSM,TCL P600
+TCT (Alcatel),TCL P606,Rav4_GSM,TCL P606
+TCT (Alcatel),TCL P606,Rav4_GSM,TCL P606T
+TCT (Alcatel),TCL P618L,HUMMER5_CT,TCL P618L
+TCT (Alcatel),TCL P631M,Civic_X,TCL P631M
+TCT (Alcatel),TCL P689L,POLO55,TCL_P689L
+TCT (Alcatel),TCL P728M,CROSS_LTE,TCL P728M
+TCT (Alcatel),TCL S300T,TCLS300T,TCL S300T
+TCT (Alcatel),TCL S500,TCL_S500_GSM,TCL S500
+TCT (Alcatel),TCL S520,TCL_S520_GSM,TCL S520
+TCT (Alcatel),TCL S530T,California,TCL S530T
+TCT (Alcatel),TCL S600,TCL_S600_GSM,TCL S600
+TCT (Alcatel),TCL S700,TCLS700,TCL S700
+TCT (Alcatel),TCL S700T,TCLS700T,TCL S700T
+TCT (Alcatel),TCL S720,Cross55,TCL S720
+TCT (Alcatel),TCL S720T,Cross55,TCL S720T
+TCT (Alcatel),TCL S725T,Cross55_TD_Plus,TCL_S725T
+TCT (Alcatel),TCL S820,Diablo,TCL S820
+TCT (Alcatel),TCL S850,DiabloHD,TCL S850
+TCT (Alcatel),TCL S860,Alpha,TCL S860
+TCT (Alcatel),TCL S900,S900,TCL S900
+TCT (Alcatel),TCL S950,DIABLOX,TCL S950
+TCT (Alcatel),TCL S950T,DIABLOX,TCL S950T
+TCT (Alcatel),TCL S960,DIABLOXPLUS,TCL S960
+TCT (Alcatel),TCL S960T,DIABLOXPLUS,TCL S960T
+TCT (Alcatel),TCL T500L,evoque_cn,TCL T500L
+TCT (Alcatel),TCL Y900,Scribe5HD_GSM,TCL Y900
+TCT (Alcatel),TCL Y910,SCRIBEPRO,TCL Y910
+TCT (Alcatel),TCL Y910T,SCRIBEPRO,TCL Y910T
+TCT (Alcatel),TCL i708U,EOS_MACAN,TCL i708U
+TCT (Alcatel),TCL i718M,EOS2,TCL i718M
+TCT (Alcatel),TCL i718M,EOS_Plus,TCL i709M
+TCT (Alcatel),TCL-550,shine_plus,TCL-550
+TCT (Alcatel),TCL-J320D,Daniel_lite_2S,TCL-J320D
+TCT (Alcatel),TCL-J900C,TCL_J900C,TCL-J900C
+TCT (Alcatel),TCL-P306C,Ford50,TCL-P306C
+TCT (Alcatel),TCL_6110A,Telsa,TCL 6110A
+TCT (Alcatel),TCL_6110A,Telsa,TCL_6110A
+TCT (Alcatel),TCL_J636D,msm7627a_a5y_j636d,TCL_J636D
+TCT (Alcatel),TCL_J706T,Focus_L,TCL_J706T
+TCT (Alcatel),TCL_P561U,Fit55_CU,TCL_P561U
+TCT (Alcatel),TCL_U980,TCL_U980,TCL_U980
+TCT (Alcatel),TCL_Xess_P17AA,Xess,TCL Xess P17AA
+TCT (Alcatel),TCL_Xess_P17AA_OS,Xess,TCL Xess P17AA
+TCT (Alcatel),Telenor_Smart,one_touch_985_gsm,Telenor_Smart
+TCT (Alcatel),Telenor_Smart_Mini,SOUL4,Telenor Smart Mini
+TCT (Alcatel),U3,U3_3G,4049D
+TCT (Alcatel),U3,U3_3G,4049E
+TCT (Alcatel),U3,U3_3G,4049G
+TCT (Alcatel),U3,U3_3G,4049M
+TCT (Alcatel),U3,U3_3G,4049X
+TCT (Alcatel),U5,BUZZ6T4G,5044A
+TCT (Alcatel),U5,BUZZ6T4G,5044P
+TCT (Alcatel),U5,BUZZ6T4G,5044Y
+TCT (Alcatel),U5 3G,U5_3G,4047A
+TCT (Alcatel),U5 3G,U5_3G,4047F
+TCT (Alcatel),U5 HD,BUZZ6E,5047D
+TCT (Alcatel),U5 HD,BUZZ6E,5047I
+TCT (Alcatel),U5 HD,BUZZ6E,5047U
+TCT (Alcatel),U5 HD,BUZZ6E,5047Y
+TCT (Alcatel),U50\xe2\x84\xa2,BUZZ6T4GTELUS,5044G
+TCT (Alcatel),U50\xe2\x84\xa2,BUZZ6T4GTELUS,5044S
+TCT (Alcatel),VF 860,Vodafone_Smart_II_gsm,Vodafone Smart II
+TCT (Alcatel),Vodafone 785,Vodafone_785,MTC 982
+TCT (Alcatel),Vodafone 861,one_touch_922_gsm,ALCATEL ONE TOUCH 922
+TCT (Alcatel),Vodafone 861,one_touch_922_gsm,Vodafone 861
+TCT (Alcatel),Vodafone 985N,Vodafone985N,Vodafone 985N
+TCT (Alcatel),Vodafone Smart III,Vodafone_975,Vodafone 975
+TCT (Alcatel),Vodafone Smart III (with NFC),Vodafone_975N,Vodafone 975N
+TCT (Alcatel),X35E,X35E,X35E
+TCT (Alcatel),X50D,X50D,X50D
+TCT (Alcatel),Xess mini,Xess-mini,TCL Xess miniC15BA
+TCT (Alcatel),Xess-mini,Xess-mini,TCL Xess C15BA
+TCT (Alcatel),alcatel PIXI 4 (5.5),PIXI4_55_3G,5012D
+TCT (Alcatel),alcatel PIXI 4 (5.5),PIXI4_55_3G,5012F
+TCT (Alcatel),alcatel PIXI 4 (5.5),PIXI4_55_3G,5012G
+TCT (Alcatel),alcatel U5,BUZZ6T4G,5044D
+TCT (Alcatel),alcatel U5,BUZZ6T4G,5044I
+TCT (Alcatel),alcatel U5,BUZZ6T4G,5044K
+TCT (Alcatel),alcatel U5,BUZZ6T4G,5044O
+TCT (Alcatel),alcatel U5,BUZZ6T4G,5044T
+TCT (Alcatel),freebit PandA_m14,YARIS_55,freebit PandA_m14
+TCT (Alcatel),one touch 995C+,one_touch_995C_cdma,one touch 995C+
+TCT (Alcatel),one touch D920,one_touch_D920,ALCATEL one touch D920
+TCT (Alcatel),one touch D920,one_touch_D920,one touch D920
+TCT (Alcatel),one_touch_4030_TLVE,Beetle_GSM,ALCATEL_one_touch_4030A
+TCT (Alcatel),one_touch_D920_ALIQ,one_touch_D920,one touch D920
+TCT (Alcatel),onetouch_P689L,POLO55,onetouch_P689L
+TCT (Alcatel),tbd,Mickey6TFUMTS,A576BL
+TCT (Alcatel),tmn smarta8,ONE_TOUCH_991D_gsm,moche smart a8
+TCT (Alcatel),tmn smarta8,ONE_TOUCH_991D_gsm,tmn smart a8
+TG&Co.,TG-L800S,PHX,TG-L800S
+TG&Co.,TG-L900S,JGR,TG-L900S
+THTF,"TSINGHUA TONGFANG CO., LTD.",TR10CD1_3,TR10CD1
+TIM,TIM BOX,uzw4010tim,TIM_BOX
+TIM,TIMvision,dwt765ti,skipper
+TJC,Metal Tablet,Metal_Tablet_10,Metal_Tablet_10
+TMAX,TM9S775,MID908A-K,TM9S775
+TPS,MTC 982o,MTC_982O,MTC_982O
+TPS,SMART Sprint,SMARTSprint,SMART Sprint
+TSUNAMi,Tablet Tsunami TSTA080D1,MG080D1T,MG080D1T
+TUNTUN English,DREAM PAD,delight,ITP-R408W
+TUPAD,TU7_58212_18222,TU7_58212,TU7_18222
+TaiwanMobile,A5C,A5C,A5C
+TaiwanMobile,A6S,A6S,A6S
+TaiwanMobile,Amazing A8,D78,Amazing A8
+TaiwanMobile,Amazing X3,TX3,Amazing X3
+TaiwanMobile,Amazing_A35,Amazing_A35,Amazing_A35
+Takara,MID 107,MID107,MID107
+Takara,MID210,MID210,MID210
+Tech 4u,Force,t592_otd_tech_4u_we,Force
+Technicolor,,omap4_WT3,T-Hub2
+Technicolor,Euskaltel,dci765ekt,cooper
+Technicolor,LMT viedtelev\xc4\xabzijas iek\xc4\x81rta,dwt765lmt,skipper
+Technicolor,Shortcut,dwt765ltt,Shortcut
+Techpad,KIICAA POWER,KIICAA_POWER,KIICAA POWER
+Techpad,M5Plus,M5Plus,M5Plus
+Techpad,TECHPAD X5,F518,Techpad X5
+Techpad,TechPad,TechPad_916,916
+Techpad,TechPad_10x,TechPad_10x,TechPad_10x
+Techpad,TechPad_3Gx,TechPad_3Gx,TechPad_3Gx
+Techpad,TechPad_716,TechPad_716,716
+Tecno,A7S,TECNO-A7S,TECNO-A7S
+Tecno,C5,TECNO-C5,TECNO-C5
+Tecno,C7,TECNO-C7,TECNO-C7
+Tecno,C8,TECNO-C8,TECNO-C8
+Tecno,C9,TECNO-C9,TECNO-C9
+Tecno,C9S,TECNO-C9,TECNO-C9S
+Tecno,CAMON CM,TECNO-CA6,TECNO CA6
+Tecno,Camon CX,TECNO-CX,TECNO Camon CX
+Tecno,Camon CX,TECNO-CX,TECNO Camon CXS
+Tecno,Camon CX Air,TECNO-CX-Air,TECNO CX Air
+Tecno,Camon CXS,TECNO-CX,TECNO Camon CXS
+Tecno,Camon I,TECNO-IN5,TECNO IN5
+Tecno,Camon I Air,TECNO-IN3,TECNO IN3
+Tecno,DP10APro-SLA1,DP10APro,DP10APro
+Tecno,DP7CPro-SGA1,DP7CPro-SGA1,DP7CPro-SGA1
+Tecno,DroiPad 10 Pro\xe2\x85\xa1,DP10APro,DP10APro
+Tecno,DroiPad 10D,TECNO-P904,TECNO P904
+Tecno,DroiPad 7C Pro,DP7CPRO,DP7CPRO
+Tecno,DroiPad 7D,TECNO-P701,TECNO P701
+Tecno,DroiPad 7D ProLTE,TECNO-P702,TECNO P702
+Tecno,DroiPad 7D ProLTE,TECNO-P702,TECNO P702A
+Tecno,DroiPad 8\xe2\x85\xa1,DP8D,DP8D
+Tecno,Droipad10,DP10A,DP10A
+Tecno,Droipad10,DP10A,TECNO DP10A
+Tecno,H5S,up09_tecno_h5s,TECNO H5S
+Tecno,H7S,qp16_tecno_h7s,H7S
+Tecno,Hot 4 Pro,Infinix-X5511-13M,Infinix HOT 4 Pro
+Tecno,J5,TECNO-J5,TECNO-J5
+Tecno,J7,TECNO-J7,TECNO-J7
+Tecno,J8,TECNO-J8,TECNO-J8
+Tecno,L5,TECNO-L5,TECNO-L5
+Tecno,L8,TECNO-L8,TECNO-L8
+Tecno,L8 Lite,L8Lite,TECNO L8 Lite
+Tecno,L8 Plus,TECNO-L8,TECNO-L8Plus
+Tecno,L8Plus,TECNO-L8,TECNO-L8Plus
+Tecno,L9,TECNO-L9,TECNO L9
+Tecno,L9Plus,TECNO-L9Plus,TECNO L9 Plus
+Tecno,M3,up11_tecno_m3s,TECNO M3S
+Tecno,M6S,g335_b1,TECNO-M6S
+Tecno,N2,TECNO_N2S,TECNO-N2
+Tecno,N2S,TECNO_N2S,TECNO-N2S
+Tecno,N5S,N5S,TECNO N5S
+Tecno,N6,TECNO-N6,TECNO-N6
+Tecno,N6S,TECNO-N6S,TECNO-N6S
+Tecno,N8,TECNO-N8,TECNO N8
+Tecno,N8,TECNO-N8,TECNO-N8
+Tecno,N8R,N8R,TECNO-N8R
+Tecno,N8S,TECNO-N8S,TECNO-N8S
+Tecno,N9,N9,TECNO-N9
+Tecno,N9S,N9S,TECNO-N9S
+Tecno,P5,up08_tecno_p5s,TECNO P5S
+Tecno,P702AS,TECNO-P702,TECNO P702AS
+Tecno,PHANTOM-Z-mini,PTM-Z-mini,PTM-Z-mini
+Tecno,PHANTOM5,TECNO-PHANTOM5,TECNO-PHANTOM5
+Tecno,POWERMAX 1,TECNO-LA6,TECNO LA6
+Tecno,Phantom6,Phantom6,Phantom6
+Tecno,Phantom6 plus,Phantom6-Plus,Phantom6-Plus
+Tecno,Phantom6S,Phantom6,Phantom6S
+Tecno,Phantom8,TECNO-AX8,TECNO AX8
+Tecno,PhonePad 3,TECNO-PP7FPro,TECNO PhonePad 3
+Tecno,PhonePad 7 II,PP7E-DLA1,TECNO PP7E-DLA1
+Tecno,PhonePad 7 II,PP7E-DLA1,TECNO PP7E-SLA1
+Tecno,R6,TECNO-R6,TECNO R6
+Tecno,R6,TECNO-R6,TECNO R6S
+Tecno,S1,TECNO-S1,TECNO S1
+Tecno,S1,TECNO-S1,TECNO S1M
+Tecno,S1 Pro,TECNO-S1-Pro,TECNO S1 Pro
+Tecno,S1 Pro,TECNO-S1-Pro,TECNO S1E Pro
+Tecno,S1E Pro,TECNO-S1-Pro,TECNO S1E Pro
+Tecno,S6S,TECNO-S6S,TECNO S6S
+Tecno,SPARK,TECNO-K7,TECNO K7
+Tecno,SPARK CM,TECNO-KA9,TECNO KA9
+Tecno,SPARK Plus,TECNO-K9,TECNO K9
+Tecno,SPARK Pro,TECNO-K8,TECNO K8
+Tecno,TECNO AX8,TECNO-AX8,TECNO AX8
+Tecno,TECNO CX Air,TECNO-CX-Air,TECNO CX Air
+Tecno,TECNO K7,TECNO-K7,TECNO K7
+Tecno,TECNO K9,TECNO-K9,TECNO K9
+Tecno,TECNO P904,TECNO-P904,TECNO P904
+Tecno,TECNO R6,TECNO-R6,TECNO R6
+Tecno,TECNO R6S,TECNO-R6,TECNO R6S
+Tecno,TECNO S1 Lite,TECNO-S1Lite,TECNO S1 Lite
+Tecno,TECNO S6S,TECNO-S6S,TECNO S6S
+Tecno,TECNO W5,TECNO-W5,TECNO-W5
+Tecno,TECNO WX4 Pro S,TECNO-WX4-Pro,TECNO WX4 Pro S
+Tecno,TECNO i3,TECNO-i3,TECNO i3
+Tecno,TECNO-Y2,TECNO-Y2,TECNO-Y2
+Tecno,TECNO-Y2,TECNO-Y2,TECNO-Y3+
+Tecno,Techno L6,TECNO-L6,TECNO-L6
+Tecno,W1,TECNO_W1,TECNO W1
+Tecno,W2,TECNO_W2,TECNO W2
+Tecno,W3,TECNO-W3,TECNO-W3
+Tecno,W3 Pro,TECNO-W3Pro,TECNO W3 Pro
+Tecno,W3LTE,TECNO-W3LTE,TECNO-W3LTE
+Tecno,W4,TECNO_W4,TECNO_W4
+Tecno,W5,TECNO-W5,TECNO-W5
+Tecno,W5 Lite,W5Lite,TECNO W5 Lite
+Tecno,WX3,TECNO-WX3,TECNO WX3
+Tecno,WX3 LTE,TECNO-WX3LTE,TECNO WX3LTE
+Tecno,WX3F LTE,TECNO-WX3FLTE,TECNO WX3F LTE
+Tecno,WX3LTE,TECNO-WX3LTE,TECNO WX3LTE
+Tecno,WX3P,TECNO-WX3P,TECNO WX3P
+Tecno,WX4,TECNO-WX4,TECNO WX4
+Tecno,WX4 Pro,TECNO-WX4-Pro,TECNO WX4 Pro
+Tecno,WX4 Pro S,TECNO-WX4-Pro,TECNO WX4 Pro S
+Tecno,Y3,TECNO-Y3,TECNO-Y3
+Tecno,Y3+,TECNO-Y2,TECNO-Y2
+Tecno,Y3+,TECNO-Y2,TECNO-Y3+
+Tecno,Y3S,TECNO-Y3S,TECNO-Y3S
+Tecno,Y4,TECNO-Y4,TECNO-Y4
+Tecno,Y5,TECNO-Y5,TECNO-Y5
+Tecno,Y6,TECNO-Y6,TECNO-Y6
+Tecno,i3,TECNO-i3,TECNO i3
+Tecno,i3 Pro,TECNO-i3-Pro,TECNO i3 Pro
+Tecno,i3-Pro,TECNO-i3-Pro,TECNO i3 Pro
+Tecno,i5,TECNO-i5,TECNO i5
+Tecno,i5-Pro,TECNO-i5-Pro,TECNO i5 Pro
+Tecno,i7,TECNO-i7,TECNO i7
+Teknosa,Preo P2,Preo_P2,Preo_P2
+Tekwind,A10A,A10A,A10A
+Tekwind,TC97RA1,TC97RA1_1,TC97RA1
+Telcel,i50F,i50F,i50F
+Tele2,Maxi,Tele2_Maxi,Tele2_Maxi
+Tele2,Maxi 1.1,TELE2_Maxi_1_1,TELE2_Maxi_1_1
+Tele2,Maxi_Plus,Tele2_Maxi_Plus,Tele2_Maxi_Plus
+Tele2,Midi,Tele2_Midi,Tele2
+Tele2,Midi 1.1,Tele2_Midi_1_1,Tele2_Midi_1_1
+Tele2,Midi LTE,Tele2_Midi_LTE,Tele2_Midi_LTE
+Tele2,Mini,Tele2_Mini,Tele2_Mini
+Tele2,Mini 1.1,Tele2_Mini_1_1,Tele2_Mini_1.1
+Tele2,Mini 1.1,Tele2_Mini_1_1,Tele2_Mini_1_1
+Tele2,Tele 2 Maxi LTE,Tele2_Maxi_LTE,Tele2_Maxi_LTE
+Tele2,Tele2_Midi_2_0,Tele2_Midi_2_0,Tele2_Midi_2_0
+Tele2,Tele2fon V4,Tele2fon_v4,Tele2fon v4
+Tele2,Tele2fon V5,Tele2fon_v5,Tele2fon v5
+Telecable,tedi,dtiw384,Telecable ATV
+Teleepoch,,MaxBravo,PMI920
+Teleepoch,,U670C,U670C
+Teleepoch,,chaser-921,Chaser
+Teleepoch,Essentiel B SmartTab 1002,T9660R,SmartTAB 1002
+Teleepoch,U675,U675,U675
+Teleepoch,UMX U680C,U680C,U680C
+Telefunken,Enjoy TE1,TE1,TE1
+Telefunken,VP73_Telefunken,Telefunken,VP73_Telefunken
+Telenor,Infinity K,Infinity_K,Infinity_K
+Telenor,Infinity a2,b3680,Infinity_a2
+Telenor,Infinity e2,i6379,Infinity_e2
+Telenor,Infinity_a,Telenor_Infinity_a,Infinity_a
+Telenor,Infinity_e,Telenor_Infinity_e,Infinity_e
+Telenor,Infinity_i,TELENOR_Infinity_i,Infinity i
+Telenor,K530,Telenor_K530,Telenor K530
+Telenor,N940,Telenor_N940,Telenor N940
+Telenor,Smart,Telenor_Smart,Telenor_Smart
+Telenor,Smart II,SmartII,SmartII
+Telenor,Smart plus II,SmartPlusII,SmartPlusII
+Telenor,Smart4G,Telenor_Smart_4G,Telenor_Smart_4G
+Telkom,Telkom,DV8219,TVB-100
+TellyTablet,VM_MD_001,VM_MD_001,VM_MD_001
+Telma,TELMA FEEL,TELMA_FEEL,TELMA FEEL
+Telma,TITAN,Telma_Titan_4G,Telma_Titan_4G
+Telus,Pik TV Media Box,HMB2213PW22TS,HMB2213PW22TS
+Tesco,Hudl 2,HTF8A4,Hudl 2
+Tesco,Hudl HT7S3,ht7s3,Hudl HT7S3
+Tesco,Hudl HT7S3,ht7s3,hudl ht7s3
+Tesco,W032I_C3,w032i_c3,W032I_C3
+Tesco,hudl 2,HTF8A4,Hudl 2
+Tesla,Tablet_L7_1,Tablet_L7_1,Tesla L7.1
+Tesla,Tesla SP3.3 Lite,Tesla_SP3_3Lite,Tesla_SP3.3 Lite
+Tesla,Tesla Smartphone 3.3,Tesla_SP3_3,Tesla_SP3.3
+Tesla,Tesla Smartphone 6.3,Tesla_SP6_3,Tesla_SP6.3
+Tesla,Tesla Smartphone 9.1,L6195,Tesla_SP9.1
+Tesla,Tesla_SP9.1,L6195,Tesla_SP9.1
+Tetratab,TF10EA2,TF10EA2_Medical_1,CASEBOOK_3
+Thinpad,TH805,TH805,TH805
+Thomson,Delight TH201,Delight_TH201,Delight TH201
+Thomson,Friendly TH101,Friendly_TH101,Friendly_TH101
+Thomson,PRIMO7 Tablet,PRIMO7,PRIMO7
+Thomson,PRIMO8 Tablet,AMLMY8306P,PRIMO8
+Thomson,TCL  Percee TV,tcl_eu,Percee TV
+Thomson,TEO10,TEO10,SPTEO10BK16
+Thomson,TLink 455,TLINK455,TLINK455
+Time2,TIME2,TP860P,TP860B
+Timovi,Infinit Lite 2,Timovi_Infinit_Lite_2,Infinit_Lite_2
+Timovi,Infinit MX Pro,Infinit_MX_Pro,Infinit MX Pro
+Timovi,Timovi Infinit MX,Timovi_Infinit_MX,Infinit MX
+Timovi,Timovi Infinit X CAM,Timovi_Infinit_X_CAM,Infinit_X_CAM
+Timovi,Timovi_Vision_PRO,Timovi_Vision_PRO,Vision_PRO
+Timovi,VISION ULTRA,VISION_ULTRA,VISION ULTRA
+Tinhvan,TA80TA1,TA80TA1_1,TA80TA1
+Tobii DynaVox,T10+,T10plus,T10+
+Tobii DynaVox,T7,T7,T7
+Tonino Lamborghini,Antares,TL66,TL66
+Tonino Lamborghini,Antares,TL_Antares,Antares
+Tonino Lamborghini,TL99,ailsa_ii,TL99
+Tonino Lamborghini,TL99G,ailsa_ii,TL99G
+Toshiba,,WDPF-703TI,Hikari-iFrame/WDPF-703TI
+Toshiba,,tosebook01,DB50
+Toshiba,,tostab05,AT200
+Toshiba,,tostabg1,LT170
+Toshiba,A204,tos14ast10,A204
+Toshiba,A205,tos15ast20,A205
+Toshiba,AT10-A/AT15-A (Japan: AT503),tostab12BL,AT10-A
+Toshiba,AT10-A/AT15-A (Japan: AT503),tostab12BL,AT502
+Toshiba,AT10-A/AT15-A (Japan: AT503),tostab12BL,AT503
+Toshiba,AT10-A/AT15-A (Japan: AT503),tostab12BL,AT503_HEMS
+Toshiba,AT100,tostab03,AT100
+Toshiba,AT100,tostab03,Tostab03
+Toshiba,AT10LE-A/AT15LE-A/AT10PE-A/AT15PE-A  (Japan: AT703),tostab12BA,AT10LE-A
+Toshiba,AT10LE-A/AT15LE-A/AT10PE-A/AT15PE-A  (Japan: AT703),tostab12BA,AT10PE-A
+Toshiba,AT10LE-A/AT15LE-A/AT10PE-A/AT15PE-A  (Japan: AT703),tostab12BA,AT702
+Toshiba,AT10LE-A/AT15LE-A/AT10PE-A/AT15PE-A  (Japan: AT703),tostab12BA,AT703
+Toshiba,AT400,tostab12AL,AT300SE
+Toshiba,AT400,tostab12AL,AT400
+Toshiba,AT7-A,tost7t,AT374
+Toshiba,AT7-A,tost7t,AT7-A
+Toshiba,AT7-B,tos13t7gt,AT374
+Toshiba,AT7-B,tos13t7gt,AT7-B
+Toshiba,AT7-C,tos14riy20,A17
+Toshiba,AT7-C,tos14riy20,AT7-C
+Toshiba,JP:REGZA Tablet AT570  Others:TOSHIBA AT270,tostab11BS,AT270
+Toshiba,JP:REGZA Tablet AT570  Others:TOSHIBA AT270,tostab11BS,AT470
+Toshiba,JP:REGZA Tablet AT570  Others:TOSHIBA AT270,tostab11BS,AT570
+Toshiba,JPN:REGZA Tablet AT500  Other countries:TOSHIBA AT300,tostab11BA,AT300
+Toshiba,JPN:REGZA Tablet AT500  Other countries:TOSHIBA AT300,tostab11BA,AT500
+Toshiba,JPN:REGZA Tablet AT500  Other countries:TOSHIBA AT300,tostab11BA,AT500a
+Toshiba,JPN:REGZA Tablet AT830 Other countries:TOSHIBA AT330,tostab11BT,AT330
+Toshiba,JPN:REGZA Tablet AT830 Other countries:TOSHIBA AT330,tostab11BT,AT830
+Toshiba,L4300,l4300,l4300
+Toshiba,L5450,tostv14rtk1,l5400
+Toshiba,L5450,tostv14rtk1,l5450
+Toshiba,L5450/L5400,tostv14rtk1,l5400
+Toshiba,L5450/L5400,tostv14rtk1,l5450
+Toshiba,L5450/L5400,tostv14rtk2,l5400
+Toshiba,L5450/L5400,tostv14rtk2,l5450
+Toshiba,L5450C,l5450,l3453
+Toshiba,L5450C,l5450,l5450
+Toshiba,L5450ME,tostv14rtk2,l5400
+Toshiba,L5450ME,tostv14rtk2,l5450
+Toshiba,L5550/L5551/L5552,tostv15rtk2,l5550
+Toshiba,L9450,l9450,l9450
+Toshiba,Mozart,Mozart,Mozart
+Toshiba,STB10,TOSPASB,TOSPASB
+Toshiba,Thrive 7,tostab04,AT1S0
+Toshiba,tt300/tt301/tt302,Mozart,Mozart
+Toughshield,R200,R200,R200
+Toughshield,T700_TABLET,T700_TABLET,T700
+Trekstor,SurfTab ST70204-3,TREKM7100KLD,SurfTab ST70204-3
+Trekstor,SurfTab breeze 9.6 quad,SurfTab,TrekStor SurfTab breeze 9.6 quad
+Trekstor,SurfTab breeze 9.6 quad 3G,ST9641602,TrekStor SurfTab breeze 9.6 quad 3G
+Trekstor,SurfTab breeze 9.6 quad 3G,ST9643203,TrekStor SurfTab breeze 9.6 quad 3G
+Trekstor,SurfTab xintron i 7.0,st70408_4_coho,st70408_4
+Trekstor,SurfTab xintron i 7.0,st70408_4_coho,st70408_4_coho
+Trekstor,tolino tab 7,tolino7,tolino tab 7
+Trekstor,tolino tab 8,tolino8,tolino tab 8
+Trekstor,tolino tab 8.9,tolino89,tolino tab 8.9
+Trevi,Retailer Stores,KID_TAB_7_S02,KID_TAB_7_S02
+Trimble Navigation,MM50,EE773X_4G,MobileMapper50_4G
+Trimble Navigation,MM50,EE773X_4G,TDC100_4G
+Trimble Navigation,MM50,EE773X_WiFi,MobileMapper50_WiFi
+Trimble Navigation,MM50,EE773X_WiFi,TDC100_WiFi
+Trimble Navigation,PeopleNet ConnectedTablet,MS5,MS5
+Trimble Navigation,TD-520,td520,TD520
+Trimble Navigation,TDC500 Handheld,workhorse,TDC500
+Trimble Navigation,TDC500 Handheld,workhorse_wifi,TDC500
+Trimble Navigation,TDC800 Handheld,pelican,TDC800
+Trimble Navigation,TDC800 Handheld,pelican_wifi,TDC800
+Trimble Navigation,TDI 600,ulmo_pro,Rugged Tablet
+Trimble Navigation,TDI 600,ulmo_pro,TDI 600
+Trimble Navigation,Trimble ConnectedTablet,MS5,MS5
+Trio,7.85,astar-y3,TRIO-7.85
+Trio,7.85 vQ,Trio-785-vQ,Trio 7.85 vQ
+Trio,AXS 3G,Trio_AXS_3G,Trio AXS 3G
+Trio,MINI,Trio-MINI,Trio MINI
+Trio,MST711,nuclear-MST711,MST711
+Trio,Stealth G4 7,Trio-Stealth-G4-7,Trio-Stealth-G4-7
+Trio,Stealth-G4-101,Trio-Stealth-G4-101,Trio-Stealth G4 10.1
+Trio,Stealth-G4-7.85,Trio-Stealth-G4-785,Trio-Stealth-G4-7.85
+True,SMART 4G Adventure,SMART_4G_ADVENTURE,SMART 4G Adventure
+True,"SMART 4G GEN C 4.0""",SMART_4G_GEN_C_4,SMART 4G GEN C 4.0
+True,"SMART 4G GEN C 5.0""",SMART_4G_GEN_C_5,SMART 4G GEN C 5.0
+True,SMART 4G M1,SMART_4G_M1,SMART 4G M1
+True,SMART 4G M1 Plus,SMART_4G_M1_Plus,SMART 4G M1 Plus
+True,SMART 4G Octa 5.5,M636T,SMART 4G Octa 5.5
+True,SMART TAB 4G M1,SMART_TAB_4G_M1,SMART TAB 4G M1
+True,SMART_Champ_4inch,SMART_Champ_4inch,SMART Champ 4.0
+True,SMART_MAX_4.0_PLUS,P909,SMART_MAX_4.0_PLUS
+Tunisie Telecom,Star Trail by TT,startrail3_tt,StarTrail TT
+Turbonet,ADR1776,ADR1776,ADR1776
+Turbonet,TN500A1,TN500A1,TN500A1
+Turbonet,TN500A2,TN500A2,TN500A2
+Turbonet,TurboTab E1,TN800A1,TN800A1
+Turk Telekom,E4,722T,E4
+UNOWHY,QOOQ,QOOQ,QOOQ
+UNOWHY,QOOQ,QOOQ-V41,QOOQ-V41
+UNOWHY,UNOWHY,QOOQ-V50,QOOQ-V50
+UNOWHY,UNOWHY,SQOOL-V41,SQOOL-V41
+USA111,IRULU X11,iRULU-X11,iRULU X11
+USA111,IRULU X9,X9,X9
+USA111,Irulu X7,X7,X7
+USA111,iRULU V3,iRULU_V3,iRULU_V3
+USA111,iRULU V3,iRULU_V3i,iRULU_V3
+USA111,iRULU_V4,iRULU,V4
+Ubiquiti,USS,grizzlies_telefi4wm,USS
+Ubiquiti,UVP,capri_ubq_telefi5,UVP
+Ubiquiti,UVP Executive,capri_ubq_telefi7,UVP Executive
+Ubiquiti,UVP Pro,capri_ubq_telefi5p,UVP Pro
+Ubiquiti,UVP-X,grizzlies_telefi4x,UVP-X
+Ubiquiti,UVP-X,grizzlies_telefi4xp,UVP-X
+Ulefone,Armor 2,Armor_2,Armor_2
+Ulefone,MIX,t816_gq_ulefone,MIX
+Ulefone,MIX S,t815_gq_ulefone,MIX_S
+Ulefone,MIX_2,MIX_2,MIX_2
+Ulefone,Power 2,Power_2,Power_2
+Ulefone,Power 3,Power_3,Power_3
+Ulefone,S7,t662_gq_n1616_we,Ulefone S7
+Ulefone,S7,t662_gq_ulefone,Ulefone S7
+Ulefone,S8,S8,Ulefone S8
+Ulefone,S8 Pro,S8_Pro,S8_Pro
+Ulefone,S8_,S8,Ulefone S8
+Ulefone,T1,Ulefone_T1,T1
+Umax,UMAX,visionbook_P55_LTE,visionbook P55 LTE
+Umax,VisionBook P50 Plus LTE,P50Plus_LTE,VisionBook_P50Plus_LTE
+Umax,VisionBook10Q,VB_10Q_Plus,VB_10Q_Plus
+Umax,VisionBook_P55_LTE_Pro,VisionBook_P55_LTE_Pro,VisionBook P55 LTE Pro
+Umx(Ultimate Mobile Experience),U2VR,U2VR,U2VR
+Umx(Ultimate Mobile Experience),U673C,U673C,U673C
+Utopia,UH0342  UHTABLET10.1INCH,UH0342,UH0342
+V7,Zyro,zyro,V7 Zyro
+VAIO,VA-10J,VA-10J,JCI VA-10J
+VAIO,VPA051,VPA051,VPA051
+VENSTAR,VENSTAR2050,VENSTAR2050,VENSTAR2050
+VIBE Z,K910,kitonw,Lenovo K910
+VSN,V.35,up11_h1_vsn,V.35
+VT,MB300,MB300,SmartTV
+Vaxcare,VAX114,VAX114,VAX114
+Venturer,i7,RCT6773W22,i7
+VerD,E1,E1,E1
+Verizon Wireless,Ellipsis 10,QTAIR7,QTAIR7
+Verizon Wireless,Ellipsis 7,QMV7A,QMV7A
+Verizon Wireless,Ellipsis 7,QMV7A,QMV7B
+Verizon Wireless,Ellipsis 7 (QMV7A),QMV7A,QMV7A
+Verizon Wireless,Ellipsis 7 (QMV7B),QMV7A,QMV7B
+Verizon Wireless,Ellipsis 8,QTAQZ3,QTAQZ3
+Verizon Wireless,Ellipsis 8 HD,QTASUN1,QTASUN1
+Verizon Wireless,Ellipsis 8 HD,QTASUN1,QTASUN2
+Verizon Wireless,Ellipsis \xc2\xae 10 HD,QTAXIA1,QTAXIA1
+Verizon Wireless,Gizmo Tab,QTASUN2,QTASUN2
+Verizon Wireless,QTAQZ3KID,QTAQZ3KID,QTAQZ3KID
+Verizon Wireless,Wear24,dorado,Wear24
+Verizon Wireless,ZenPad Z8,P008,P008
+Vernee,M5,vernee_M5,vernee_M5
+Vernee,Thor E,Thor_E,Thor E
+Vernee,Thor Plus,Thor_Plus,Thor Plus
+Verssed,FW8977-ED,FW8977-ED,FW8977-ED
+Vertex,Impress Action,Impress_Action,Impress_Action
+Vertex,Impress Dune,Impress_Dune,Impress_Dune
+Vertex,Impress Eagle,Impress_Eagle,Impress_Eagle
+Vertex,Impress Fortune,Impress_Fortune,Impress_Fortune
+Vertex,Impress Grip,Grip,Impress_Grip
+Vertex,Impress Groove,Impress_Groove,Impress_Groove
+Vertex,Impress Lightning,Impress_Lightning,Impress_Lightning
+Vertex,Impress Lion (3G),Impress_Lion_3G,Impress_Lion_3G
+Vertex,Impress Lion (4G),Impress_Lion_4G,Impress_Lion_4G
+Vertex,Impress Lotus,Impress_Lotus,Impress_Lotus
+Vertex,Impress Luck,Impress_Luck,Impress_Luck
+Vertex,Impress Ra (4G),Impress_Ra,Impress_Ra
+Vertex,Impress Razor,Impress_Razor,Impress_Razor
+Vertex,Impress Saturn,Impress_Saturn,Impress_Saturn
+Vertex,Impress Tiger,Tiger,Tiger
+Vertex,Impress Tor,Impress_Tor,Impress_Tor
+Vertex,Impress_Lagune,Impress_Lagune,Impress_Lagune
+Vertu,Aster,alexa,Aster
+Vertu,Aster T,alexa,Aster T
+Vertu,Constellation V,gambit,Constellation V
+Vertu,Constellation X,tron,CONSTELLATION X
+Vertu,Signature Touch,odin,Signature Touch
+Vertu,Signature Touch,titan,Signature Touch
+Vertu,Signature Touch,titan,Signature Touch L
+Vertu,Ti,hermione,VERTU Ti
+Verykool,S5019,verykoolS5019,verykoolS5019
+Verykool,S5019,verykoolS5019,verykools5019
+Verykool,SL5029,verykoolSL5029,verykoolSL5029
+Verykool,SL5050,verykoolSL5050,verykoolSL5050
+Verykool,SL5200,verykoolSL5200,verykoolSL5200
+Verykool,SL5560,verykoolSL5560,verykoolSL5560
+Verykool,T7445,verykoolT7445,verykoolT7445
+Verykool,s4513,verykoolS4513,verykool Luna II S4513
+Verykool,s5007,verykoolS5007,verykoolS5007
+Verykool,s5021,verykoolS5021,verykool Wave Pro s5021
+Verykool,s5021,verykoolS5021,verykoolS5021
+Verykool,s5027,verykoolS5027,verykoolS5027
+Verykool,s5028,verykoolS5028,verykoolS5028
+Verykool,s5029,verykool_s5029,s5029
+Verykool,s5031,verykool_s5031,s5031
+Verykool,s5034,verykools5034,verykools5034
+Verykool,s5035,verykools5035,verykools5035
+Verykool,s5526,verykools5526,verykools5526
+Verykool,s5527,verykools5527,verykools5527
+Verykool,s5528,verykools5528,verykools5528
+Verykool,verykool s6005x,verykools6005X,s6005X
+Verykool,verykoolSL5565,verykoolSL5565,verykoolSL5565
+Verykool,verykools5205,verykools5205,verykools5205
+Verykool,verykools5528Jr,verykools5528Jr,verykools5528Jr
+Vestel,5000,Leo,Vestel_5000
+Vestel,5000,Leo,Vestel_5000_Dual
+Vestel,5000_2gb,Leo_2GB,Vestel_5000_2gb
+Vestel,5530,Pars,Vestel_5530
+Vestel,5530,Pars,Vestel_5530_Dual
+Vestel,Farabi,frb3g,Farabi
+Vestel,Riga,Riga,Venus E3
+Vestel,S7252,BCM7252S,S7252
+Vestel,Teos,Teos,Venus V5
+Vestel,"V TAB 7"" LITE II",V_TAB_7_LITE_II,VTAB7LITEII
+Vestel,V TAB 7\'\' LITE II,V_TAB_7_LITE_II,V_TAB_7_LITE_II
+Vestel,V TAB 7011,V_TAB_7011,V_TAB_7011
+Vestel,V TAB 7015,V_TAB_7015,V_TAB_7015
+Vestel,V TAB 7020,V_TAB_7020,V_TAB_7020
+Vestel,V TAB 7020A,V_TAB_7020A,V_TAB_7020A
+Vestel,V TAB 7025,V_TAB_7025,V_TAB_7025
+Vestel,V TAB 7810,V_TAB_7810,V_TAB_7810
+Vestel,V TAB 8010,V_TAB_8010,V_TAB_8010
+Vestel,V TAB 8029,V_TAB_8029,V TAB 8029
+Vestel,V TAB 9.7\'\' PRO,VT97PRO,VT97PRO
+Vestel,V Tab 7010,VTab7010,V Tab 7010
+Vestel,V3 5580 Dual,Orsa,V3_5580_Dual
+Vestel,VP100+,ephesus,10.1Myros
+Vestel,VP100+,ephesus,VP100+
+Vestel,VP73,wing-ibt,VP73
+Vestel,VP73,wing-ibt,VP73_Hyundai
+Vestel,VP73,wing-ibt,VP73_Myros
+Vestel,VP73,wing-ibt,VP73_Vox
+Vestel,VP73,wing-ibt,VP73_le
+Vestel,VP74,wifionly-gms,VP74
+Vestel,VP74,wifionly-gms,VP74-Celcus
+Vestel,VP74,wifionly-gms,VP74-Finlux
+Vestel,VP74,wifionly-gms,VP74-Luxor
+Vestel,VP74,wifionly-gms,VP74-Orava
+Vestel,VP74,wifionly-gms,VP74-Telefunken
+Vestel,VP74,wifionly-gms,VP74-Vox
+Vestel,VSP145M,VSP145M,VSP145M
+Vestel,VSP250g,VSP250g,VSP250g
+Vestel,VSP250s,VSP250s,VSP250s
+Vestel,VSP355g,g55,VSP355g
+Vestel,VSP355s,s55,VSP355s
+Vestel,VT10E,VT10E,VT10E
+Vestel,VT10E2,VT10E2,S TAB 10\'\' II
+Vestel,VT10E2,VT10E2,V TAB 10\'\' LITE
+Vestel,VT10E2,VT10E2,VT10E2
+Vestel,VT785P2,VT785P2,V TAB 7.85\'\' LITE
+Vestel,VT785P2,VT785P2,VT785P2-Celcus
+Vestel,VT785P2,VT785P2,VT785P2-Cleverpad
+Vestel,VT785P2,VT785P2,VT785P2-Finlux
+Vestel,VT785P2,VT785P2,VT785P2-Vestel
+Vestel,VTAB 1040,V_TAB_1040,V_TAB_1040
+Vestel,Venus E2 Plus,Ada,Venus E2 Plus
+Vestel,Venus V3 5010,DynoLight,Venus_V3_5010
+Vestel,Venus V3 5020,Arya,Venus_V3_5020
+Vestel,Venus V3 5030,Dyno,Venus_V3_5030
+Vestel,Venus V3 5040,Venus_V3_5040,Venus_V3_5040
+Vestel,Venus V3 5040,Venus_V3_5045,Venus_V3_5040_2GB
+Vestel,Venus V3 5070,Venus_V3_5070,Venus_V3_5070
+Vestel,Venus V3 5570,Venus_V3_5570,Venus_V3_5570
+Vestel,Venus V3 5580,Orsa,Venus_V3_5580
+Vestel,Venus V4,V4,Venus_V4
+Vestel,Venus Z10,Reys,Venus Z10
+Vgo Tel,OCEAN 6,VGOTEL_OCEAN_6,Ocean 6
+Vgo Tel,Ocean 9,Ocean_9,Ocean_9
+ViewSonic,,ViewPad_IR10Q,IR10Q
+ViewSonic,,ViewPad_IR8Q,IR8Q
+ViewSonic,,v350,ViewSonic-V350
+ViewSonic,,viewpad4,ViewSonic-ViewPad4
+ViewSonic,,viewpad7,ViewPad7
+ViewSonic,,viewpad7x,ViewPad7X
+ViewSonic,,viewpad7x,ViewPad7x
+ViewSonic,Q5,Q5,Viewphone Q5
+ViewSonic,VIEWSONIC,VIEWPAD_AW7M_PLUS,VIEWPAD_AW7M_PLUS
+ViewSonic,VSD221,VSD221,VSD221
+ViewSonic,VSD231,VSD231-VSA,VSD231
+ViewSonic,VSD241 Smart Display,VSD241,VSD241
+ViewSonic,VSD242,VSD242,VSD242
+ViewSonic,ViewPad I7M,VIEWPAD,VIEWPAD I7M
+ViewSonic,ViewPad IR7Q,IR7Q,IR7Q
+ViewSonic,ViewPad_M10,mid1016_ma,ViewPad_M10
+ViewSonic,ViewPadi7Q,vsi7q_1_coho,vsi7q_1
+ViewSonic,ViewPadi7Q,vsi7q_1_coho,vsi7q_1_coho
+ViewSonic,ViewPadi8Q,vsi8q_1_coho,vsi8q_1
+ViewSonic,ViewPadi8Q,vsi8q_1_coho,vsi8q_1_coho
+Visiontouch,Inspire,VisionTouchInspire,Vision Touch Inspire
+Visiontouch,Life,VisionTouchLife,VisionTouchLife
+Visual Land,Prestige Elite10QI,Elite10QI,Elite10QI
+Visual Land,Prestige Elite10QL,Elite10QL,Elite10QL
+Visual Land,Prestige Elite10QS,Elite10QS,Elite10QS
+Visual Land,Prestige Elite11Q,Elite11Q,Elite11Q
+Visual Land,Prestige Elite13Q,Elite13Q,Elite13Q
+Visual Land,Prestige Elite7QL,Elite7QL,Elite7QL
+Visual Land,Prestige Elite7QS,Elite7QS,Elite7QS
+Visual Land,Prestige Elite8QI,Elite8QI,Elite8QI
+Visual Land,Prestige Elite8QL,Elite8QL,Elite8QL
+Visual Land,Prestige Elite9QL,Elite9QL,Elite9QL
+Visual Land,Prestige Prime10ES,Prime10ES,Prime10ES
+Visual Land,Prestige Prime10SE,Prime10SE,Prime10SE
+Visual Land,Prestige Prime11E,Prime11E,Prime11E
+Vitsmo,Zero Spin,Zero_Spin,Zero_Spin
+Vivo,1601,1601,vivo 1601
+Vivo,1601,1601,vivo 1713
+Vivo,1609,1609,vivo 1609
+Vivo,PD1304DL,PD1304DL,vivo Y13iL
+Vivo,PD1419V,PD1419V,vivo Y923
+Vivo,PD1612,PD1612,vivo PD1612
+Vivo,PD1612,PD1612,vivo Y67
+Vivo,V1,V1,vivo V1
+Vivo,V1Max,Y37,vivo Y37
+Vivo,V3,PD1524,vivo V3
+Vivo,V3,V3,vivo V3
+Vivo,V3Lite,V3Lite,vivo V3Lite
+Vivo,V3M A,PD1524B,vivo PD1524B
+Vivo,V3Max,V3Max,vivo V3Max
+Vivo,V3Max + A,PD1523B,vivo V3Max+ A
+Vivo,V3Max A,PD1523,vivo PD1523A
+Vivo,V5Plus,V5Plus,vivo V5Plus
+Vivo,X5,X5,vivo X5
+Vivo,X5M,PD1401CL,vivo X5M
+Vivo,X5Max,X5Max,vivo X5Max
+Vivo,X5Max S,bbk6752_lwt_kk,vivo X5Max S
+Vivo,X5MaxV,msm8916_32,vivo X5MaxV
+Vivo,X5Pro,X5Pro,vivo X5Pro
+Vivo,X5Pro D,bbk6752_lwt_l,vivo X5Pro D
+Vivo,X5Pro V,PD1421V,vivo X5Pro V
+Vivo,X6A,PD1415A,vivo PD1415A
+Vivo,X6D,PD1415D,vivo X6D
+Vivo,X6Plus A,PD1515A,vivo PD1515A
+Vivo,X6Plus D,PD1501D,vivo PD1501D
+Vivo,X6S A,PD1415BA,vivo X6S A
+Vivo,X6SPlusA,PD1515BA,vivo PD1515BA
+Vivo,X7,PD1602,vivo X7
+Vivo,X7Plus,PD1603,vivo X7Plus
+Vivo,X9,PD1616,vivo X9
+Vivo,X9i,PD1624,vivo X9i
+Vivo,Xplay5A,PD1522A,vivo PD1522A
+Vivo,Xplay5A,PD1522A,vivo Xplay5A
+Vivo,Xplay6,PD1610,vivo Xplay6
+Vivo,Y11,Y11,vivo Y11
+Vivo,Y15,Y15,vivo Y15
+Vivo,Y15S,Y15S,vivo Y15S
+Vivo,Y21,Y21,vivo Y21
+Vivo,Y21L,Y21L,vivo Y21L
+Vivo,Y22,Y22,vivo Y22
+Vivo,Y27,Y27,vivo Y27
+Vivo,Y28,Y28,vivo Y28
+Vivo,Y31,PD1505,vivo Y31
+Vivo,Y31,Y31,vivo Y31
+Vivo,Y31L,Y31L,vivo Y31L
+Vivo,Y31i,Y31i,vivo 1707
+Vivo,Y31i,Y31i,vivo Y31
+Vivo,Y31i,Y31i,vivo Y31i
+Vivo,Y33,bbk6735_65c_l,vivo Y33
+Vivo,Y35,PD1502L,vivo Y35
+Vivo,Y35A,PD1502A,vivo Y35A
+Vivo,Y51,Y51,vivo Y51
+Vivo,Y51A,PD1510,vivo Y51A
+Vivo,Y53,1606,vivo 1606
+Vivo,Y53L,PD1628,vivo PD1628
+Vivo,Y55,1603,vivo 1603
+Vivo,Y55A,PD1613,vivo Y55
+Vivo,Y55s,1610,vivo 1610
+Vivo,Y66,PD1621,vivo Y66
+Vivo,Y67,PD1612,vivo Y67
+Vivo,Y79A,PD1708,vivo PD1708
+Vivo,Y79A,PD1708,vivo Y79A
+Vivo,Y937,PD1503,vivo Y937
+Vivo,vivo 1611,1611,vivo 1611
+Vivo,vivo 1714,1714,vivo 1714
+Vivo,vivo 1716,1716,vivo 1716
+Vivo,vivo 1718,1718,vivo 1718
+Vivo,vivo 1720,PD1710F_EX,vivo 1720
+Vivo,vivo 1721,PD1709F_EX,vivo 1721
+Vivo,vivo X20,PD1709,vivo PD1709
+Vivo,vivo X20Plus,PD1710,vivo PD1710
+Vivo,vivo X9Plus,PD1619,vivo X9Plus
+Vivo,vivo X9s,PD1616B,vivo PD1616B
+Vivo,vivo X9s,PD1616B,vivo X9s
+Vivo,vivo X9s Plus,PD1635,vivo PD1635
+Vivo,vivo X9s Plus,PD1635,vivo X9s Plus
+Vivo,vivo Y65,1719,vivo 1719
+Vivo,vivo Y66i A,PD1621B,vivo Y66i A
+Vivo,vivo Y75A,PD1718,vivo Y75A
+Viwa,LIGHT ONE,VIWA_LIGHT_ONE,LIGHT ONE
+Viwa,X2,VIWA_X2,X2
+Vizio,StreamPlayer,VAP430,VAP430
+Vizio,VTAB1008,VTAB1008,VTAB1008
+Vizio,XR6M10,XR6M10,XR6M10
+Vizio,XR6P10,XR6P10,XR6P10
+Vodafone,785,Vodafone_785,Vodafone 785
+Vodafone,895,VF-895N,VF-895N
+Vodafone,Smart N8,VFD610,VFD 610
+Vodafone,Smart Tab 4,Vodafone_Smart_Tab_4,Vodafone Smart Tab 4
+Vodafone,Smart Tab N8,VFD1300,VFD 1300
+Vodafone,Smart V8,VFD710,VFD 710
+Vodafone,Smart first 7,P731V35,VFD 200
+Vodafone,Smart mini 7,VFD300,VFD 300
+Vodafone,Smart mini 7 dual,VFD301,VFD 301
+Vodafone,Smart platinum 7,VFD900,VFD 900
+Vodafone,Smart prime 7,P809V50,VFD 600
+Vodafone,Smart turbo 7,VFD500,VFD 500
+Vodafone,Smart turbo 7,VFD501,VFD 501
+Vodafone,Smart turbo 7 dual,VFD502,VFD 502
+Vodafone,Smart ultra 6,P839V55,Vodafone Smart ultra 6
+Vodafone,Smart ultra 7,VFD700,Maxis VFD700
+Vodafone,Smart ultra 7,VFD700,VFD 700
+Vodafone,Smart_Tab_3G,Vodafone_Smart_Tab_3G,Vodafone Smart Tab 3G
+Vodafone,Smart_Tab_4G,Vodafone_Smart_Tab_4G,Vodafone Smart Tab 4G
+Vodafone,Tab Prime 7,VFD1400,VFD 1400
+Vodafone,Tab Prime 7,VFD1400,VFD1400
+Vodafone,Tab mini 7,Tab7,VFD 1100
+Vodafone,VDF 600,P809V50,VFD 600
+Vodafone,VF-1296,voda_tab,Vodacom Power Tab 10
+Vodafone,VF-1296,voda_tab,Vodafone Tab grand 6
+Vodafone,VF-1397,Vodafone_Tab_speed_6,VF-1397
+Vodafone,VF-1497,Vodafone_Tab_Prime,VF-1497
+Vodafone,VF685,VF685,VF685
+Vodafone,VF695,VF695,VF695
+Vodafone,VFD 200,P731V35,VFD 200
+Vodafone,Vodacom Kicka VE,VFD100,VFD 100
+Vodafone,Vodafone Smart E8,VFD510,VFD 510
+Vodafone,Vodafone Smart E8,VFD511,VFD 511
+Vodafone,Vodafone Smart E8,VFD512,VFD 512
+Vodafone,Vodafone Smart E8,VFD513,VFD 513
+Vodafone,Vodafone Smart mini,Vodafone_875,Vodafone 875
+Vodafone,Vodafone Smart mini 7 ve,U3_3G,VFD 310
+Vodafone,Vodafone Smart mini 7 ve dual,U3_3G,VFD 311
+Volt Mobile,VOLT_SV451_Vision,VOLT_SV451_Vision,VOLT_SV451_Vision
+Vonino,Druid_L10,Druid_L10,Druid_L10
+Vonino,Epic E8,Epic_E8,Epic E8
+Vonino,Epic P7,Epic_P7,Epic_P7
+Vonino,Jax X,Jax_X,Jax X
+Vonino,Jax X A6,Jax_X,Jax X
+Vonino,Jax_S,Jax_S_A7,Jax_S_A7
+Vonino,Jax_X_TM,JAX,Jax X
+Vonino,Magnet M1_A7,Magnet_M1_A7,Magnet M1
+Vonino,Magnet_M1,Magnet_M1,Magnet M1
+Vonino,Magnet_W10,Magnet_W10,Magnet_W10
+Vonino,MusicPAD,MusicPAD,MusicPAD
+Vonino,Navo  P,Navo_P,Navo_P
+Vonino,Navo QS,Navo_QS,Navo_QS
+Vonino,Navo S,Navo_S,Navo S
+Vonino,Pluri B7,Pluri_B7,Pluri B7
+Vonino,Pluri C7,Pluri_C7,Pluri C7
+Vonino,Pluri C8,Pluri_C8,Pluri C8
+Vonino,Pluri M7,Pluri_M7,Pluri_M7
+Vonino,Pluri M7 A6,Pluri_M7,Pluri_M7
+Vonino,Pluri Q8,Pluri_Q8,Pluri_Q8
+Vonino,Pluri Q8 A6,Pluri_Q8,Pluri_Q8
+Vonino,Pluri Q8 TM,Pluri_Q8,Pluri_Q8
+Vonino,Pluri_B7_TM,Pluri_B7_TM,Pluri_B7_TM
+Vonino,Pluri_G7,Pluri_G7,Pluri G7
+Vonino,Volt S,Volt_S,Volt S
+Vonino,Volt_S,Volt_S_A7,Volt_S_A7
+Vonino,Volt_X,Volt_X,Volt_X
+Vonino,Xavy G7,Xavy_G7,Xavy G7
+Vonino,Xavy L8 A6,Xavy_L8,Xavy_L8
+Vonino,Xavy T7 A6,Xavy_T7,Xavy_T7
+Vonino,Xavy_L8,Xavy_L8,Xavy_L8
+Vonino,Xavy_T7,Xavy_T7,Xavy_T7
+Vonino,Xylo  P,Xylo_P,Xylo P
+Vonino,Xylo X A6,Xylo_X,Xylo X
+Vonino,Xylo_X_TM,Xylo,Xylo X
+Vonino,ZUN XO,ZUN_XO,ZUN XO
+Vonino,ZUN XO A6,Zun_XO,ZUN XO
+Vonino,Zun X,Zun_X,Zun X
+Vonino,Zun X A6,Zun_X,Zun X
+Vonino,Zun XS,Zun_XS,Zun XS
+Vonino,jax_S,Jax_S,Jax_S
+Vsun,MARS  Touch,MARS_TOUCH,MARS TOUCH
+Vsun,MARS Nocam,MARS_NOCAM,MARS NOCAM
+Vsun,MARS Note,MARS_NOTE,MARS NOTE
+Vsun,MERCURY Tough,MERCURY_Tough,MERCURY Tough
+Vsun,SATURN Selfie,SATURN_SELFIE,SATURN SELFIE
+Vulcan,Pulse 7,VT0701A08,VT0701A08
+Vulcan,Pulse 7S,VT0702A16,VT0702A16
+Vulcan,TA10TA2,TA10TA2_1,TA10TA2
+Vulcan,TA71CA1,TA71CA1,TA71CA1
+Vulcan,TA71CA2,TA71CA2_1,TA71CA2
+Vulcan,TEMPO S11,VS4011,VS4011
+Vulcan,TEMPO S12,VS5012,VS5012
+Vulcan,TEMPO S13,VS5513,VS5513
+Vulcan,TEMPO S16,VS5016,VS5016
+Vulcan,Tempo 5,VP5004A,VP5004A
+Vulcan,VT0702A08,VT0702A08,VT0702A08
+Vulcan,Vulcan Rhyme 10A,VT1002A16,VT1002A16
+Vulcan,Vulcan Rhyme 10J,VT1003J16,VT1003J16
+Vulcan,Vulcan Rhyme 7C,VT0703,VT0703C16
+Vulcan,Vulcan VR5533,VR5533,VR5533
+Vulcan,Vulcan VR6031,VR6031,VR6031
+Vulcan,Vulcan VR6032,VR6032,VR6032
+W.e.,WETAB700DG,WETAB700DG,WETAB700DG
+W.e.,WeTab1004B,WeTab1004B,WeTab1004B
+Wacom,Cintiq Companion Hybrid 13HD,CintiqCompanionHybrid13HD,Cintiq Companion Hybrid 13HD
+Walton,LT750,LT750,LT750
+Walton,Primo E8s,Primo_E8s,Primo E8s
+Walton,Primo F7s,Primo_F7s,Primo F7s
+Walton,Primo F8,Primo_F8,Primo F8
+Walton,Primo G8,Primo_G8,Primo G8
+Walton,Primo GF6,Primo_GF6,Primo GF6
+Walton,Primo GH5,WBW5615WA,Primo GH5
+Walton,Primo GH5 mini,Primo_GH5_mini,Primo GH5 mini
+Walton,Primo GH7,Primo_GH7,Primo GH7
+Walton,Primo GM2,Primo_GM2,Primo GM2
+Walton,Primo GM2 Plus,Primo_GM2_Plus,Primo GM2 Plus
+Walton,Primo H6+,Primo_H6_Plus,Primo H6 Plus
+Walton,Primo H7,Primo_H7,Primo H7
+Walton,Primo HM4,Primo_HM4,Primo HM4
+Walton,Primo HM4+,Primo_HM4_PLUS,Primo HM4+
+Walton,Primo N3,Primo_N3,Primo N3
+Walton,Primo NF3,Primo_NF3,Primo NF3
+Walton,Primo NH3,Primo_NH3,Primo NH3
+Walton,Primo NH3 Lite,Primo_NH3_Lite,Primo NH3 Lite
+Walton,Primo NH3i,Primo_NH3i,Primo NH3i
+Walton,Primo NX3,Primo_NX3,Primo_NX3
+Walton,Primo NX4,Primo_NX4,Primo NX4
+Walton,Primo NX4 mini,Primo_NX4_mini,Primo NX4 mini
+Walton,Primo R4,Primo_R4,Primo R4
+Walton,Primo R4 Plus,Primo_R4_Plus,Primo R4 Plus
+Walton,Primo RH3,Primo_RH3,Primo RH3
+Walton,Primo RM2 mini,WBW5616WA,Primo RM2 mini
+Walton,Primo RX5,Primo_RX5,Primo RX5
+Walton,Primo S5,Primo_S5,Primo_S5
+Walton,Primo S6,Primo_S6,Primo S6
+Walton,Primo X4,WALTON_Primo_X4,Primo X4
+Walton,Primo X4 Pro,Primo_X4_Pro,Primo X4 Pro
+Walton,Primo ZX2,GBL5805WA,Primo_ZX2
+Walton,Primo ZX2 Lite,BBL7505WA,Primo ZX2 Lite
+Walton,Primo ZX2 mini,Primo_ZX2_mini,Primo ZX2 mini
+Walton,Primo ZX3,Primo_ZX3,Primo ZX3
+Walton,Primo_RM3,Primo_RM3,Primo RM3
+We (BD),L7,L7,L7
+WeTek,Play,Play,Play
+Weimei,WEIMEI NEON2,WEIMEI_NEON2,WEIMEI_NEON2
+Welgate,WA-U420D,WA-U420D,WA-U420D
+Wenu,Kate,Wenu,Kate
+Wiko,B-KOOL,V2502AN01D,B-KOOL
+Wiko,BIRDY,BIRDY,BIRDY
+Wiko,BLOOM,s4700,BLOOM
+Wiko,Barry,s7811,BARRY
+Wiko,CINK SLIM 2,s8074,CINK SLIM 2
+Wiko,DARKFULL,s9311,DARKFULL
+Wiko,DARKFULL,s9311,Dream
+Wiko,DARKNIGHT,s9203,DARKNIGHT
+Wiko,DARKNIGHT,s9203,X-tremer
+Wiko,FEVER,L5460AP25E,FEVER
+Wiko,FEVER,l5460,FEVER
+Wiko,FEVER,l5460,Ridge 4G-Fever
+Wiko,FREDDY,T3903BN,FREDDY
+Wiko,FREDDY,V3903BN,FREDDY
+Wiko,GETAWAY,s8812,GETAWAY
+Wiko,GOA,s3511,GOA
+Wiko,HARRY,V3953AN25K,HARRY
+Wiko,HARRY,v3953,HARRY
+Wiko,HIGHWAY,s9320,HIGHWAY
+Wiko,HIGHWAY 4G,s9321,HIGHWAY 4G
+Wiko,HIGHWAY PURE,l9010,HIGHWAY PURE
+Wiko,HIGHWAY SIGNS,s4750,HIGHWAY SIGNS
+Wiko,HIGHWAY STAR,l5560ae,HIGHWAY STAR
+Wiko,IGGY,s7521,Cynus F4
+Wiko,IGGY,s7521,Golf
+Wiko,IGGY,s7521,IGGY
+Wiko,JERRY,V2802AN,JERRY
+Wiko,JERRY,v2806,JERRY
+Wiko,JERRY MAX,V3610AN,JERRY MAX
+Wiko,JERRY2,v2610,JERRY2
+Wiko,JIMMY,s4300ae,JIMMY
+Wiko,K-KOOL,T2800AN,K-KOOL
+Wiko,K-KOOL,V2800AN,K-KOOL
+Wiko,KENNY,V3913BN22I,KENNY
+Wiko,KENNY,v3913,KENNY
+Wiko,KITE,l4020,KITE
+Wiko,LENNY,s5201ap,LENNY
+Wiko,LENNY2,S5030AP12H,LENNY2
+Wiko,LENNY2,s5030,LENNY2
+Wiko,LENNY3,V3702AN,LENNY3
+Wiko,LENNY3 MAX,V3802AN,LENNY3 MAX
+Wiko,Lenny4,v3720,Lenny4
+Wiko,Lenny4 Plus,v3740,Lenny4 Plus
+Wiko,MACARON,l8401_international,MACARON
+Wiko,P4903JP,P4903JP,P4903JP
+Wiko,PULP,S5420,PULP
+Wiko,PULP 4G,l5421,PULP 4G
+Wiko,PULP FAB,S5260,PULP FAB
+Wiko,PULP FAB,S5260,SLIDE2
+Wiko,PULP FAB 4G,l5261,PULP FAB 4G
+Wiko,RAINBOW,s5501,RAINBOW
+Wiko,RAINBOW 4G,l5503,RAINBOW 4G
+Wiko,RAINBOW JAM,S5254AP24K,RAINBOW JAM
+Wiko,RAINBOW JAM,s5250,RAINBOW JAM
+Wiko,RAINBOW JAM,s5254,RAINBOW JAM
+Wiko,RAINBOW LITE,s5222,RAINBOW LITE
+Wiko,RAINBOW LITE 4G,L5221,RAINBOW LITE 4G
+Wiko,RAINBOW LITE 4G,L5221AE23G,RAINBOW LITE 4G
+Wiko,RAINBOW LITE 4G,L5225AC,RAINBOW LITE 4G
+Wiko,RAINBOW LITE 4G,L5227AC,RAINBOW LITE 4G
+Wiko,RAINBOW LITE 4G,L5251,RAINBOW JAM 4G
+Wiko,RAINBOW UP,s5400,RAINBOW UP
+Wiko,RAINBOW UP 4G,l5401,RAINBOW UP 4G
+Wiko,RIDGE\t\t,s5513ap,RIDGE
+Wiko,RIDGE 4G,l5510,RIDGE 4G
+Wiko,RIDGE FAB 4G,l5320,RIDGE FAB 4G
+Wiko,ROBBY,V3750AN,ROBBY
+Wiko,ROBBY,V3750AN24K,ROBBY
+Wiko,ROBBY2,V3921,ROBBY2
+Wiko,SELFY,SELFY,SELFY
+Wiko,SELFY 4G,l4801,SELFY 4G
+Wiko,SLIDE,s8321,SLIDE
+Wiko,SUGAR F7 mini,p7203,SUGAR F7 mini
+Wiko,SUGAR S9,i9031,SUGAR S9
+Wiko,SUNNY,T2504AN,SUNNY
+Wiko,SUNNY,V2502AN,SUNNY
+Wiko,SUNNY,V2504AN,SUNNY
+Wiko,SUNNY,V2504AN01D,SUNNY
+Wiko,SUNNY,V2508AN01D,SUNNY
+Wiko,SUNNY,v2508,SUNNY
+Wiko,SUNNY MAX,T2520AN,SUNNY MAX
+Wiko,SUNNY MAX,v2520,SUNNY MAX
+Wiko,SUNNY2,v2510,SUNNY2
+Wiko,SUNSET,s4011,SUNSET
+Wiko,SUNSET2,s4050ap,SUNSET2
+Wiko,Sunny2 Plus,v2600cn,Sunny2 Plus
+Wiko,TOMMY,P4901AC,TOMMY
+Wiko,TOMMY,P4903LA,TOMMY
+Wiko,TOMMY2,T3931AC,TOMMY2
+Wiko,TOMMY2,V3931AC,TOMMY2
+Wiko,TOMMY2,V3933AC,TOMMY2
+Wiko,Tommy2 Plus,v3941,Tommy2 Plus
+Wiko,U FEEL,P6601AE,U FEEL
+Wiko,U FEEL,P6609BC,U FEEL
+Wiko,U FEEL,P6609BCD,U FEEL
+Wiko,U FEEL FAB,V3991AN,SUGAR Y7 MAX
+Wiko,U FEEL FAB,V3991AN,SUGAR Y8
+Wiko,U FEEL FAB,V3991AN,U FEEL FAB
+Wiko,U FEEL GO,P4661AN,U FEEL GO
+Wiko,U FEEL LITE,P4601AN,U FEEL LITE
+Wiko,U FEEL LITE,T4601AN,U FEEL LITE
+Wiko,U FEEL PRIME,p7201,U FEEL PRIME
+Wiko,U PULSE,v3961,U PULSE
+Wiko,U PULSE LITE,v3971,U PULSE LITE
+Wiko,VIEW,v12dnlite,View
+Wiko,VIEW,v12enlite,View
+Wiko,View,v12bnlite,View
+Wiko,View Prime,v12bn,View Prime
+Wiko,View XL,v11cnlite,View XL
+Wiko,WAX,s8515,WAX
+Wiko,WIM,T9051AC,WIM
+Wiko,WIM,i9051,WIM
+Wiko,WIM Lite,T6901AC,WIM Lite
+Wiko,WIM Lite,p6901,WIM Lite
+Wileyfox,Spark,porridge,Wileyfox Spark
+Wileyfox,Spark,porridge,Wileyfox Spark +
+Wileyfox,Spark,porridgek3,Wileyfox Spark X
+Wileyfox,Spark Add-X,porridge,Wileyfox Spark
+Wileyfox,Spark X,porridgek3,Wileyfox Spark X
+Wileyfox,Spark X Add-X,porridgek3,Wileyfox Spark X
+Wileyfox,Storm,kipper,Wileyfox Storm
+Wileyfox,Swift,crackling,Wileyfox Swift
+Wileyfox,Swift 2,marmite,Swift 2
+Wileyfox,Swift 2,marmite,Swift 2 Plus
+Wileyfox,Swift 2,marmite,Swift 2 X
+Wileyfox,Swift 2,marmite,Wileyfox Swift 2 Plus
+Wileyfox,Swift2 Add-X,marmite,Swift 2 Plus
+Wink,City S,Wink_City_S,Wink_City_S
+Wink,Glory_SE,Wink_Glory_SE,Wink Glory SE
+Wink,Share SE,Wink_Share_SE,Wink_Share_SE
+Wink,World SE,Wink_World_SE,Wink World SE
+Winmax,Tiger X4,TIGER_X4,TIGER X4
+Wintec,T730,T730,Clear
+Wintec,T730,T730,T730
+Wintec,T750,T750,Clear
+Wistron,DW-21(A),DA-21,DW-21(A)
+Wistron,W1011A,w1011a,W1011A
+Wizz,DV-PTB1080,DV-PTB1080,DV-PTB1080
+Woongjin,WoongjinThinkbig,BP-1001,BP-1001
+Woxter,Woxter,Woxter_N70,Woxter_N70
+X-TIGI,V3+,X-TIGI_V3_Plus,X-TIGI_V3+
+X-TIGI,X_TIGI_A1,X_TIGI_A1,X_TIGI_A1
+X-TIGI,X_TIGI_A1Plus,X_TIGI_A1Plus,X_TIGI_A1Plus
+Xiaomi,China,braveheart,MiTV
+Xiaomi,HM 1SC,armani,HM 1AC
+Xiaomi,HM 1SC,armani,HM 1S
+Xiaomi,HM 1SC,armani,HM 1SC
+Xiaomi,HM 1SC,armani,HM 1SW
+Xiaomi,HM 1SLTETD,HM2014501,2014501
+Xiaomi,HM 1STD,HM2014011,2014011
+Xiaomi,HM 2A,lte26007,2014502
+Xiaomi,HM 2A,lte26007,HM 2A
+Xiaomi,HM 2LTE-BR,HM2014819,2014819
+Xiaomi,HM 2LTE-CMCC,HM2014813,2014813
+Xiaomi,HM 2LTE-CT,HM2014812,2014812
+Xiaomi,HM 2LTE-CU,HM2014811,2014811
+Xiaomi,HM 2LTE-IN,HM2014818,2014818
+Xiaomi,HM 2LTE-SA,HM2014817,2014817
+Xiaomi,HM NOTE 1LTETD,dior,HM NOTE 1LTE
+Xiaomi,HM NOTE 1LTETD,dior,HM NOTE 1LTETD
+Xiaomi,HM NOTE 1LTETD,dior,HM NOTE 1LTEW
+Xiaomi,HM NOTE 1S CT,gucci,HM NOTE 1S
+Xiaomi,HM NOTE 1S CT,gucci,gucci
+Xiaomi,HM NOTE 1TD,lcsh92_wet_tdd,HM NOTE 1TD
+Xiaomi,HM NOTE 1W,lcsh92_wet_jb9,HM NOTE 1W
+Xiaomi,HM Note 2,hermes,Redmi Note 2
+Xiaomi,Hong Mi,HM2013022,2013022
+Xiaomi,MI 2,aries,MI 2
+Xiaomi,MI 2,aries,MI 2S
+Xiaomi,MI 2A,taurus,MI 2A
+Xiaomi,MI 3W,cancro,MI 3W
+Xiaomi,MI 4LTE,cancro,MI 4C
+Xiaomi,MI 4LTE,cancro,MI 4LTE
+Xiaomi,MI 4LTE,cancro,MI 4W
+Xiaomi,MI 4LTE-CT,cancro,MI 4LTE
+Xiaomi,MI 4s,aqua,MI 4S
+Xiaomi,MI 5C,meri,MI 5C
+Xiaomi,MI 5C,meri,Meri
+Xiaomi,MI 5X,tiffany,MI 5X
+Xiaomi,MI 5s Plus,natrium,MI 5s Plus
+Xiaomi,MI MAX,helium,MI MAX
+Xiaomi,MI MAX,hydrogen,MI MAX
+Xiaomi,MI MAX 2,oxygen,MI MAX 2
+Xiaomi,MI NOTE LTE,virgo,MI NOTE LTE
+Xiaomi,MI NOTE Pro,leo,MI NOTE Pro
+Xiaomi,MI Note 3,jason,Mi Note 3
+Xiaomi,MI PAD,mocha,MI PAD
+Xiaomi,MI PAD 3,cappu,MI PAD 3
+Xiaomi,MI6,sagit,MI 6
+Xiaomi,MIBOXPRO,kungfupanda,MiBOX_PRO
+Xiaomi,MIPAD2,latte,MI PAD 2
+Xiaomi,MITV3S,missionimpossible,MiTV3S
+Xiaomi,MITV3S-55/60,pulpfiction,MiTV3S
+Xiaomi,MITV3S-55/60,pulpfiction,MiTV4
+Xiaomi,MIX,lithium,MIX
+Xiaomi,MIX,lithium,lithium
+Xiaomi,MIX 2,chiron,MIX 2
+Xiaomi,MIX 2,chiron,Mi MIX 2
+Xiaomi,Mi 3,pisces,MI 3
+Xiaomi,Mi 4c,libra,Mi-4c
+Xiaomi,Mi 4i,ferrari,Mi 4i
+Xiaomi,Mi 5,gemini,MI 5
+Xiaomi,Mi 5s,capricorn,MI 5s
+Xiaomi,Mi A1,tissot_sprout,MI A1
+Xiaomi,Mi A1,tissot_sprout,Mi A1
+Xiaomi,Mi Box,once,MIBOX3
+Xiaomi,Mi Note,virgo,MI NOTE LTE
+Xiaomi,Mi Note2,scorpio,Mi Note 2
+Xiaomi,MiBOX1S,casablanca,MiBOX1S
+Xiaomi,MiBOX2,dredd,MiBOX2
+Xiaomi,MiBOX3S,queenchristina,MiBOX3S
+Xiaomi,MiBOX_mini,forrestgump,MiBOX_mini
+Xiaomi,MiTV2,entrapment,MiTV2
+Xiaomi,Redmi,HM2013023,2013023
+Xiaomi,Redmi 3,ido,Redmi 3
+Xiaomi,Redmi 3,ido,ido
+Xiaomi,Redmi 3S,land,Redmi 3S
+Xiaomi,Redmi 4,prada,Redmi 4
+Xiaomi,Redmi 4 Pro,markw,Redmi 4
+Xiaomi,Redmi 4A,rolex,Redmi 4A
+Xiaomi,Redmi 4X,santoni,Redmi 4X
+Xiaomi,Redmi 4X,santoni,santoni
+Xiaomi,Redmi 5,rosy,Redmi 5
+Xiaomi,Redmi 5 Plus,vince,Redmi 5 Plus
+Xiaomi,Redmi 5 Plus,vince,Redmi Note 5
+Xiaomi,Redmi 5A,riva,Redmi 5A
+Xiaomi,Redmi Note 3,hennessy,Redmi Note 3
+Xiaomi,Redmi Note 3,kate,Redmi Note 3
+Xiaomi,Redmi Note 3,kenzo,Redmi Note 3
+Xiaomi,Redmi Note 4,mido,Redmi Note 4
+Xiaomi,Redmi Note 4,mido,Redmi Note 4X
+Xiaomi,Redmi Note 4,nikel,Redmi Note 4
+Xiaomi,Redmi Note 5A,ugg,Redmi Note 5A
+Xiaomi,Redmi Note 5A,ugg,Redmi Y1
+Xiaomi,Redmi Note 5A,ugglite,Redmi Note 5A
+Xiaomi,Redmi Pro,omega,Redmi Pro
+Xiaomi,TELEBEE,once,MIBOX3
+Xolo,Era 2X 2GB,XE2X,Era 2X
+Xolo,Era 2X 3GB,XE2X3GB,Era 2X 3GB
+Xolo,Era3,Era_3,Era 3
+Xolo,XOLO ERA 2V,Era_2V,Era 2V
+Xolo,XOLO ERA 3X,Era_3X,era3x
+Xolo,era1X,era1X,era1X
+Xplore Technologies,RangerX,iX101T1,iX101T1
+Xplore Technologies,RangerX,iX101T1_2G,iX101T1-2G
+Xplore Technologies,XSLATE_D10,XSLATE_D10,iX101B1
+Xplore Technologies,XSLATE_D10,XSLATE_D10,iX101D1
+Xplore Technologies,XSLATE_D10,XSLATE_D10,iX101D1-FIOS
+YU,YUNICORN,YUNICORN,YU5530
+YU,YUNIQUE,YU4711,YU4711
+YU,YUPHORIA,YUPHORIA,YU5010
+YU,YUPHORIA,YUPHORIA,YU5010A
+YU,YUREKA,YUREKA,YU5510
+YU,YUREKAS,YUREKAS,YU5200
+YU,Yunique 2,YU5011,YU5011
+YU,Yureka,YUREKA,AO5510
+YU,Yureka,YUREKA,YU5510
+YU,Yureka,YUREKA,YU5510A
+YU,Yureka,YUREKA,YUREKA
+YU,Yureka Black,YU5040,YU5040
+YU,Yureka Black,YU5041,YU5041
+YU,Yureka Note,YU6000,YU 6000
+Yes,Altitude 2,M651G_MY,M651G_MY
+Yes,M631Y,M631Y,M631Y
+Yes,STING,dwi765yes,STING
+Yezz,5.5M,5_5M,5.5M
+Yezz,5E,5E,5E
+Yota Devices,C9660,yotaphone,C9660
+Yota Devices,YotaPhone2,yotaphone2,YD201
+Yuho,Y2,YUHO_Y2,YUHO_Y2
+Yuho,Y2_PRO,YUHO_Y2_PRO,YUHO_Y2_PRO
+ZTE,,BUL_P726G,ZTE-RACER
+ZTE,,D930,D930
+ZTE,,Grand-S,ZTE Grand S
+ZTE,,N720,N720
+ZTE,,N720_Micromax,Micromax A60
+ZTE,,N721,N721
+ZTE,,N721,ZTE-U N721
+ZTE,,N721,ZTE_U N721
+ZTE,,N8010_CT,ZXY-ZTE_N8010
+ZTE,,N8010_CT_BL,ZXY-ZTE_N8010
+ZTE,,N8300_CT,ZXY-ZTE N8300
+ZTE,,NX501,NX501
+ZTE,,P117A11,ZTE U807
+ZTE,,P117A13,ZTE U807N
+ZTE,,P117A20qHD,ZTE U817
+ZTE,,P117A30,ZTE U935
+ZTE,,P117T21,ZTE U960E
+ZTE,,P188T10,ZTE U956
+ZTE,,P188T20,ZTE U819
+ZTE,,P253A20,ZTE V768
+ZTE,,P722G,ZTE-U X876
+ZTE,,P726CU,ZTE-U X850
+ZTE,,P726G,ZTE-LINK
+ZTE,,P726G,ZTE-RACER
+ZTE,,P726G,ZTE-WAVE
+ZTE,,P726N,soft stone
+ZTE,,P726N,soft-stone
+ZTE,,P726VV,ZTE-U X850
+ZTE,,P727A,VF945
+ZTE,,P729B,Orange Tactile internet 2
+ZTE,,P729C,ZTE-BLADE
+ZTE,,P810A10,ZTE U880s2
+ZTE,,P810A20,ZTE U887
+ZTE,,P810T01,ZTE U791
+ZTE,,P810T01,ZTE U791(OPEN)
+ZTE,,P810T02,ZTE U793
+ZTE,,P825T10,ZTE U808
+ZTE,,P825T10,ZTE U808(OPEN)
+ZTE,,QB7211,QB7211
+ZTE,,QB7211,STARTEXT II
+ZTE,,T77,T77
+ZTE,,T9,ZTE-T T9
+ZTE,,TWM_P726G,Taiwan Mobile T2
+ZTE,,U788,ZTE U788
+ZTE,,U790,ZTE U790
+ZTE,,U795,ZTE U795
+ZTE,,U805,ZTE-T U805
+ZTE,,U812,ZTE-T U812
+ZTE,,U830,ZTE-T U830
+ZTE,,U880E,ZTE U880E
+ZTE,,U880F1,ZTE U880F1
+ZTE,,U880s,ZTE U880s
+ZTE,,U885,ZTE U885
+ZTE,,U930HD,ZTE U930HD
+ZTE,,U960s,ZTE-T U960s
+ZTE,,U960s2,ZTE U960s2
+ZTE,,U960s3,ZTE U960s3
+ZTE,,V6020_Claro,V6020_Claro
+ZTE,,V66,V66
+ZTE,,V68,V68
+ZTE,,V71A,STARTAB
+ZTE,,V71A,V71B
+ZTE,,V768,ZTE V768
+ZTE,,V8100_Z55,V8100_Z55
+ZTE,,V8200_EE_UK,V8200_EE_UK
+ZTE,,V8200_OSK,V8200-Memphis-orange-Slovakia
+ZTE,,V8300_Z39,V8300_Z39
+ZTE,,V857,ZTE-U V857
+ZTE,,V875m,ZTE-U V875m
+ZTE,,X500,X500
+ZTE,,X500,X500_USA_General
+ZTE,,X500MMB,ZTE-C X500
+ZTE,,ZTE-Grand-S,ZTE Grand S
+ZTE,,ZTE-N5,ZTE N5
+ZTE,,ZTE-N807,ZTE N807
+ZTE,,ZTE-N880F,ZTE N880F
+ZTE,,ZTE-N881E,ZTE N881E
+ZTE,,ZTE-N881F,ZTE N881F
+ZTE,,ZTE-N980,ZTE N980
+ZTE,,ZTE-N988,ZTE N988
+ZTE,,ZTE-U-V889F,ZTE-U V889F
+ZTE,,ZTE-V72A,V72A
+ZTE,,ZTE-V889F,ZTE V889F
+ZTE,,ZTE-V955,ZTE V955
+ZTE,,ZTE-V956,ZTE V956
+ZTE,,ZTE-V988,ZTE Grand S
+ZTE,,ZTE-V988,ZTE V988
+ZTE,,amigo,Android Edition Starnaute
+ZTE,,arthur,N860
+ZTE,,atlas40,Acqua
+ZTE,,atlas40,BLADE III
+ZTE,,atlas40,MEDION LIFE P4012
+ZTE,,atlas40,N880E
+ZTE,,atlas40,ZTE G882
+ZTE,,atlas40,ZTE N880E
+ZTE,,atlas40,ZTE N881D
+ZTE,,atlas40,ZTE N882E
+ZTE,,atlas40,ZTE R22
+ZTE,,atlas40,ZTE T22
+ZTE,,atlas40,ZTE V880E
+ZTE,,atlas40,ZTE V889D
+ZTE,,banana,ZTE-C N780
+ZTE,,blade,MegaFon SP-A5
+ZTE,,blade,V880
+ZTE,,blade,ZTE Libra
+ZTE,,blade,ZTE-BLADE
+ZTE,,blade2,ATLAS W
+ZTE,,blade2,BLADEII
+ZTE,,blade2,Blade S
+ZTE,,blade2,San Francisco II
+ZTE,,bladeplus,008Z
+ZTE,,bladeplus,V881
+ZTE,,bladeplus,ZTE V881
+ZTE,,bladeplus,ZTE-U V881
+ZTE,,cardhu,ZTE-T T98
+ZTE,,crane-zte7,K75
+ZTE,,dana,ZTE N970
+ZTE,,deepblue,ZTE N790
+ZTE,,deepblue,ZTE N790S
+ZTE,,enterprise,ZTE U5
+ZTE,,enterprise_HK,ZTE Grand Era
+ZTE,,enterprise_U950,ZTE U950
+ZTE,,enterprise_U985,ZTE U985
+ZTE,,enterprise_V985,ZTE V985
+ZTE,,frosty,ZTE T82
+ZTE,,hct77_ics2,V865M
+ZTE,,hope,N855D
+ZTE,,hope,N855D_PERFECTUM
+ZTE,,hope,N855D_YM
+ZTE,,hope,ZTE N855
+ZTE,,hope,ZTE N855D
+ZTE,,hope,ZTE N855D+
+ZTE,,iliamna,ZTE T81
+ZTE,,joe,V871
+ZTE,,joe,Vodafone 945
+ZTE,,kiska,ZTE V9800
+ZTE,,mooncake2,MTS-SP102
+ZTE,,mooncake2,Mtag 281
+ZTE,,mooncake2,ZTE N660
+ZTE,,msm7627a,ZTE N880F
+ZTE,,msm7627a,ZTE V889F
+ZTE,,msm7627a,ZTE-U V889F
+ZTE,,msm7630_zteu960,ZTE U960D
+ZTE,,msm7630_zteu960,ZTE-T U960
+ZTE,,nice,A21plus
+ZTE,,nice,ICE
+ZTE,,nice,KIS II
+ZTE,,nice,Orange Zali
+ZTE,,nice,Turkcell Maxi Plus 5
+ZTE,,nice,V880S
+ZTE,,nice,ZTE Kis Pro
+ZTE,,okmok,ZTE V9500
+ZTE,,p173a10,ZTE-U V760
+ZTE,,r750,ZTE-C R750
+ZTE,,racer2,ARIZONA
+ZTE,,racer2,Kyivstar Shine
+ZTE,,racer2,RACERII
+ZTE,,racer2,RacerII
+ZTE,,racer2,Turkcell T11
+ZTE,,racer2,ZTE-U V859
+ZTE,,roamer,ZTE Roamer
+ZTE,,roamer,ZTE roamer
+ZTE,,roamer,ZTE-C N760
+ZTE,,roamer2,Dubai
+ZTE,,roamer2,Dublin
+ZTE,,roamer2,N788_BASHA
+ZTE,,roamer2,Orange Dublin
+ZTE,,roamer2,V788D
+ZTE,,roamer2,ZTE N788
+ZTE,,roamer2,ZTE N789
+ZTE,,roamer2,ZTE V788D
+ZTE,,roundtop,ZTE V9800
+ZTE,,sailboat,ZTE V875
+ZTE,,sean,N850
+ZTE,,skate,KPN Smart 200
+ZTE,,skate,MEDION LIFE P4310
+ZTE,,skate,Monte Carlo
+ZTE,,skate,Optimus Monte Carlo
+ZTE,,skate,Orange Monte Carlo
+ZTE,,skate,ZTE N960
+ZTE,,skate,ZTE Skate
+ZTE,,skate,ZTE V960
+ZTE,,skate,ZTE-SKATE
+ZTE,,skate,ZTE-Skate
+ZTE,,skate,ZTE-U V960
+ZTE,,skateplus,Skate4.3 H
+ZTE,,turies,Android Edition StarText
+ZTE,,turies,Vodafone Smart Chat
+ZTE,,turies,ZTE-Tureis
+ZTE,,v9plus,BASE Tab 7.1
+ZTE,,v9plus,Light Tab 2
+ZTE,,v9plus,Light Tab 2W
+ZTE,,v9plus,MegaFon V9+
+ZTE,,v9plus,TT102
+ZTE,,v9plus,Telenor Touch Pad
+ZTE,,v9plus,V9+
+ZTE,,v9plus,V9A
+ZTE,,v9plus,V9e+
+ZTE,,v9plus,ZTE V10
+ZTE,,v9plus,ZTE V9A
+ZTE,,ventana,ZTE U970
+ZTE,,ventana_U880F,ZTE U880F
+ZTE,,ventana_U930,ZTE U930
+ZTE,,warp2,N861
+ZTE,,whistler,STARADDICT II
+ZTE,,whistler,V961
+ZTE,,whistler,ZTE Grand X
+ZTE,,whistler,ZTE V970T
+ZTE,,whistler,ZTE-Mimosa X
+ZTE,,z788,ZTE U788+
+ZTE,,z795,ZTE U795+
+ZTE,,zte_v857,ZTE-U V857
+ZTE,009Z,bladeplus,009Z
+ZTE,009Z,bladeplus,ZTE V882
+ZTE,009Z,bladeplus,ZTE V886J
+ZTE,402ZT,ZTE-402ZT,402ZT
+ZTE,A1P,ailsa,A1P
+ZTE,A1R,billy,A1
+ZTE,A1R,billy,A1R
+ZTE,A2,A2,A2
+ZTE,A2015,msm8994,ZTE A2015
+ZTE,A2016,msm8994,ZTE A2016
+ZTE,A2017,ailsa_ii,ZTE A2017
+ZTE,A2017G,ailsa_ii,ZTE A2017G
+ZTE,A2017U,ailsa_ii,ZTE A2017U
+ZTE,A2018,candice,ZTE A2018
+ZTE,A880,ZTE-A880,ZTE A880
+ZTE,AV-ATB100,B800S2_V1,AV-ATB100
+ZTE,AXON 7 mini,msm8952_64,AXON 7 mini
+ZTE,AXON WATCH,rolex,AXON WATCH
+ZTE,AXON WATCH,rolex,ZTE W1010
+ZTE,Amazing A1,roamer2,Amazing A1
+ZTE,Amazing A30,P809F20,Amazing A30
+ZTE,Amazing A50,P637F02,Amazing A50
+ZTE,Amazing P6,msm8226,Amazing P6
+ZTE,Amazing X2,msm8226,Amazing X2
+ZTE,Amazing X5s,ZTE_T620,Amazing X5s
+ZTE,Amazing X6,P839F30,Amazing X6
+ZTE,Amazing X7,P839V56,Amazing X7
+ZTE,Amazing p5_Lite,V77,Amazing p5_Lite
+ZTE,Amazing_X3s,Amazing_X3s,Amazing_X3s
+ZTE,Amazing_X3s_16G,Amazing_X3s,Amazing_X3s_16G
+ZTE,Android edition by sfr STARADDICT,skate,Android edition by sfr STARADDICT
+ZTE,Andromax G46D1Z,Andromax_G46D1Z,Andromax G46D1Z
+ZTE,Avea inTouch 2,atlas40,Avea inTouch 2
+ZTE,Avea inTouch 4,msm8916_32,Avea inTouch 4
+ZTE,Avea inTouch 4,msm8916_32,ZTE Blade V220
+ZTE,B2015,msm8916_64,ZTE B2015
+ZTE,B2016,msm8916_64,ZTE B2016
+ZTE,B2017G,msm8952_64,ZTE B2017G
+ZTE,B2017G,tulip,ZTE B2017G
+ZTE,B2017G,verdandi,ZTE B2017G
+ZTE,B760E,ztemt85_bx_kk,B760E
+ZTE,B760E,ztemt85_bx_kk,B760H
+ZTE,B790,roamer2,ZTE B790
+ZTE,B860AV2,p200_2G,B860AV2
+ZTE,B860H,B860H_V1,B860H
+ZTE,B860H,B860H_V1,B860H V1.0
+ZTE,B860H,B860H_V1,B860H V1.1
+ZTE,B880,P635N30,ZTE B880
+ZTE,B880,S_P635N30,ZTE B880
+ZTE,BA510,P635T39,ZTE BA510
+ZTE,BA520,P637T10,ZTE BA520
+ZTE,BA601,ZTE_BA601,ZTE BA601
+ZTE,BA602,P637S02,ZTE BA602
+ZTE,BA602T,P637T02,ZTE BA602T
+ZTE,BA603,P809S10,ZTE BA603
+ZTE,BA610C,P635N36,ZTE BA610C
+ZTE,BA610T,P635T36,ZTE BA610T
+ZTE,BA610T,V_P635T36,ZTE BA610T
+ZTE,BA611C,P635N40,ZTE BA611C
+ZTE,BA611T,P635T40,ZTE BA611T
+ZTE,BA611T,V_P635T40,ZTE BA611T
+ZTE,BA910,P653N31,ZTE BA910
+ZTE,BA910,V_P653N31,ZTE BA910
+ZTE,BA910T,T_P653N31,ZTE BA910T
+ZTE,BASE Lutea 2,skate,BASE Lutea 2
+ZTE,BGH Joy X5,ZTE_Blade_V580,BGH Joy X5
+ZTE,BLADE,blade,ZTE-BLADE
+ZTE,BLADE A110,ZTE_BLADE_A110,BLADE A110
+ZTE,BLADE A110,ZTE_BLADE_A110,ZTE BLADE A110
+ZTE,BLADE A112,P635A60,ZTE BLADE A112
+ZTE,BLADE A310,P809A50,Blade A310
+ZTE,BLADE A310,P809A50,ZTE BLADE A310
+ZTE,BLADE A320,P809F20,BLADE A320
+ZTE,BLADE A320,P809F20,ZTE BLADE A320
+ZTE,BLADE A506,P809F52,ZTE BLADE A506
+ZTE,BLADE A510,P635A50,BLADE A510
+ZTE,BLADE A510,P635A50,Blade A510
+ZTE,BLADE A510,P635A50,ZTE BLADE A510
+ZTE,BLADE A512,P817E52,ZTE BLADE A512
+ZTE,BLADE A520,P637F10,BLADE A520
+ZTE,BLADE A520,P637F10,ZTE BLADE A520
+ZTE,BLADE A521,P809F10,BLADE A521
+ZTE,BLADE A521,P809F10,ZTE BLADE A521
+ZTE,BLADE A6,P840F13,BLADE A6
+ZTE,BLADE A601,ZTE_BLADE_A601,ZTE BLADE A601
+ZTE,BLADE A602,P637F02,BLADE A602
+ZTE,BLADE A602,P637F02,ZTE BLADE A602
+ZTE,BLADE A610,ZTE_BLADE_A610,BLADE A610
+ZTE,BLADE A610,ZTE_BLADE_A610,ZTE BLADE A610
+ZTE,BLADE A610C,P635F50,ZTE BLADE A610C
+ZTE,BLADE A612,P635F50,ZTE BLADE A612
+ZTE,BLADE A910,P635A31,BLADE A910
+ZTE,BLADE A910,P635A31,ZTE BLADE A910
+ZTE,BLADE B112,P635A60,ZTE BLADE B112
+ZTE,BLADE III,atlas40,Skate Pro
+ZTE,BLADE III,atlas40,ZTE BLADE III
+ZTE,BLADE III,atlas40,ZTE Blade III
+ZTE,BLADE III_IL,atlas40,BLADE III_IL
+ZTE,BLADE L0510,P680A20,ZTE BLADE L0510
+ZTE,BLADE L0510,P680A20,ZTE Blade L5 Plus
+ZTE,BLADE L110,ZTE_BLADE_L110,Blade L110
+ZTE,BLADE L110,ZTE_BLADE_L110,ZTE BLADE L110
+ZTE,BLADE L111,ZTE_BLADE_L110,ZTE BLADE L111
+ZTE,BLADE L5 PLUS,P680A20,ZTE BLADE L5 PLUS
+ZTE,BLADE L7,P731F10,BLADE L7
+ZTE,BLADE L7,P731F10,ZTE BLADE L7
+ZTE,BLADE V0710,ZTE_BLADE_V0710,ZTE BLADE V0710
+ZTE,BLADE V0720,ZTE_BLADE_V0720,ZTE BLADE V0720
+ZTE,BLADE V0730,ZTE_BLADE_V0730,ZTE BLADE V0730
+ZTE,BLADE V0800,ZTE_BLADE_V0800,ZTE BLADE V0800
+ZTE,BLADE V0820,ZTE_BLADE_V0820,ZTE BLADE V0820
+ZTE,BLADE V0850,ZTE_BLADE_V0850,ZTE BLADE V0850
+ZTE,BLADE V7,P653A10,BLADE V7
+ZTE,BLADE V7,P653A10,ZTE BLADE V7
+ZTE,BLADE V7 LITE,ZTE_BLADE_V0720,ZTE BLADE V0720
+ZTE,BLADE V7 LITE,ZTE_BLADE_V0720,ZTE BLADE V7 LITE
+ZTE,BLADE V7 PLUS,P653A11,ZTE BLADE V7 PLUS
+ZTE,BLADE V8,ZTE_BLADE_V0800,BLADE V8
+ZTE,BLADE V8 MINI,ZTE_BLADE_V0850,BLADE V8 MINI
+ZTE,BLADE V8 MINI,ZTE_BLADE_V0850,ZTE BLADE V8 MINI
+ZTE,BLADE V8 SE,ZTE_BLADE_V0820,BLADE V8 SE
+ZTE,BLADE V8 mini,ZTE_BLADE_V0850,BLADE V8 mini
+ZTE,BLADE V8Q,P817F01,BLADE V8Q
+ZTE,BOLTON,bolton,N9560
+ZTE,BV0701,P653N11,ZTE BV0701
+ZTE,BV0701,P653N11,ZTE V0721
+ZTE,BV0710,P655A30,ZTE BV0710
+ZTE,BV0710T,P655A30,ZTE BV0710T
+ZTE,BV0720,P650A30,ZTE BV0720
+ZTE,BV0720T,P650A30,ZTE BV0720T
+ZTE,BV0730,P650A31,ZTE BV0730
+ZTE,BV0800,P840S10,ZTE BV0800
+ZTE,BV0850,P840S01,ZTE BV0850
+ZTE,Baker,ZTE-Baker,Baker
+ZTE,Beeline E600,roamer2,Beeline E600
+ZTE,Beeline Smart 2,P172R10,Beeline Smart 2
+ZTE,Blade,blade,003Z
+ZTE,Blade,blade,Android Edition StarTrail
+ZTE,Blade,blade,BASE lutea
+ZTE,Blade,blade,BLADE_N880
+ZTE,Blade,blade,Beeline E400
+ZTE,Blade,blade,Kyivstar Spark
+ZTE,Blade,blade,MF8604
+ZTE,Blade,blade,Movistar Prime
+ZTE,Blade,blade,N880
+ZTE,Blade,blade,Netphone 701
+ZTE,Blade,blade,Optimus San Francisco
+ZTE,Blade,blade,Orange San Francisco
+ZTE,Blade,blade,Orange Tactile internet 2
+ZTE,Blade,blade,RTK V8
+ZTE,Blade,blade,San Francisco
+ZTE,Blade,blade,V8502
+ZTE,Blade,blade,WayteQ Libra
+ZTE,Blade,blade,XCD35
+ZTE,Blade,blade,ZTE Libra
+ZTE,Blade,blade,ZTE V880
+ZTE,Blade,blade,ZTE-BLADE
+ZTE,Blade,blade,ZTE-C N880S
+ZTE,Blade,blade,ZTE-LIBRA
+ZTE,Blade,blade,ZTE-Libra
+ZTE,Blade,blade,ZTE-U V880
+ZTE,Blade,blade,a5
+ZTE,Blade A210,ZTE_Blade_A210,ZTE BLADE A210
+ZTE,Blade A210,ZTE_Blade_A210,ZTE Blade A210
+ZTE,Blade A315,ZTE_Blade_A315,ZTE Blade A315
+ZTE,Blade A410,P635E40,Blade A410
+ZTE,Blade A410,P635E40,ZTE Blade A410
+ZTE,Blade A452,P635F33,NOS FIVE
+ZTE,Blade A452,P635F33,ZTE Blade A452
+ZTE,Blade A460,P809A20,A460-T
+ZTE,Blade A460,P809A20,Blade A460
+ZTE,Blade A460,P809A20,ZTE BLADE A460
+ZTE,Blade A460,P809A20,ZTE Blade A460
+ZTE,Blade A460,P809A20,ZTE T610
+ZTE,Blade A462,P809A50,ZTE Blade A462
+ZTE,Blade A465,ZTE_Blade_A465,Blade A465
+ZTE,Blade A465,ZTE_Blade_A465,ZTE Blade A465
+ZTE,Blade A470,P809A40,ZTE Blade A470
+ZTE,Blade A475,ZTE_Blade_A475,BGH JOY X2
+ZTE,Blade A475,ZTE_Blade_A475,Blade A475
+ZTE,Blade A475,ZTE_Blade_A475,ZTE Blade A475
+ZTE,Blade A475,ZTE_Blade_A475,ZTE Blade L4 Pro
+ZTE,Blade A476,ZTE_Blade_A476,BLADE E01
+ZTE,Blade A476,ZTE_Blade_A476,ZTE Blade A476
+ZTE,Blade A510,P635A50,Blade A510
+ZTE,Blade A510,ZTE_BLADE_A601,ZTE BLADE A601
+ZTE,Blade A511,ZTE_Blade_A511,Blade A511
+ZTE,Blade A511,ZTE_Blade_A511,ZTE Blade A511
+ZTE,Blade A515,ZTE_Blade_A511,ZTE Blade A515
+ZTE,Blade A570,ZTE_T617,ZTE Blade A570
+ZTE,Blade Apex,coeus,Blade Apex
+ZTE,Blade Apex,oceanus,ZTE Blade Apex
+ZTE,Blade Apex2,msm8226,Blade Apex2
+ZTE,Blade Apex2,msm8226,ZTE Blade Apex2
+ZTE,Blade Apex3,msm8916_32,ZTE Blade Apex3
+ZTE,Blade C312,P715A20,ZTE Blade C312
+ZTE,Blade C340,P172R12,ZTE Blade C340
+ZTE,Blade C340,P172R12,ZTE T220
+ZTE,Blade C340,P172R12,ZTE V812
+ZTE,Blade C370,ZTE_Blade_C370,NOS NOVU
+ZTE,Blade C370,ZTE_Blade_C370,ZTE BLADE C370
+ZTE,Blade C370,ZTE_Blade_C370,ZTE Blade C370
+ZTE,Blade D6 Lite 3G,P658A10,ZTE Blade D6 Lite 3G
+ZTE,Blade D6 Lite 4G,P635A30,ZTE Blade D6 Lite 4G
+ZTE,Blade Force,warp8,N9517
+ZTE,Blade G,ZTE-Blade-G,ZTE Blade G
+ZTE,Blade G LTE,coeus,ZTE Blade G LTE
+ZTE,Blade G LTE,oceanus,Blade G LTE
+ZTE,Blade G Lux,P172F10,BGH Joy Smart A6
+ZTE,Blade G Lux,P172F10,BGH Joy Smart A6d
+ZTE,Blade G Lux,P172F10,Blade G Lux
+ZTE,Blade G Lux,P172F10,DIGICEL DL800
+ZTE,Blade G Lux,P172F10,MEO Smart A40
+ZTE,Blade G Lux,P172F10,Orange Tado
+ZTE,Blade G Lux,P172F10,ZTE Blade G Lux
+ZTE,Blade G Lux,P172F10,ZTE Kis3 max
+ZTE,Blade G Lux,P172F10,ZTE V830W
+ZTE,Blade HN,ZTE_Blade_HN,ZTE Blade HN
+ZTE,Blade III,atlas40,Blade III
+ZTE,Blade III,atlas40,Skate Pro
+ZTE,Blade III,atlas40,ZTE Blade III
+ZTE,Blade III Pro,Blade-III-Pro,ZTE Blade III Pro
+ZTE,Blade L110,ZTE_BLADE_L110,Blade L110
+ZTE,Blade L110,ZTE_BLADE_L110,ZTE Blade L110
+ZTE,Blade L2,P182A10,BGH Joy Smart AXS
+ZTE,Blade L2,P182A10,BGH Joy Smart AXS D
+ZTE,Blade L2,P182A10,Blade L2
+ZTE,Blade L2,P182A10,MEO Smart A75
+ZTE,Blade L2,P182A10,ZTE Blade L2
+ZTE,Blade L2 Plus,ZTE_Blade_L2_PLUS,Blade L2 Plus
+ZTE,Blade L3,P182A20,Blade L3
+ZTE,Blade L3,P182A20,DIGICEL DL910
+ZTE,Blade L3,P182A20,MEO Smart A80
+ZTE,Blade L3,P182A20,X8607
+ZTE,Blade L3,P182A20,ZTE Blade L3
+ZTE,Blade L3 Apex,ZTE_Blade_L3_Apex,ZTE Blade L3 Apex
+ZTE,Blade L3 Lite,P172A50,Blade L3 Lite
+ZTE,Blade L3 Lite,P172A50,ZTE Blade L3 Lite
+ZTE,Blade L3 Plus,Blade_L3_Plus,Blade L3 Plus
+ZTE,Blade L3 Plus,ZTE_Blade_L3_Plus,ZTE Blade L3 Plus
+ZTE,Blade L315,ZTE_Blade_L315,ZTE Blade L315
+ZTE,Blade L370,ZTE_Blade_C370,ZTE Blade L370
+ZTE,Blade L5,P172A40,Blade L5
+ZTE,Blade L5,P172A40,ZTE Blade L5
+ZTE,Blade L5 Plus,P680A20,Blade L5 Plus
+ZTE,Blade L5 Plus,P680A20,ZTE Blade L5 Plus
+ZTE,Blade L6,P680A10,ZTE Blade L6
+ZTE,Blade L6,P680A10,ZTE Blade V6 Lite
+ZTE,Blade Q Lux,P632A10,BGH Joy Smart A7G
+ZTE,Blade Q Lux,P632A10,Beeline Pro
+ZTE,Blade Q Lux,P632A10,UZTE Blade Q Lux
+ZTE,Blade Q Lux,P632A10,ZTE Blade A430
+ZTE,Blade Q Lux,P632A10,ZTE Blade Q Lux
+ZTE,Blade Q Lux,P632A10,ZTE Blade Q Lux 3G
+ZTE,Blade Q Lux,P632A10,ZTE Fit 4G Smart
+ZTE,Blade Q Lux,P632A10,ZTE T311
+ZTE,Blade Q Lux,P816A12,Blade Q Lux
+ZTE,Blade Q Lux,P816A12,ZTE Blade Q Lux
+ZTE,Blade Q Mini,P172G10_UK_VIRGIN,ZTE Blade Q Mini
+ZTE,Blade Q2,P172A12,Blade Q2
+ZTE,Blade Q3,P731A30,ZTE Blade Q3
+ZTE,Blade Q3,P731A30,ZTE T230
+ZTE,Blade S,P839F30,Blade S
+ZTE,Blade S,blade2,Blade S
+ZTE,Blade S Lite,P839F30,Blade S Lite
+ZTE,Blade S6,P839F30,Blade S6
+ZTE,Blade S6,P839F30,LS-5008
+ZTE,Blade S6,P839F30,NOS SLIM
+ZTE,Blade S6 Flex,P839T60,ZTE Blade S6 Flex
+ZTE,Blade S6 Lite,P839F30,Blade S6
+ZTE,Blade S6 Lite,P839F30,Blade S6 Lite
+ZTE,Blade S6 Lite,P839F30,ZTE T912
+ZTE,Blade S6 Plus,P839F50,Blade S6 Plus
+ZTE,Blade V,ZTE-Blade-V,Vodafone Blade V
+ZTE,Blade V,ZTE-Blade-V,ZTE Blade V
+ZTE,Blade V+,P816A12,Blade V+
+ZTE,Blade V2,msm8916_32,ZTE Blade V2
+ZTE,Blade V220,msm8916_32,ZTE Blade V220
+ZTE,Blade V580,ZTE_Blade_V580,Blade V580
+ZTE,Blade V580,ZTE_Blade_V580,Turk Telekom TT175
+ZTE,Blade V580,ZTE_Blade_V580,ZTE Blade V580
+ZTE,Blade V6,P635A20,BGH Joy V6
+ZTE,Blade V6,P635A20,Blade V6
+ZTE,Blade V6,P635A20,ZTE Blade V6
+ZTE,Blade V6,P635A20,ZTE T660
+ZTE,Blade V6,P635A20,ZTE T663
+ZTE,Blade V6 Max,ZTE_BLADE_A610,Blade V6 Max
+ZTE,Blade V6 Plus,ZTE_BLADE_V0720,Blade V6 Plus
+ZTE,Blade V6 Plus,ZTE_BLADE_V0720,ZTE Blade V6 Plus
+ZTE,Blade V770,P852F52,ZTE Blade V770
+ZTE,Blade VEC,P692S20_Q82,ZTE Blade VEC
+ZTE,Blade Vec,P692S20_Q82,Blade Vec
+ZTE,Blade Vec,P692S20_Q82,ZTE Blade Vec
+ZTE,Blade Vec,P692S20_Q82,ZTE Geek 2
+ZTE,Blade Vec 4G,msm8226,ZTE Blade Vec 4G
+ZTE,Blade Vec Pro,P692S20_M92,ZTE Blade Vec Pro
+ZTE,Blade X Max,stollen,Z983
+ZTE,Bland A610,ZTE_BLADE_A610,ZTE BLADE A610
+ZTE,Bland A610,ZTE_BLADE_A610,ZTE Blade A610
+ZTE,Bolton,florist,Z986DL
+ZTE,Bouygues Telecom Bs 351,nice,Bouygues Telecom Bs 351
+ZTE,Bouygues Telecom Bs 402,P172G10,A4C
+ZTE,Bouygues Telecom Bs 402,P172G10,Amazing A4C
+ZTE,Bouygues Telecom Bs 402,P172G10,Bouygues Telecom Bs 402
+ZTE,Bouygues Telecom Bs 402,P172G10,ZTE Blade Q Mini
+ZTE,C2016,orchid,ZTE C2016
+ZTE,C2017,alice,ZTE C2017
+ZTE,C310,P172D04,L8301
+ZTE,C310,P172D04,Movitel M8410
+ZTE,C310,P172D04,ZTE Blade C310
+ZTE,C310,P172D04,ZTE C310
+ZTE,C880,P635N32,ZTE C880
+ZTE,C880A,P635B32,ZTE C880A
+ZTE,C880D,P635D32,ZTE C880D
+ZTE,C880S,P635N34,ZTE C880S
+ZTE,C880S,S_P635N34,ZTE C880S
+ZTE,C880S,T_P635N34,ZTE C880S
+ZTE,C880S,V_P635N34,ZTE C880S
+ZTE,C880U,P635V32,ZTE C880U
+ZTE,CELL C EMPIRE E8,P635F50,CELL C EMPIRE E8
+ZTE,Chapel,chapel,Z831
+ZTE,ConeXis A1,ZTE_BLADE_L110,ConeXis A1
+ZTE,ConeXis X1,P809F52,ConeXis X1
+ZTE,ConeXis X2,ZTE_BLADE_V0850,ConeXis X2
+ZTE,Cosmote Smart Share,nice,Cosmote Smart Share
+ZTE,Cosmote Xplore,Cosmote,Cosmote Xplore
+ZTE,Cosmote Xplore,Cosmote-Xplore,Cosmote Xplore
+ZTE,DL2 PLUS,P637F02,DL2 PLUS
+ZTE,DL2 PLUS,P637F02,Digicel DL2 XL
+ZTE,Dialog Q143L,frosty,Dialog Q143L
+ZTE,Extreme E8,P635A31,Extreme E8
+ZTE,FT142D,msm8226,FT142D
+ZTE,Fanfare 2,sheen,Z815
+ZTE,G601U,P172E02,ZTE G601U
+ZTE,G717C,P692N30,ZTE G717C
+ZTE,G718C,ZTE-G718C,ZTE G718C
+ZTE,G719C,ZTE-G719C,ZTE G719C
+ZTE,G720C,ZTE-G720C,ZTE G720C
+ZTE,G720T,P839T30,ZTE G720T
+ZTE,G720T,V_P839T30,ZTE G720T
+ZTE,GEEK II 4G,msm8226,ZTE GEEK II 4G
+ZTE,GEEK II Pro,ztexasp92_wet_jb9,ZTE GEEK II Pro
+ZTE,GEEK II Pro,ztexasp92_wet_jb9,ZTE M1001
+ZTE,Geek,redhookbay,ZTE Geek
+ZTE,Geek 2 LTE,msm8226,ZTE Geek 2 LTE
+ZTE,Geek 2 pro,P692S20_M92,ZTE Geek 2 pro
+ZTE,Grand Era,enterprise_RU,ZTE Grand Era
+ZTE,Grand Memo,prindle,Grand Memo
+ZTE,Grand Memo LTE,Grand-Memo,ZTE Grand Memo
+ZTE,Grand Memo LTE,Grand-Memo,ZTE Grand Memo LTE
+ZTE,Grand S Flex,iris,Grand S Flex
+ZTE,Grand S Flex,iris,ZTE Grand S Flex
+ZTE,Grand S II,P541T50,ZTE Grand S II
+ZTE,Grand S II,P541T50,ZTE S221
+ZTE,Grand S II,P897A21,ZTE Grand S II
+ZTE,Grand S II LTE,msm8974,ZTE Grand S II LTE
+ZTE,Grand X,P175A20,Grand X
+ZTE,Grand X,P175A20,Grand X(M)
+ZTE,Grand X,P175A20,ZTE Grand X Classic
+ZTE,Grand X,P175A20,ZTE V970
+ZTE,Grand X,P175A20,ZTE V970M
+ZTE,Grand X,P175A20,ZTE-U V970M
+ZTE,Grand X,P175A20,tmn smart a18
+ZTE,Grand X 2,P682F06,Amazing A7
+ZTE,Grand X 2,P682F06,ZTE Grand X 2
+ZTE,Grand X 2,P682F06,ZTE V968
+ZTE,Grand X 2,P682F06,ZTE V969
+ZTE,Grand X In,mfld_pr2,Grand X In
+ZTE,Grand X In,mfld_pr2,STARADDICT II Plus
+ZTE,Grand X In,mfld_pr2,ZTE Grand X In
+ZTE,Grand X Max 2,jerry,Z988
+ZTE,Grand X Pro,P177A20,Blade Super
+ZTE,Grand X Pro,P177A20,Grand X Pro
+ZTE,Grand X Pro,P177A20,KPN Smart 300
+ZTE,Grand X Quad Lite,P188F07,Amazing A6
+ZTE,Grand X Quad Lite,P188F07,V8602
+ZTE,Grand X Quad Lite,P188F07,ZTE Grand X Quad Lite
+ZTE,Grand X Quad Lite,P188F07,ZTE Grand X2
+ZTE,Grand X Quad Lite,P188F07,ZTE Skate 2
+ZTE,Grand X Quad Lite,P188F07,ZTE V967S
+ZTE,Grand X2 In,redhookbay,Grand X2 In
+ZTE,Grand X2 In,redhookbay,ZTE Grand X2 In
+ZTE,GrayJoy,grayjoy,N9136
+ZTE,Helios X1,P809A01,Helios X1
+ZTE,I-O DATA,B800S2_V1,AV-ATB100
+ZTE,Infinity X^2 mini,msm8226,Infinity X^2 mini
+ZTE,Jasper LTE,lemon,Z718TL
+ZTE,K81,helen,K81
+ZTE,K813,P809K50,ZTE-K813
+ZTE,K83,K83,Amazing_P8
+ZTE,K83,K83,K83
+ZTE,K85,K85,K85
+ZTE,K88,jasmine,K88
+ZTE,K92,primrose,K92
+ZTE,K97,K97,K97
+ZTE,K97,K97,ZTE K97
+ZTE,KIS,roamer2,KIS
+ZTE,KIS PLUS,roamer2,KIS PLUS
+ZTE,KPN Smart 400,msm8226,KPN Smart 400
+ZTE,Karbonn_A1,N721,Karbonn_A1
+ZTE,Kis 3,ZTE-P821E10,MEO SMART A16
+ZTE,Kis 3,ZTE-P821E10,MEO Smart A16
+ZTE,Kis 3,ZTE-P821E10,MOCHE SMART A16
+ZTE,Kis 3,ZTE-P821E10,ZTE Kis 3
+ZTE,Kis 3,ZTE-P821E10,ZTE V811
+ZTE,Kis Lite,roamer2,ZTE Kis Lite
+ZTE,Kis Pro,nice,Optimus Zali
+ZTE,Kis Pro,nice,ZTE Kis Pro
+ZTE,Kis Q,P172D02,ZTE Kis Q
+ZTE,Kis T3,roamer2,Kis T3
+ZTE,LEO M1,V883M,V883M
+ZTE,LEO M1,V883M,ZTE LEO M1
+ZTE,LEO S1,V972M,V972M
+ZTE,LEO S1,V972M,ZTE LEO S1
+ZTE,LEO S2,V982M_Z64,ZTE LEO S2
+ZTE,LEO_Q1,hct72_wet_jb3,V765M
+ZTE,LEO_Q1,hct72_wet_jb3,ZTE LEO Q1
+ZTE,LEO_Q1,hct72_wet_jb3,ZTE V765M
+ZTE,LEO_Q1,hct72_wet_jb3,ZTE_CLARO_Q1
+ZTE,LEO_Q1,hct72_wet_jb3,ZTE_LEO_Q1
+ZTE,LEO_Q1,hct72_wet_jb3,mobifone M9001
+ZTE,LS-5503,P839F50,LS-5503
+ZTE,LS-5503,P839F50,ZTE Blade S6 Plus
+ZTE,Lannister,weeper,Z863DL
+ZTE,Leopard MF800,roamer2,Leopard MF800
+ZTE,Light Tab 2,v9plus,Light Tab 2
+ZTE,M8402,roamer2,M8402
+ZTE,M901C,P692N60,ZTE M901C
+ZTE,MEDION LIFE P4310,skate,MEDION LIFE P4310
+ZTE,MEDION Smartphone LIFE E3501,roamer2,MEDION Smartphone LIFE E3501
+ZTE,MF97A,MF97A,MF97A
+ZTE,MF97B,msm8974,MF97B
+ZTE,MF97B,msm8974,MF97B_ROGERS
+ZTE,MF97B_T,msm8974,MF97B_T
+ZTE,MF97E,msm8974,MF97E
+ZTE,MF97G,msm8974,MF97G
+ZTE,MF97W,MF97W,MF97W
+ZTE,MO-01J,MO-01J,MO-01J
+ZTE,MO-01K,MO-01K,MO-01K
+ZTE,MS4A,kiska,MS4A
+ZTE,MS4A,roundtop,MS4A
+ZTE,MTC SMART Run 4G,P632T31,MTC SMART Run 4G
+ZTE,Majesty Pro LTE,stark,Z798BL
+ZTE,Momodesign MD Droid,atlas40,Momodesign MD Droid
+ZTE,Movistar Express,QB7211,Movistar Express
+ZTE,Movistar Motion,roamer2,Movistar Motion
+ZTE,N5L,prmthus,ZTE N5L
+ZTE,N5S,P189F10,ZTE N5S
+ZTE,N720,N720,N720
+ZTE,N720,N720,ZTE-U N720
+ZTE,N720,N720,ZTE_U N720
+ZTE,N762,roamer,N762
+ZTE,N765_APT,N765,N765_APT
+ZTE,N790,deepblue,N790
+ZTE,N795,deepblue,ZTE N795
+ZTE,N798,atlas40,ZTE N798
+ZTE,N798+,ZTE_N798,ZTE N798+
+ZTE,N798+,ZTE_N798P,ZTE N798+
+ZTE,N799D,ZTE-N799D,N799D
+ZTE,N799D,ZTE-N799D,ZTE N799D
+ZTE,N800,nex,N800
+ZTE,N8000_USA_Cricket,N8000,N8000_USA_Cricket
+ZTE,N8000_USA_RS,N8000,N8000_USA_RS
+ZTE,N8000_WHTE_CKT,N8000,N8000_WHTE_CKT
+ZTE,N8010_APT,N8010_APT,N8010_APT
+ZTE,N810,fluid,N810
+ZTE,N817,wellington,N817
+ZTE,N818,ZTE-N818,N818
+ZTE,N818,ZTE-N818,ZTE N818
+ZTE,N8300_Reliance,N8300_Reliance,N8300_Reliance
+ZTE,N8303,roamer2,N8303
+ZTE,N850,sean,N850
+ZTE,N850L,seanplus,N850L
+ZTE,N855D,hope,N855D
+ZTE,N860,arthur,N860
+ZTE,N860,arthur,Warp
+ZTE,N861,warp2,N861
+ZTE,N880E,atlas40,ZTE N880E
+ZTE,N880G,ZTE-N880G,ZTE N880G
+ZTE,N900,ZTE-N900,ZTE N900
+ZTE,N900D,ZTE-N900D,ZTE N900D
+ZTE,N909,ZTE-N909,ZTE N909
+ZTE,N909D,ZTE-N909D,ZTE N909D
+ZTE,N910,arthur4g,ZTE-N910
+ZTE,N9100,hayes,N9100
+ZTE,N9101,apollo,N9101
+ZTE,N9120,elden,ZTE N9120
+ZTE,N9130,speed,N9130
+ZTE,N9132,cinco,N9132
+ZTE,N9180,N9180,N9180
+ZTE,N918St,N918St,BGH Joy Smart AXS II
+ZTE,N918St,N918St,BGH Joy Smart AXS II D
+ZTE,N918St,N918St,N918St
+ZTE,N918St,N918St,ZTE N918St
+ZTE,N919,ZTE-N919,ZTE N919
+ZTE,N919D,ZTE-N919D,N919D
+ZTE,N919D,ZTE-N919D,ZTE N919D
+ZTE,N928Dt,N928Dt,ZTE N928Dt
+ZTE,N940Sc,N940Sc,N940Sc
+ZTE,N9500,gordon,N9500
+ZTE,N9510,warplte,N9510
+ZTE,N9511,hera,ZTE_N9511
+ZTE,N9515,warp4,N9515
+ZTE,N9516,eridani,N9516
+ZTE,N9518,warp6,N9518
+ZTE,N9520,stormer,N9520
+ZTE,N9521,max,N9521
+ZTE,N958St,N958St,N958St
+ZTE,N9810,quantum,N9810
+ZTE,N983,P177F03,ZTE N983
+ZTE,N9835,chovar,N9835
+ZTE,N9835,chovar,ZTE N9835
+ZTE,N986,P188F02,N986
+ZTE,N986,P188F02,ZTE N986
+ZTE,N986D,P188F10,N986+
+ZTE,N986D,P188F10,N986D
+ZTE,NE501J,NE501J,NE501J
+ZTE,NE501J,NE501J,V5
+ZTE,NE501J,NE501J,ZTE_V5
+ZTE,NOS NEVA 80,P852F52,NOS NEVA 80
+ZTE,NOS NOVU II,P680A20,NOS NOVU II
+ZTE,NOS NOVU III,P637F10,NOS NOVU III
+ZTE,NX402,NX40X,NX402
+ZTE,NX403A,NX403A,NX403A
+ZTE,NX404H,NX404H,NX404H
+ZTE,NX405H,NX405H,NX405H
+ZTE,NX406E,NX406E,NX406E
+ZTE,NX40X,NX402,NX402
+ZTE,NX40X_APT,NX40X,NX40X
+ZTE,NX40X_APT,NX40X,NX40X_APT
+ZTE,NX501,NX501,NX501
+ZTE,NX501_APT,NX501,NX501_APT
+ZTE,NX503A_Z4,NX503A_Z4,NX503A_Z4
+ZTE,NX503J,NX503J,NX503J
+ZTE,NX505J,NX505J,NX505J
+ZTE,NX506J,NX506J,NX506J
+ZTE,NX507J,NX507J,NX507H
+ZTE,NX507J,NX507J,NX507J
+ZTE,NX508J,NX508J,NX508J
+ZTE,NX510J,NX510J,NX510J
+ZTE,NX511J,NX511J,NX511J
+ZTE,NX511J_V3,NX511J_V3,NX511J_V3
+ZTE,NX512J,NX512J,NX512J
+ZTE,NX513J,NX513J,NX513J
+ZTE,NX521J,NX521J,BGH Joy Smart AXS II
+ZTE,NX521J,NX521J,NX521J
+ZTE,NX523J_V1,NX523J_V1,NX523J_V1
+ZTE,NX527J_V1,NX527J_V1,NX527J_V1
+ZTE,NX529J,NX529J,NX529J
+ZTE,NX531J,NX531J,NX531J
+ZTE,NX535J,NX535J,NX535J
+ZTE,NX541J,NX541J,NX541J
+ZTE,NX549J,NX549J,NX549J
+ZTE,NX551J,NX551J,NX551J
+ZTE,NX563J,NX563J,NX563J
+ZTE,NX569J,NX569J,NX569J
+ZTE,NX573J,NX573J,NX573J
+ZTE,NX575J,NX575J,NX575J
+ZTE,NX591J,NX591J,NX591J
+ZTE,NX597J,NX597J,NX597J
+ZTE,NX601J,NX601J,NX601J
+ZTE,NX907J,NX907J,NX907J
+ZTE,OWN FUN 5(4G),VFD511,OWN FUN 5(4G)
+ZTE,OWN One Plus,ZTE_Blade_V580,OWN One Plus
+ZTE,Optimus Barcelona,blade2,Optimus Barcelona
+ZTE,Orange Hi 4G,Orange_Hi_4G,Orange Hi 4G
+ZTE,Orange Hi 4G,msm8226,Orange Hi 4G
+ZTE,Orange Monte Carlo,skate,Orange Monte Carlo
+ZTE,Orange Novi,oceanus,Orange Novi
+ZTE,Orange Reyo,P172D10,Avea inTouch 3 Large
+ZTE,Orange Reyo,P172D10,Blade Q Maxi
+ZTE,Orange Reyo,P172D10,Orange Reyo
+ZTE,Orange Reyo,P172D10,ZTE Blade Q Maxi
+ZTE,Orange Rono,Vec4G,Orange Rono
+ZTE,Orange Rono,msm8226,Orange Rono
+ZTE,Orange Zali,nice,Orange Zali
+ZTE,Own One,P635A20,Own One
+ZTE,P_C880S,P_P635N34,ZTE P_C880S
+ZTE,Preo Teknosa P1,msm8916_32,Preo Teknosa P1
+ZTE,Q101T,P810T10,ZTE Q101T
+ZTE,Q201T,P172T24,ZTE Q201T
+ZTE,Q2S-C,P826N50,ZTE Q2S-C
+ZTE,Q2S-T,P826T50,ZTE Q2S-T
+ZTE,Q301C,APT_TW_P810N30,ZTE Q301C
+ZTE,Q301C,P810N30,ZTE Q301C
+ZTE,Q301T,P172T33,ZTE Q301T
+ZTE,Q302C,P809N20,ZTE Q302C
+ZTE,Q5-C,P816N34,ZTE Q5-C
+ZTE,Q5-T,CU_P816T32,ZTE Q5-T
+ZTE,Q5-T,P816T32,ZTE Q5-T
+ZTE,Q501T,P172T31,ZTE Q501T
+ZTE,Q501U,P172F04,ZTE Q501U
+ZTE,Q503U,P682V53,ZTE Q503U
+ZTE,Q505T,P826T20,ZTE Q505T
+ZTE,Q507T,P682T20,ZTE Q507T
+ZTE,Q508U,P816V50,ZTE Q508U
+ZTE,Q509T,P632T31,Amazing X5
+ZTE,Q509T,P632T31,MTC SMART Run 4G
+ZTE,Q509T,P632T31,ZTE Blade A450
+ZTE,Q509T,P632T31,ZTE Blade V2 Lite
+ZTE,Q509T,P632T31,ZTE Q509T
+ZTE,Q519T,ZTE_Q519T,ZTE Q519T
+ZTE,Q529C,P635N33,ZTE Q529C
+ZTE,Q529C,V_P635N33,ZTE Q529C
+ZTE,Q529E,P635T35,ZTE Q529E
+ZTE,Q529T,P635T33,ZTE Q529T
+ZTE,Q7,CMCC_P839V50,ZTE Q7
+ZTE,Q7,CU_P839V50,ZTE Q7
+ZTE,Q7,P839V50,ZTE Q7
+ZTE,Q7-C,P839N50,ZTE Q7-C
+ZTE,Q701C,ZTE-Q701C,ZTE Q701C
+ZTE,Q705U,P682V60,ZTE Q705U
+ZTE,Q801C,ZTE-Q801C,ZTE Q801C
+ZTE,Q801L,ZTE-Q801L,ZTE Q801L
+ZTE,Q801T,P181L30,ZTE Q801T
+ZTE,Q801U,P826V30,ZTE Q801U
+ZTE,Q802C,ZTE-Q802C,ZTE Q802C
+ZTE,Q802D,ZTE-Q802D,ZTE Q802D
+ZTE,Q802T,P826T30,ZTE Q802T
+ZTE,Q805T,P120T55,ZTE Q805T
+ZTE,Q806T,V_P635T30,ZTE Q806T
+ZTE,Quartz,platy,Quartz
+ZTE,Quartz,platy,ZW10
+ZTE,R83,demeter,ZTE R83
+ZTE,RACER III mini,roamer2,RACER III mini
+ZTE,Racer,mooncake,Carl
+ZTE,Racer,mooncake,MTC 916
+ZTE,Racer,mooncake,MTS-SP100
+ZTE,Racer,mooncake,Movistar Link
+ZTE,Racer,mooncake,RTK D1
+ZTE,Racer,mooncake,Racer
+ZTE,Racer,mooncake,TaiWan Mobile T2
+ZTE,Racer,mooncake,V8402
+ZTE,Racer,mooncake,Vip Droid
+ZTE,Racer,mooncake,XCD 28
+ZTE,Racer,mooncake,ZTE X850
+ZTE,Racer,mooncake,ZTE-C N600
+ZTE,Racer,mooncake,ZTE-C N600+
+ZTE,Racer,mooncake,ZTE-LINK
+ZTE,Racer,mooncake,ZTE-RACER
+ZTE,Racer,mooncake,ZTE-U V852
+ZTE,Racer,mooncake,ZTE-U X850
+ZTE,Rook from EE,P635E40,Rook from EE
+ZTE,S118,P189S10,Grand S Lite
+ZTE,S118,P189S10,ZTE S118
+ZTE,S2004,msm8974,ZTE S2004
+ZTE,S2005,msm8974,ZTE S2005
+ZTE,S2007,msm8974,ZTE S2007
+ZTE,S2010,P653S10,ZTE S2010
+ZTE,S2010,P_P653S10,ZTE S2010
+ZTE,S2010,V_P653S10,ZTE S2010
+ZTE,S2010,ZTE_S2010,ZTE S2010
+ZTE,S2014,ZTE-S2014,ZTE S2014
+ZTE,S2015,ZTE-S2015,ZTE S2015
+ZTE,S8Q,MT8123,S8Q
+ZTE,SKATE,skate,ZTE-SKATE
+ZTE,SMART Start 3,ZTE_BLADE_L110,SMART Start 3
+ZTE,STAR,msm8226,ZTE GEEK II Pro 4G
+ZTE,STAR,msm8226,ZTE S2002
+ZTE,STAR,msm8226,ZTE STAR
+ZTE,STAR,msm8226,ZTE Star 1
+ZTE,STARNAUTE II,V6600,STARNAUTE II
+ZTE,STARTRAIL 4,P172E10,Avea inTouch 3
+ZTE,STARTRAIL 4,P172E10,STARTRAIL 4
+ZTE,STARTRAIL 4,P172E10,ZTE Blade Q
+ZTE,STARXTREM,prindle,STARXTREM
+ZTE,STARXTREM 4,msm8916_32,STARXTREM 4
+ZTE,Sapphire 3G,sapphire,N818S
+ZTE,Skate,skate,ZTE Skate
+ZTE,Skate  Pro,atlas40,Skate Pro
+ZTE,SmartTab10,V11A,SmartTab10
+ZTE,SmartTab7,V71A,SmartTab7
+ZTE,SoshPhone 3,SoshPhone_3,SoshPhone 3
+ZTE,Soshphone 4G,Vec4G,Soshphone 4G
+ZTE,Soshphone 4G,msm8226,Soshphone 4G
+ZTE,Spro 2,msm8974,502ZT
+ZTE,Spro 2,msm8974,MF97B
+ZTE,Spro 2,msm8974,MF97V
+ZTE,Spro 2,msm8974,Spro 2
+ZTE,Spro 2,msm8974,Spro 2 LTE
+ZTE,Spro 2,msm8974,ZKB2A
+ZTE,Spro2,msm8974,Spro2
+ZTE,Stack,martell,Z799VL
+ZTE,Switch X1,deepblue,ZTE Switch X1
+ZTE,Switch X1,deepblue,ZTE V796
+ZTE,T-Mobile Vivacity,blade2,T-Mobile Vivacity
+ZTE,T12,P173A30T,ZTE T12
+ZTE,T221,P731A20,Blade C341
+ZTE,T221,P731A20,DIGICEL DL755
+ZTE,T221,P731A20,KIS C341
+ZTE,T221,P731A20,ZTE Blade A5
+ZTE,T221,P731A20,ZTE Blade AF5
+ZTE,T221,P731A20,ZTE Blade C341
+ZTE,T221,P731A20,ZTE Blade C342
+ZTE,T221,P731A20,ZTE T221
+ZTE,T221,P731A20,ZTE T230
+ZTE,T28,bluetick,ZTE T28
+ZTE,T28,bluetick,ZTE T28 Prepaid
+ZTE,T3,skate,T3
+ZTE,T325,ZTE_T325,ZTE T325
+ZTE,T520,P172A40,ZTE T520
+ZTE,T60,turies,ZTE T60
+ZTE,T617,ZTE_T617,ZTE T617
+ZTE,T620,ZTE_T620,ZTE T620
+ZTE,T630,P635T30,ZTE T630
+ZTE,T760,P173A10T,ZTE T760
+ZTE,T790,roamer2,ZTE T790
+ZTE,T792,ZTE-T792,ZTE B792
+ZTE,T792,ZTE-T792,ZTE T792
+ZTE,T80,msm8226,ZTE T80
+ZTE,T81,iliamna,ZTE T81
+ZTE,T82,frosty,ZTE T82
+ZTE,T83,demeter,ZTE T83
+ZTE,T84,P816A20,ZTE R84
+ZTE,T84,P816A20,ZTE T84
+ZTE,T85,P840F20,T85
+ZTE,T86,msm8226,Amazing X1
+ZTE,T86,msm8226,ZTE T86
+ZTE,T88,msm8226,ZTE T88
+ZTE,T911,P839F30,ZTE T911
+ZTE,T912,P839F30,ZTE T912
+ZTE,T920,ZTE_T920,ZTE T920
+ZTE,TQ150,QB7211,TQ150
+ZTE,TURKCELL T40,TURKCELL-T40,TURKCELL T40
+ZTE,TURKCELL T50,msm8226,TURKCELL T50
+ZTE,TURKCELL T50,msm8226,TURKCELL TURBO T50
+ZTE,TURKCELL T60,P839T60,TURKCELL T60
+ZTE,TURKCELL T60,msm8916_32,TURKCELL T60
+ZTE,TURKCELL T70,P809T70,TURKCELL T70
+ZTE,TURKCELL T80,P840F14,TURKCELL T80
+ZTE,Telenor Touch Plus,blade2,Telenor Touch Plus
+ZTE,Tempo,xray45,N9131
+ZTE,Turkcell Maxi Plus 5,nice,Turkcell Maxi Plus 5
+ZTE,U N721,N721,ZTE-U N721
+ZTE,U V760,ztenj73_gb,MD Smart
+ZTE,U V760,ztenj73_gb,Telenor Touch Mini
+ZTE,U V760,ztenj73_gb,ZTE-U V760
+ZTE,U V760,ztenj73_gb,ZTE-U V856
+ZTE,U V760,ztenj73_gb,ZTE-U V857
+ZTE,U V760,ztenj73_gb,moii E598
+ZTE,U5S,P188T51,ZTE U5S
+ZTE,U809,P172T11,ZTE U809
+ZTE,U816,P988T20,ZTE U816
+ZTE,U817,P117A20,ZTE U817
+ZTE,U818,P172T21,ZTE U818
+ZTE,U879,P172T30,ZTE U879
+ZTE,U880,U880,ZTE-T U880
+ZTE,U889,P183T30,ZTE U889
+ZTE,U9180,U9180,U9180
+ZTE,U9180,U9180,ZTE U9180
+ZTE,U968,P682T51,ZTE U968
+ZTE,U969,P682T50,ZTE U969
+ZTE,U9815,P945T20,ZTE U9815
+ZTE,U988S,pluto,ZTE U988S
+ZTE,UZTE V790,roamer2,UZTE V790
+ZTE,UZTE V817,ZTE-V956,UZTE V817
+ZTE,Uhura,noah,Z968
+ZTE,Ultym 5.2,msm8916_32,Ultym 5.2
+ZTE,V55,V55,V55
+ZTE,V5S,P189F13,ZTE Grand Memo lite
+ZTE,V5S,P189F13,ZTE V5S
+ZTE,V6500,V6500,Etisalat Smartphone
+ZTE,V6500,V6500,ZTE-V6500
+ZTE,V70,ZTE-V70,ZTE V70
+ZTE,V7073,V7073,ZTE V7073
+ZTE,V72,V72,MT7A
+ZTE,V72,V72,ZTE V72
+ZTE,V72,V72,myPad P4 Lite
+ZTE,V72C,v72c,V72C
+ZTE,V72M,eos,V72M
+ZTE,V768,V768,ZTE V768
+ZTE,V769M,V769M,V769M
+ZTE,V769M,V769M,ZTE LEO Q2
+ZTE,V769M,V769M,ZTE V769M
+ZTE,V779M,ZTEV779M,ZTE V779M
+ZTE,V790,roamer2,ZTE V790
+ZTE,V791,P175A40,V791
+ZTE,V791,P175A40,ZTE V791
+ZTE,V792C,P810D01,ZTE V792C
+ZTE,V793,P175A60,Amazing A3
+ZTE,V793,P175A60,Cellcom 4G
+ZTE,V793,P175A60,M9000
+ZTE,V793,P175A60,Telcel T20
+ZTE,V793,P175A60,ZTE KIS Flex
+ZTE,V793,P175A60,ZTE V793
+ZTE,V793,P175A60,tmn smart a6
+ZTE,V795,P172D01,BGH Joy Smart A1
+ZTE,V795,P172D01,V795(A3S)
+ZTE,V795,P172D01,ZTE B795
+ZTE,V795,P172D01,ZTE KIS II
+ZTE,V795,P172D01,ZTE KIS II PRO
+ZTE,V795,P172D01,ZTE Kis II
+ZTE,V795,P172D01,ZTE V795
+ZTE,V797,P172D03,VIETTEL V8411
+ZTE,V797,P172D03,ZTE V797
+ZTE,V8000_USA_Cricket,V8000,V8000_USA_Cricket
+ZTE,V807,P177E01,Amazing A4
+ZTE,V807,P177E01,Beeline E700
+ZTE,V807,P177E01,Leopard MF900
+ZTE,V807,P177E01,UZTE V807
+ZTE,V807,P177E01,V8501
+ZTE,V807,P177E01,ZTE BLADE C
+ZTE,V807,P177E01,ZTE V807
+ZTE,V807,P177E01,ZTE V889S
+ZTE,V808,P172E01,UZTE V808
+ZTE,V808,P172E01,ZTE V808
+ZTE,V809,P172A10,BGH Joy Smart A2
+ZTE,V809,P172A10,ZTE Blade C2
+ZTE,V809,P172A10,ZTE T809
+ZTE,V809,P172A10,ZTE V809
+ZTE,V809,P172A10,meo smart a12
+ZTE,V811,ZTE-V811,Beeline Smart2
+ZTE,V811,ZTE-V811,ZTE V811
+ZTE,V8110,V8110,V8110
+ZTE,V811C,P810E01,ZTE V811C
+ZTE,V811W,P821E10,ZTE V811
+ZTE,V811W,P821E10,ZTE V811W
+ZTE,V813W,P172B20,ZTE Blade C2 Plus
+ZTE,V813W,P172B20,ZTE V813W
+ZTE,V815W,P172R10,Amazing A4S
+ZTE,V815W,P172R10,B8405
+ZTE,V815W,P172R10,BGH Joy Smart A5C
+ZTE,V815W,P172R10,BGH Joy Smart A5d
+ZTE,V815W,P172R10,KIS II Max
+ZTE,V815W,P172R10,SMART Start
+ZTE,V815W,P172R10,UZTE GRAND V7
+ZTE,V815W,P172R10,ZTE B815
+ZTE,V815W,P172R10,ZTE B816
+ZTE,V815W,P172R10,ZTE Blade Buzz
+ZTE,V815W,P172R10,ZTE Blade C320
+ZTE,V815W,P172R10,ZTE Blade Q1
+ZTE,V815W,P172R10,ZTE Kis II Max
+ZTE,V815W,P172R10,ZTE Kis II Max Plus
+ZTE,V815W,P172R10,ZTE Kis II Max plus
+ZTE,V815W,P172R10,ZTE Maxx
+ZTE,V815W,P172R10,ZTE T815
+ZTE,V815W,P172R10,ZTE T816
+ZTE,V815W,P172R10,ZTE V815W
+ZTE,V815W,P172R10,ZTE V816W
+ZTE,V817,ZTE-V817,V817
+ZTE,V817,ZTE-V817,ZTE V817
+ZTE,V817,ZTE-V956,ZTE V817
+ZTE,V818,P172F01,ZTE Blade 2
+ZTE,V818,P172F01,ZTE V818
+ZTE,V8200plus,V8200plus,V8200plus
+ZTE,V8285,MT8382,V8285
+ZTE,V829,P172A30,BGH Joy Smart A3
+ZTE,V829,P172A30,Blade G Pro
+ZTE,V829,P172A30,V8507
+ZTE,V829,P172A30,ZTE Blade G Plus
+ZTE,V829,P172A30,ZTE Blade G Pro
+ZTE,V829,P172A30,ZTE V829
+ZTE,V831W,P731A10,Amazing A5S
+ZTE,V831W,P731A10,UZTE Blade Q Pro
+ZTE,V831W,P731A10,ZTE T320
+ZTE,V831W,P731A10,ZTE V831W
+ZTE,V8403,roamer2,V8403
+ZTE,V8514,P821E10,V8514
+ZTE,V856,zte_v856,ZTE-V856
+ZTE,V865M,hct77_jb,V865M
+ZTE,V879,P172F02,ZTE V879
+ZTE,V880E,atlas40,ZTE V880E
+ZTE,V880G,ZTE-V880G,ZTE V880G
+ZTE,V887,P177A10,ZTE Blade L
+ZTE,V887,P177A10,ZTE V887
+ZTE,V887,P177A10,tmn smart a20
+ZTE,V889D,atlas40,ZTE V889D
+ZTE,V889M,P175A10,UZTE V889M
+ZTE,V889M,P175A10,ZTE V889M
+ZTE,V891,P986E01,ZTE V891
+ZTE,V9,v9,A100
+ZTE,V9,v9,BASE Tab
+ZTE,V9,v9,BLACK 03
+ZTE,V9,v9,Beeline M2
+ZTE,V9,v9,Light
+ZTE,V9,v9,Light Tab
+ZTE,V9,v9,MTC 1055
+ZTE,V9,v9,One Pad
+ZTE,V9,v9,RTK V9
+ZTE,V9,v9,TO101
+ZTE,V9,v9,TT101
+ZTE,V9,v9,V9
+ZTE,V9,v9,V9C
+ZTE,V9,v9,V9c
+ZTE,V9,v9,V9e
+ZTE,V9,v9,myPad P2
+ZTE,V9180,V9180,V9180
+ZTE,V956,ZTE-V956,ZTE V956
+ZTE,V965,P188F03,ZTE Blade G2
+ZTE,V965,P188F03,ZTE R880H
+ZTE,V965,P188F03,ZTE V880H
+ZTE,V965,P188F03,ZTE V965
+ZTE,V969,P682F01,ZTE V969
+ZTE,V96A,V96A,V96A
+ZTE,V970,whistler,UZTE V970
+ZTE,V970,whistler,ZTE V970
+ZTE,V975,redhookbay,V975
+ZTE,V975,redhookbay,ZTE Geek
+ZTE,V975,redhookbay,ZTE V975
+ZTE,V9800,kiska,ZTE V9800
+ZTE,V9820,ZTE-V9820,ZTE V9820
+ZTE,V983,P177A30,ZTE V983
+ZTE,V987,P188F04,UZTE GRAND X Quad
+ZTE,V987,P188F04,ZTE Grand X
+ZTE,V987,P188F04,ZTE V987
+ZTE,V993W,ZTE_V993W,ZTE V993W
+ZTE,V9A,v9plus,Light Tab 2
+ZTE,V9A,v9plus,V9A
+ZTE,V9A,v9plus,ZTE V9A
+ZTE,V9A,v9plus,my Pad P3
+ZTE,V9A,v9plus,myPad P3
+ZTE,V9S,V9S,V9S
+ZTE,V9S,V9S,myPadP4
+ZTE,VERGATARIO 5,ZTE_BLADE_L110,VERGATARIO 5
+ZTE,VERGATARIO5PLUS,ZTE_BLADE_L110,VERGATARIO5PLUS
+ZTE,Vesta,proline,Z965
+ZTE,Vip Racer III,atlas40,Vip Racer III
+ZTE,Vodafone Smart Chat,turies,Vodafone Smart Chat
+ZTE,Vodafone Smart ultra 6,msm8916_32,Vodafone Smart ultra 6
+ZTE,Warp 7,beam,N9519
+ZTE,X500,X500,X500
+ZTE,X500,X500,ZTE-X500
+ZTE,X501_USA_Cricket,X501,X501_USA_Cricket
+ZTE,X501_USA_Cricket,X501,X501_USA_RS
+ZTE,X501_USA_OM,X501,X501_USA_OM
+ZTE,X9180,X9180,X9180
+ZTE,Z10,P817E52,ZTE Z10
+ZTE,Z353VL,oldman,Z353VL
+ZTE,Z557BL,msm8909,Z557BL
+ZTE,Z660G,nice,Z660G
+ZTE,Z665C,seanplus,Z665C
+ZTE,Z667,demi,Z667
+ZTE,Z667T,bonnie,Z667T
+ZTE,Z716BL,baffin,Z716BL
+ZTE,Z717VL,lavender,Z717VL
+ZTE,Z730,ada,Z730
+ZTE,Z740,metis,Z740
+ZTE,Z740G,metis,Z740G
+ZTE,Z750C,Z750C,Z750C
+ZTE,Z752C,eros,Z752C
+ZTE,Z753G,faerie,Z753G
+ZTE,Z755,iris,Z755
+ZTE,Z768G,Z768G,Z768G
+ZTE,Z777,betty,Z777
+ZTE,Z787,apus,Z787
+ZTE,Z791G,giant,Z791G
+ZTE,Z792,giant,Z792
+ZTE,Z793C,hera,Z793C
+ZTE,Z795G,ZTE-Z795G,Z795G
+ZTE,Z796C,Z796C,Z796C
+ZTE,Z797C,carol,Z797C
+ZTE,Z812,xuantan,Z812
+ZTE,Z813,xuantan,Z813
+ZTE,Z818L,sunny,Z818L
+ZTE,Z819L,sungod,Z819L
+ZTE,Z820,P675T07,Z820
+ZTE,Z826,herculis,Z826
+ZTE,Z828,achill,Z828
+ZTE,Z828,achill,Z828TL
+ZTE,Z830,gruis,Z830
+ZTE,Z832,mimir,Z832
+ZTE,Z833,camellia,Z833
+ZTE,Z835,draco,Z835
+ZTE,Z836BL,guardian,Z836BL
+ZTE,Z836F,guardian,Z836F
+ZTE,Z837VL,breaker,Z837VL
+ZTE,Z839,sweet,Z839
+ZTE,Z850,sif,Z850
+ZTE,Z861BL,benz,Z861BL
+ZTE,Z862VL,captain,Z862VL
+ZTE,Z899VL,msm8909,Z899VL
+ZTE,Z916BL,red,Z916BL
+ZTE,Z917VL,fortune,Z917VL
+ZTE,Z930L,coeus,Z930L
+ZTE,Z932L,warplte,Z932L
+ZTE,Z932L,warplte,ZTE Z932L
+ZTE,Z933,glaucus,Z933
+ZTE,Z936L,gift,Z936L
+ZTE,Z955L,leo,Z955A
+ZTE,Z955L,leo,Z955L
+ZTE,Z956,financier,Z956
+ZTE,Z957,financier,Z957
+ZTE,Z958,lol,Z958
+ZTE,Z959,abby,Z959
+ZTE,Z962BL,tom,Z962BL
+ZTE,Z963U,lily,Z963U
+ZTE,Z963VL,nancy,Z963VL
+ZTE,Z970,draconis,Z970
+ZTE,Z971,peony,Z971
+ZTE,Z980L,cygni,Z980L
+ZTE,Z981,urd,Z981
+ZTE,Z986U,cynthia,Z986U
+ZTE,Z987,cygni,Z987
+ZTE,Z990,roamer,ZTE-Z990
+ZTE,Z990G,roamer,ZTE-Z990G
+ZTE,Z992,aviva,Z992
+ZTE,Z993,aviva,Z993
+ZTE,Z995,becky,Z995
+ZTE,Z998,coeus,Z998
+ZTE,Z999,fujisan,Z999
+ZTE,ZPAD,gevjon,K90U
+ZTE,ZTE A0616,P637S15,ZTE A0616
+ZTE,ZTE A0620,P840S13,ZTE A0620
+ZTE,ZTE A0622,P817S13,ZTE A0622
+ZTE,ZTE A2018,candice,ZTE A2018
+ZTE,ZTE A520S,P809S10,ZTE A520S
+ZTE,ZTE AVID 4,calbee,Z855
+ZTE,ZTE BLADE A0620,P840F12,ZTE BLADE A0620
+ZTE,ZTE BLADE A0621,P840F13,ZTE BLADE A0621
+ZTE,ZTE BLADE A0622,P809F12,ZTE BLADE A0622
+ZTE,ZTE BLADE A320,P809F20,ZTE BLADE A320
+ZTE,ZTE BLADE A321,VFD511,ZTE BLADE A321
+ZTE,ZTE BLADE A330,P809F30,ZTE BLADE A330
+ZTE,ZTE BLADE A506,P809T70,ZTE BLADE A506
+ZTE,ZTE BLADE A520,P637F10,ZTE BLADE A520
+ZTE,ZTE BLADE A520C,P809F10,ZTE BLADE A520C
+ZTE,ZTE BLADE A521,P809F10,ZTE BLADE A521
+ZTE,ZTE BLADE A6,P840F13,ZTE BLADE A6
+ZTE,ZTE BLADE A602,P637F02,ZTE BLADE A602
+ZTE,ZTE BLADE A610,ZTE_BLADE_A610,ZTE BLADE A610
+ZTE,ZTE BLADE A612,P635F50,ZTE BLADE A612
+ZTE,ZTE BLADE A910,P635A31,ZTE BLADE A910
+ZTE,ZTE BLADE L111,ZTE_BLADE_L110,ZTE BLADE B111
+ZTE,ZTE BLADE L111,ZTE_BLADE_L110,ZTE BLADE L110
+ZTE,ZTE BLADE L111,ZTE_BLADE_L110,ZTE BLADE L111
+ZTE,ZTE BLADE L7,P731F10,ZTE BLADE L7
+ZTE,ZTE BLADE V0710,ZTE_BLADE_V0710,ZTE BLADE V0710
+ZTE,ZTE BLADE V0720,ZTE_BLADE_V0720,ZTE BLADE V0720
+ZTE,ZTE BLADE V0800,ZTE_BLADE_V0800,ZTE BLADE V0800
+ZTE,ZTE BLADE V0820,ZTE_BLADE_V0820,ZTE BLADE V0820
+ZTE,ZTE BLADE V0840,P817F01,ZTE BLADE V0840
+ZTE,ZTE BLADE V0850,ZTE_BLADE_V0850,ZTE BLADE V0850
+ZTE,ZTE BLADE V7 PLUS,P653A11,ZTE BLADE V7 PLUS
+ZTE,ZTE BLade Zmax,crocus,Z982
+ZTE,ZTE BV0870,P840V71,ZTE BV0870
+ZTE,ZTE Blade A522,P817E53,ZTE Blade A522
+ZTE,ZTE Blade L5,P172A40,ZTE Blade L5
+ZTE,ZTE Blade V770,P852F52,ZTE Blade V770
+ZTE,ZTE Blade V8 Arc,P840V80,ZTE Blade V8 Arc
+ZTE,ZTE C2017,alice,ZTE C2017
+ZTE,ZTE Fanfare 3,kelly,Z852
+ZTE,ZTE Overture 3,jeff,Z851
+ZTE,ZTE Tempo X,grayjoylite,N9137
+ZTE,ZTE V0840,P817S01,ZTE V0840
+ZTE,ZTU31,P852F52,ZTU31
+ZTE,ZXY-ZTE_N8010,N8010_YM,ZXY-ZTE_N8010
+ZTE,ZXY-ZTE_V6700,V6700,ZTE V6700
+ZTE,ZXY-ZTE_V6700,V6700,ZXY-ZTE_V6700
+ZTE,Zmax 3,dandelion,Z978
+ZTE,Zmax One,msm8909,Z719DL
+ZTE,Zmax Pro,urd,Z981
+ZTE,blade S,blade2,Blade S
+ZTE,dtac phone M1,P635A50,dtac phone M1
+ZTE,myPad P5,K78,Amazing_P5
+ZTE,myPad P5,K78,myPad P5
+ZTE,nubia Z5,NX501,nubia Z5
+ZTE,tmn smart a15,atlas40,tmn smart a15
+ZTE,tmn smart a60,kiska,tmn smart a60
+ZTE,tmn smart a7,sailboat,tmn smart a7
+Zebex,Z-2252,Z-2252,Z-2252
+Zebra,CC5000,concierge,CCHUB1
+Zebra,ET5X,ET50E,ET5X
+Zebra,ET5X,ET50T,ET5X
+Zebra,ET5X,ET55E,ET5X
+Zebra,ET5X,ET55T,ET5X
+Zebra,MC18,MC18,MC18N0
+Zebra,MC36,cardhu,MC36
+Zebra,MC40,MC40,MC40N0
+Zebra,Pollux,TC70,TC700H
+Zebra,Pollux,TC75,TC75
+Zebra,TC20,TC20RD,TC20
+Zebra,TC20,TC20RT,TC20
+Zebra,TC25,TC25FM,TC25
+Zebra,TC51,TC51,TC51
+Zebra,TC51,TC51HC,TC51
+Zebra,TC55,TC55,TC55
+Zebra,TC56,TC56,TC56
+Zebra,TC70x,TC70x,TC70x
+Zebra,TC75x,TC75x,TC75x
+Zebra,TC75xDF,TC75xDF,TC75x
+Zebra,TC8000,TC8000,TC8000
+Zebra,WT6000,WT6000,WT6000
+Zeki,TBDG1073,TBDG1073,TBDG1073
+Zeki,TBDG734,TBDG734,TBDG734
+Zeki,TBDG874 Tablet,TBDG874B,TBDG874
+Zeki,TBQC1063B,TBQC1063B,TBQC1063
+Zeki,TBQG1084,TBQG1084,TBQG1084
+Zeki,TBQG774,TBQG774,TBQG774
+Zeki,TBQG855,TBQG855,TBQG855
+Zeki,Zeki TBQG884,TBQG884,TBQG884
+Zen,ZEN ADMIRE NEO PLUS,ZEN_ADMIRE_NEO_PLUS,ADMIRE NEO+
+Zen,ZEN ADMIRE UNITY,ZEN_ADMIRE_UNITY,ADMIRE_UNITY
+Zen,Zen Admire Curve +,ZEN_ADMIRE_CURVE_PLUS,ADMIRE_CURVE+
+Zen,Zen Admire Glory+,ADMIRE_GLORY_PLUS,ADMIRE GLORY+
+Zen,Zen Admire Sense+,ZEN_ADMIRE_SENSE_PLUS,ADMIRE_SENSE+
+Zen,Zen Admire Swadesh+,ADMIRE_SWADESH_PLUS,ADMIRE SWADESH+
+Zen,Zen M72 Smart,M72_Smart,M72 Smart
+Zettaly,ZA-407,ZA-407,Zettaly Avy ZA-407
+Zilo,Zilo,Zilo,Zilo
+Ziox,Astra Blaze,Astra_Blaze,Astra Blaze
+Ziox,Astra Curve 4G,Astra_Curve_4G,Astra Curve 4G
+Ziox,Astra NXT Pro,Astra_NXT_Pro,Astra NXT Pro
+Ziox,Astra Star,Astra_Star,Astra Star
+Ziox,Astra Young Pro,Astra_Young_Pro,Astra Young Pro
+Ziox,Duopix F1,Duopix_F1,Duopix F1
+Ziox,Duopix R1,Duopix_R1,Duopix R1
+Zopo,L63,INHOh_L63,L63
+Zopo,P5000,P5000,P5000
+Zopo,PRO1,Benten_PRO1,PRO1
+Zopo,Z5000,Z5000,Z5000
+Zuk,Lenovo Z2 Plus,z2_plus_hw,ZUK Z2132
+Zuk,Z1,Z1,Z1
+Zuk,Z1,Z1,ZUK Z1
+Zuk,Z1,k9,ZUK Z1
+Zuk,Z2,z2_plus,ZUK Z2131
+Zuk,Z2 Pro,z2_row,ZUK Z2121
+Zuk,ZTE B2015,msm8916_64,ZTE B2015
+Zuk,ZTE BLADE A5 PRO,P731A20,ZTE BLADE A5 PRO
+Zuum,COVET,COVET,COVET
+Zuum,GRANT,GRANT,GRANT
+Zuum,Gravity,Gravity,Gravity
+Zuum,LIMIT,LIMIT,LIMIT
+Zuum,MAGNO,ZUUM_MAGNO,MAGNO
+Zuum,MAGNO,ZUUM_MAGNO-S,MAGNO-S
+Zuum,ONIX,ONIX,ONIX
+Zuum,ZUUM AKUS,AKUS,AKUS
+bq,Aquaris A4.5,Aquaris_A45_sprout,Aquaris A4.5
+bq,Aquaris A4.5,Aquaris_A45_sprout,Aquaris_A4.5
+bq,Aquaris E10,Aquaris_E10,Aquaris E10
+bq,Aquaris E10 3G,Aquaris_E10_3G,Aquaris E10 3G
+bq,Aquaris E4,Aquaris_E4,Aquaris E4
+bq,Aquaris E4.5,Aquaris_E45,Aquaris E4.5
+bq,Aquaris E5,Aquaris_E5,Aquaris E5
+bq,Aquaris E5 FHD,Aquaris_E5_FHD,Aquaris E5 FHD
+bq,Aquaris E5 HD,Aquaris_E5_HD,Aquaris E5 HD
+bq,Aquaris E6,Aquaris_E6,Aquaris E6
+bq,Aquaris M10,Aquaris_M10,Aquaris M10
+bq,Aquaris M10 4G,FREEZERLTE,Aquaris M10 4G
+bq,Aquaris M10 FHD,Aquaris_M10_FHD,Aquaris M10 FHD
+bq,Aquaris M4.5,Aquaris_M45,Aquaris M4.5
+bq,Aquaris M4.5,Aquaris_M45,Aquaris_M4.5
+bq,Aquaris M5,Aquaris_M5,Aquaris M5
+bq,Aquaris M5.5,Aquaris_M55,Aquaris M
+bq,Aquaris M5.5,Aquaris_M55,Aquaris M5.5
+bq,Aquaris U,chaozu,Aquaris U
+bq,Aquaris U Plus,tenshi,Aquaris U Plus
+bq,Aquaris U lite,chaozulite,Aquaris U Lite
+bq,Aquaris U2,yamcha,Aquaris U2
+bq,Aquaris U2 Lite,yamchalite,Aquaris U2 Lite
+bq,Aquaris V,nappa,Aquaris V
+bq,Aquaris V Plus,raditz,Aquaris V Plus
+bq,Aquaris X,bardock,Aquaris X
+bq,Aquaris X Pro,bardock-pro,Aquaris X Pro
+bq,Aquaris X5,Aquaris_X5,Aquaris X5
+bq,Aquaris X5 Plus,Aquaris_X5_Plus,Aquaris X5 Plus
+bq,Edison 3,Edison_3,Edison 3
+bq,Edison 3 3G,Edison_3_3G,Edison 3 3G
+bq,Edison_3_mini,Edison_3_mini,Edison 3 mini
+bq,M8,Aquaris_M8,Aquaris M8
+duraMOBI,DK66,DK66,DK66
+i-Buddie,TA10CA1,TA10CA1,TA10CA1
+i-Buddie,TA10CA2,TA10CA2,TA10CA2
+i-Buddie,TA10CA3,TA10CA3,TA10CA3
+i-Buddie,TA10CA4,TA10CA4,TA10CA4
+i-Buddie,TA71CA1,TA71CA1,TA71CA1
+i-Buddie,TA71CA5,TA71CA5,TA71CA5
+i-Buddie,TA80CA1,TA80CA1,TA80CA1
+i-Buddie,TM75A-V2,TM75A-V2,TM75A-V2
+i-Buddie,TR10CD1,TR10CD1_2,TR10CD1
+i-Buddie,TR10CD1,TR10CD1_4,TR10CD1
+i-Buddie,TR10CD1_P,TR10CD1,TR10CD1
+i-Buddie,TR10CS1,TR10CS1_12,TR10CS1
+i-Buddie,TR10CS1,TR10CS1_2,TR10CS1
+i-Buddie,TR10CS1_P,TR10CS1,TR10CS1
+i-Mobile,IQ II,imobileiq2_sprout,i-mobile IQ II
+i-Mobile,IQX KEN,IQX_KEN,IQX KEN
+i-Mobile,Y1,Y1,i-mobile Y1
+i-Mobile,i-STYLE 713,i-STYLE_713,i-STYLE 713
+i-Mobile,i-STYLE 812 4G,i_style_812_4G,i-mobile i-STYLE 812 4G
+i-Mobile,i-note WiFi 1.1,M1703,i-mobile M1703
+iBRIT,Alpha,AF51,AF51
+iBall,iBall Slide Snap 4G2,Snap_4G2,Snap_4G2
+iCraig,CLP288,ICRAIG_CLP288,ICRAIG_CLP288
+iCraig,CLP293,CLP293,CLP293
+iCraig,CLP_291,ICRAIG_CLP_291,ICRAIG_CLP291
+iCraig,CMP 756,Omega9,CMP 756
+iCraig,CMP 759,Omega7,CMP 759
+iCraig,CMP770,ICRAIG_CMP770,ICRAIG_CMP770
+iCraig,CMP791,CMP791,CMP791
+iCraig,CMP793,CMP793,CMP793
+iCraig,CMP797,CMP797,CMP797
+iCraig,CMP798,CMP798,CMP798
+iCraig,CMP821,CMP821,CMP821
+iCraig,CMP823,CMP823,CMP823
+iCraig,CMP826,CMP826,CMP826
+iCraig,CMP828,CMP828,CMP828
+iCraig,CMP_771,ICRAIG_CMP_771,ICRAIG_CMP771
+iCraig,CMP_773,ICRAIG_CMP_773,ICRAIG_CMP773
+iDea USA,CT8,CT8,CT8
+iDeaUSA,CT10,CT10,CT10
+iDeaUSA,CT7,CT7,CT7
+iGet,S100,iGET_S100,S100
+iGet,SMART,iGET_SMART,SMART
+iGet,SMART_G101,iGET_SMART_G101,SMART_G101
+iGet,SMART_G102,iGET_SMART_G102,SMART_G102
+iGet,SMART_G71,iGET_SMART_G71,SMART_G71
+iGet,SMART_G81,SMART_G81,SMART_G81
+iGet,SMART_G81H,SMART_G81H,SMART_G81H
+iGet,SMART_L102,iGET_SMART_L102,SMART_L102
+iLa Mobile,D1,D1,D1
+iLa Mobile,S1,S1,S1
+iLa Mobile,iLA-X,iLA-X,iLA-X
+iNO Mobile,S9,iNO_S9,iNO S9
+iNanny,NC1000,NC1000,NC1000
+iRiver,,smdkc110,ILT-MX100
+iRiver,DMT580D,m805_892x,DDA800R
+iRiver,DMT580D,m805_892x,DMT580D
+iRiver,DMT580D,m805_892x,MIT700
+iRiver,MM3202,mm3201,MM-3201
+iRiver,MM3202,mm3201,MM-3202
+iRiver,ULALA,msm7627a_sku3,I-K1
+iRiver,WOW Tab+(ITQ1000),itq1000,ITQ1000
+iRiver,WPT005,wikipad,WPT005
+iRiver,Wow TAB +,itq701,ITQ701
+iRiver,Wow(Window of the world),itq700,ITQ700
+iRiver,Wow(Window of the world),itq700,YBMK01
+iRulu,Irulu,octopus-masu,X10
+iRulu,L20,L20,L20
+iRulu,L21,L21,L21
+iRulu,X18,X18,X18
+iRulu,X27,X27,X27
+iRulu,X37,iRULU-X37,X37
+iRulu,X4,iRULU_X4,X4
+iRulu,X40,iRULU-X40,X40
+iRulu,X47,X47,X47
+iRulu,X57,iRULU_X57,X57
+iRulu,X58,iRULU-X58,X58
+iRulu,X67,iRULU_X67,X67
+iRulu,Y57,iRULU_Y57,Y57
+iRulu,iRULU_G36,iRULU_G36,G36
+iVOOMi,Me 1,Me_1,iV 505
+iVOOMi,Me 1+,Me_1_plus,Me 1+
+iVOOMi,Me 2,Me_2,Me 2
+iVOOMi,Me 3,Me_3,Me 3
+iVOOMi,Me 3S,Me_3S,Me 3S
+iVOOMi,Me 4,Me_4,Me 4
+iVOOMi,Me 5,Me_5,Me 5
+iVOOMi,V5,V5,V5
+iVOOMi,i1,i1,i1
+intelkom,meanIT_C1,meanIT_C1,meanIT_C1
+intelkom,meanIT_C2,meanIT_C2,meanIT_C2
+pendo,PNDPP44QC10,PNDPP44QC10,PNDPP44QC10
+pendo,PNDPP44QC7,PNDPP44QC7,PNDPP44QC7
+sugar_aums,QPOINT,QPI-1,QPI-1
+teXet,TM-4510,TM-4510,TM-4510
+tecmobile,OmnisOne,OmnisOne,Omnis One
+ucall,EASY1,EASY1,EASY1
+videocon,Delite 11,V503630,V503630
+videocon,Krypton 22+,V505024,V505024
+videocon,Metal Pro 1,V505820,V505820
+videocon,Metal Pro 2,V505920,V505920
+videocon,Starr 100,V406018,V406018
+xTouch,E4,E4,E4

--- a/lib/device_api/android/device_model.rb
+++ b/lib/device_api/android/device_model.rb
@@ -1,0 +1,31 @@
+require 'csv'
+
+module Android
+  module DeviceModel
+    @csv_file = File.expand_path('device/devices.csv', File.dirname(__FILE__))
+
+    def self.devices
+      return @devices unless @devices.nil?
+
+      rows = CSV.read(@csv_file)
+
+      @devices = rows.each_with_object({}) do |(manufacturer, marketing_name, _device, model), devices|
+        key = device_model_key(manufacturer, model)
+        devices[key] = (marketing_name || model) if model && manufacturer
+      end
+    end
+
+    def self.marketing_name(manufacturer, model)
+      key = device_model_key(manufacturer, model)
+      model && manufacturer ? @devices[key] || model : model
+    end
+
+    private
+
+    def self.device_model_key(manufacturer, model)
+      [manufacturer, model].map do |item|
+        item.to_s.strip.tr(' ', '_').downcase
+      end.join('')
+    end
+  end
+end

--- a/spec/lib/android/device_model_spec.rb
+++ b/spec/lib/android/device_model_spec.rb
@@ -1,0 +1,57 @@
+require 'time'
+require 'device_api/android/device_model'
+
+describe Android::DeviceModel do
+  subject { described_class }
+  describe '#deviceModel' do
+    it 'loads the CSV only once ' do
+      expect(CSV).to receive(:read).once.and_call_original
+      subject.devices
+      subject.devices
+    end
+  end
+
+  describe '#marketing_name' do
+    context 'with marketing name' do
+      it 'should return the display name ' do
+        subject.devices
+        expect(subject.marketing_name('Samsung', 'SM-A7000')).to eq 'Galaxy A7'
+      end
+    end
+
+    context 'with lower case marketing name' do
+      it 'should return the display name ' do
+        subject.devices
+        expect(subject.marketing_name('Samsung', 'sM-A7000')).to eq 'Galaxy A7'
+      end
+    end
+
+    context 'with a whitespace marketing name' do
+      it 'should return the display name ' do
+        subject.devices
+        expect(subject.marketing_name(' Advan digital', '7008')).to eq 'X7 Pro'
+      end
+    end
+
+    context 'without marketing name' do
+      it 'should return the display name ' do
+        subject.devices
+        expect(subject.marketing_name('Acer', 'E330')).to eq 'E330'
+      end
+    end
+
+    context 'without marketing name using lower case name' do
+      it 'should return the display name ' do
+        subject.devices
+        expect(subject.marketing_name('acer', 'e330')).to eq 'E330'
+      end
+    end
+
+    context 'unknown device' do
+      it 'should return the passed model name display name ' do
+        subject.devices
+        expect(subject.marketing_name('Some', 'Model')).to eq 'Model'
+      end
+    end
+  end
+end


### PR DESCRIPTION
This change addresses the need by:

* Fetch Marketing Name from google apis
* Create a method to determine device name
* Correctly identify device type