### PR TITLE
Detect Screen unlock

### DIFF
--- a/lib/device_api/android/device_model.rb
+++ b/lib/device_api/android/device_model.rb
@@ -16,7 +16,8 @@ module DeviceAPI
 
       def self.devices
         return @devices unless @device_list.nil?
-        @csv_file = File.expand_path('devices/devices.csv', File.dirname(__FILE__))
+
+        @csv_file = File.join(File.dirname(File.expand_path(__FILE__)), '/devices/devices.csv')
         @devices  = CSV.read(@csv_file)
       end
 


### PR DESCRIPTION
Why:

* On some devices the screen unlock is not correctly detected

This change addresses the need by:

* Check user activity to determine if screen is unlocked
* Check OS names based on OS version
* Update device pin ENV